### PR TITLE
removed arrow buttons from input fields

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -1284,6 +1284,10 @@ input.input:read-only {
 }
 
 .ohm-input-group {
+  input::-webkit-outer-spin-button, 
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+  }
   .form-control {
     background-color: #282828 !important;
     border-radius: 2rem;


### PR DESCRIPTION
added 

input::-webkit-outer-spin-button, 
input::-webkit-inner-spin-button {
    -webkit-appearance: none;
 }
 
 to style definition for .ohm-input-group to remove webkit arrows from input field. 