### PR TITLE
Feature: order bonds by discount amount

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "graphql": "^15.3.0",
     "intl": "^1.2.5",
     "isomorphic-fetch": "^3.0.0",
+    "lodash": "^4.17.21",
     "material-ui": "^0.20.2",
     "node-sass": "4.14",
     "node-watch": "^0.7.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -249,10 +249,6 @@ function App(props) {
           )}
 
           <Sidebar
-            ohmDaiBondDiscount={ohmDaiBondDiscount}
-            ohmFraxLpBondDiscount={ohmFraxLpBondDiscount}
-            daiBondDiscount={daiBondDiscount}
-            fraxBondDiscount={fraxBondDiscount}
             currentIndex={currentIndex}
             isExpanded={isSidebarExpanded}
             theme={theme}

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -9,39 +9,11 @@ import { ReactComponent as DashboardIcon } from "../../assets/icons/dashboard-ic
 import { trim } from "../../helpers";
 import "./sidebar.scss";
 import orderBy from 'lodash/orderBy'
+import useBonds from "../../hooks/Bonds";
 
-const makeBondsArray = (ohmDaiBondDiscount, ohmFraxLpBondDiscount, daiBondDiscount, fraxBondDiscount) => {
-  return [
-    {
-      name: 'OHM-DAI LP',
-      discount: Number(ohmDaiBondDiscount)
-    },
-    {
-      name: 'OHM-FRAX LP',
-      discount: Number(ohmFraxLpBondDiscount)
-    },
-    {
-      name: 'DAI',
-      discount: Number(daiBondDiscount)
-    },
-    {
-      name: 'FRAX',
-      discount: Number(fraxBondDiscount)
-    },
-  ]
-};
-
-const BONDS = makeBondsArray();
-
-function Sidebar({ isExpanded, theme, ohmDaiBondDiscount, ohmFraxLpBondDiscount, daiBondDiscount, fraxBondDiscount, currentIndex }) {
+function Sidebar({ isExpanded, theme, currentIndex }) {
   const [isActive] = useState();
-  const [bonds, setBonds] = useState(BONDS);
-
-  useEffect(() => {
-    const bondValues = makeBondsArray(ohmDaiBondDiscount, ohmFraxLpBondDiscount, daiBondDiscount, fraxBondDiscount);
-    const mostProfitableBonds = orderBy(bondValues, 'discount', 'desc');
-    setBonds(mostProfitableBonds);
-  }, [ohmDaiBondDiscount, ohmFraxLpBondDiscount, daiBondDiscount, fraxBondDiscount])
+  const bonds = useBonds();
 
   const checkPage = useCallback((match, location, page) => {
     const currentPath = location.pathname.replace("/", "");

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -14,19 +14,19 @@ const makeBondsArray = (ohmDaiBondDiscount, ohmFraxLpBondDiscount, daiBondDiscou
   return [
     {
       name: 'OHM-DAI LP',
-      discount: Number(ohmDaiBondDiscount) || ''
+      discount: Number(ohmDaiBondDiscount)
     },
     {
       name: 'OHM-FRAX LP',
-      discount: Number(ohmFraxLpBondDiscount) || ''
+      discount: Number(ohmFraxLpBondDiscount)
     },
     {
       name: 'DAI',
-      discount: Number(daiBondDiscount) || ''
+      discount: Number(daiBondDiscount)
     },
     {
       name: 'FRAX',
-      discount: Number(fraxBondDiscount) || ''
+      discount: Number(fraxBondDiscount)
     },
   ]
 };
@@ -99,7 +99,7 @@ function Sidebar({ isExpanded, theme, ohmDaiBondDiscount, ohmFraxLpBondDiscount,
             <div className="dapp-menu-data discounts">
               <div className="bond-discounts">
                 <p>Bond discounts</p>
-                {bonds.map((bond, i) => <p key={i}>{bond.name}<span>{trim(bond.discount * 100, 2)}%</span></p>)}
+                {bonds.map((bond, i) => <p key={i}>{bond.name}<span>{bond.discount ? trim(bond.discount * 100, 2) : ''}%</span></p>)}
               </div>
             </div>
           </div>

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -1,18 +1,47 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { NavLink } from "react-router-dom";
 import Social from "../Social";
 import OlympusLogo from '../../assets/logo.svg';
-import RebaseTimer from '../RebaseTimer/RebaseTimer';
 import externalUrls from './externalUrls';
 import { ReactComponent as StakeIcon } from "../../assets/icons/stake-icon.svg";
 import { ReactComponent as BondIcon } from "../../assets/icons/bond-icon.svg";
 import { ReactComponent as DashboardIcon } from "../../assets/icons/dashboard-icon.svg";
 import { trim } from "../../helpers";
 import "./sidebar.scss";
+import orderBy from 'lodash/orderBy'
 
+const makeBondsArray = (ohmDaiBondDiscount, ohmFraxLpBondDiscount, daiBondDiscount, fraxBondDiscount) => {
+  return [
+    {
+      name: 'OHM-DAI LP',
+      discount: Number(ohmDaiBondDiscount) || ''
+    },
+    {
+      name: 'OHM-FRAX LP',
+      discount: Number(ohmFraxLpBondDiscount) || ''
+    },
+    {
+      name: 'DAI',
+      discount: Number(daiBondDiscount) || ''
+    },
+    {
+      name: 'FRAX',
+      discount: Number(fraxBondDiscount) || ''
+    },
+  ]
+};
+
+const BONDS = makeBondsArray();
 
 function Sidebar({ isExpanded, theme, ohmDaiBondDiscount, ohmFraxLpBondDiscount, daiBondDiscount, fraxBondDiscount, currentIndex }) {
   const [isActive] = useState();
+  const [bonds, setBonds] = useState(BONDS);
+
+  useEffect(() => {
+    const bondValues = makeBondsArray(ohmDaiBondDiscount, ohmFraxLpBondDiscount, daiBondDiscount, fraxBondDiscount);
+    const mostProfitableBonds = orderBy(bondValues, 'discount', 'desc');
+    setBonds(mostProfitableBonds);
+  }, [ohmDaiBondDiscount, ohmFraxLpBondDiscount, daiBondDiscount, fraxBondDiscount])
 
   const checkPage = useCallback((match, location, page) => {
     const currentPath = location.pathname.replace("/", "");
@@ -70,10 +99,7 @@ function Sidebar({ isExpanded, theme, ohmDaiBondDiscount, ohmFraxLpBondDiscount,
             <div className="dapp-menu-data discounts">
               <div className="bond-discounts">
                 <p>Bond discounts</p>
-                <p>OHM-DAI LP<span>{trim(ohmDaiBondDiscount * 100, 2)}%</span></p>
-                <p>OHM-FRAX LP<span>{trim(ohmFraxLpBondDiscount * 100, 2)}%</span></p>
-                <p>DAI<span>{trim(daiBondDiscount * 100, 2)}%</span></p>
-                <p>FRAX<span>{trim(fraxBondDiscount * 100, 2)}%</span></p>
+                {bonds.map(bond => <p>{bond.name}<span>{trim(bond.discount * 100, 2)}%</span></p>)}
               </div>
             </div>
           </div>
@@ -92,11 +118,8 @@ function Sidebar({ isExpanded, theme, ohmDaiBondDiscount, ohmFraxLpBondDiscount,
         </div>
 
         <div className="dapp-menu-data bottom">
-          {/* <div className="data-rebase">
-            <RebaseTimer />
-          </div> */}
 
-        {theme === "girth" && 
+        {theme === "girth" &&
           <div className="data-ohm-index">
             <p>Current Index </p>
             <p>{trim(currentIndex, 4)} OHM</p>

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -99,7 +99,7 @@ function Sidebar({ isExpanded, theme, ohmDaiBondDiscount, ohmFraxLpBondDiscount,
             <div className="dapp-menu-data discounts">
               <div className="bond-discounts">
                 <p>Bond discounts</p>
-                {bonds.map(bond => <p>{bond.name}<span>{trim(bond.discount * 100, 2)}%</span></p>)}
+                {bonds.map((bond, i) => <p key={i}>{bond.name}<span>{trim(bond.discount * 100, 2)}%</span></p>)}
               </div>
             </div>
           </div>

--- a/src/hooks/Bonds.js
+++ b/src/hooks/Bonds.js
@@ -1,0 +1,58 @@
+import { useSelector } from "react-redux";
+import { useEffect, useState } from "react";
+import orderBy from "lodash/orderBy";
+
+export const makeBondsArray = (ohmDaiBondDiscount, ohmFraxLpBondDiscount, daiBondDiscount, fraxBondDiscount) => {
+  return [
+    {
+      name: 'OHM-DAI LP',
+      value: 'ohm_dai_lp',
+      discount: Number(ohmDaiBondDiscount)
+    },
+    {
+      name: 'OHM-FRAX LP',
+      value: 'ohm_frax_lp',
+      discount: Number(ohmFraxLpBondDiscount)
+    },
+    {
+      name: 'DAI',
+      value: 'dai',
+      discount: Number(daiBondDiscount)
+    },
+    {
+      name: 'FRAX',
+      value: 'frax',
+      discount: Number(fraxBondDiscount)
+    },
+  ]
+};
+
+const BONDS_ARRAY = makeBondsArray();
+
+export default function useBonds() {
+  const fraxBondDiscount = useSelector(state => {
+    return state.bonding['frax'] && state.bonding['frax'].bondDiscount;
+  });
+
+  const daiBondDiscount = useSelector(state => {
+    return state.bonding['dai'] && state.bonding['dai'].bondDiscount;
+  });
+
+  const ohmDaiBondDiscount = useSelector(state => {
+    return state.bonding['ohm_dai_lp'] && state.bonding['ohm_dai_lp'].bondDiscount;
+  });
+
+  const ohmFraxLpBondDiscount = useSelector(state => {
+    return state.bonding['ohm_frax_lp'] && state.bonding['ohm_frax_lp'].bondDiscount;
+  })
+
+  const [bonds, setBonds] = useState(BONDS_ARRAY);
+
+  useEffect(() => {
+    const bondValues = makeBondsArray(ohmDaiBondDiscount, ohmFraxLpBondDiscount, daiBondDiscount, fraxBondDiscount);
+    const mostProfitableBonds = orderBy(bondValues, 'discount', 'desc');
+    setBonds(mostProfitableBonds);
+  }, [ohmDaiBondDiscount, ohmFraxLpBondDiscount, daiBondDiscount, fraxBondDiscount]);
+
+  return bonds;
+}

--- a/src/hooks/Bonds.js
+++ b/src/hooks/Bonds.js
@@ -29,6 +29,12 @@ export const makeBondsArray = (ohmDaiBondDiscount, ohmFraxLpBondDiscount, daiBon
 
 const BONDS_ARRAY = makeBondsArray();
 
+/**
+ * Returns an array of bonds ordered by the most profitable ones first.
+ * Each bond object contains its display name, value, and the discount amount.
+ * 
+ * @returns {[{name: string, discount: number, value: string}, {name: string, discount: number, value: string}, {name: string, discount: number, value: string}, {name: string, discount: number, value: string}]}
+ */
 export default function useBonds() {
   const fraxBondDiscount = useSelector(state => {
     return state.bonding['frax'] && state.bonding['frax'].bondDiscount;

--- a/src/views/ChooseBond/ChooseBond.jsx
+++ b/src/views/ChooseBond/ChooseBond.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from "react";
 import { useSelector } from 'react-redux';
 import { Grid, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from "@material-ui/core"
 import { Card } from "rimble-ui";
@@ -7,11 +7,10 @@ import { BondTableData, BondCardData } from './BondRow';
 import { BONDS } from "../../constants";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
 import { trim } from "../../helpers";
-
+import useBonds from "../../hooks/Bonds";
 
 function ChooseBond({ address, provider }) {
 
-	// const fiveDayRate  = useSelector((state ) => { return state.app.fiveDayRate });
 	const marketPrice = useSelector((state ) => { return state.bonding['dai'] && state.bonding['dai'].marketPrice });
 
 	const isSmallScreen = useMediaQuery("(max-width: 1125px)");
@@ -21,6 +20,8 @@ function ChooseBond({ address, provider }) {
 	const treasuryBalance = useSelector(state => {
     	return state.app.treasuryBalance;
   	});
+
+	const bonds = useBonds();
 
 	return (
 		<Grid container id="choose-bond-view" justify="center" spacing={2}>
@@ -48,11 +49,11 @@ function ChooseBond({ address, provider }) {
 						</Grid>
           </div>
         </Card>
-          
+
         <Card className={`ohm-card primary ${isSmallScreen && "mobile"} ${isMediumScreen && "med"}`}>
 				<div className="card-header" style={{ background: 'transparent' }}>
             <h5>Bonds (1, 1)</h5>
-          </div> 
+          </div>
 					{ !isSmallScreen ?
           		<div className="card-content">
 								<TableContainer>
@@ -67,9 +68,8 @@ function ChooseBond({ address, provider }) {
 											</TableRow>
 										</TableHead>
 										<TableBody>
-											{/* { Object.keys(BONDS).map(bond => ( */}
-												{[BONDS.ohm_dai, BONDS.dai, BONDS.ohm_frax, BONDS.frax].map(bond => (
-												<BondTableData key={bond} bond={bond} />
+												{bonds.map(bond => (
+												<BondTableData key={bond.value} bond={bond.value} />
 											))}
 										</TableBody>
 									</Table>
@@ -85,10 +85,10 @@ function ChooseBond({ address, provider }) {
 								)) }
 							</>
 						}
-          
+
         </Card>
     </Grid>
 	);
   }
-  
+
   export default ChooseBond;


### PR DESCRIPTION
- Order the most profitable bonds first in the sidebar.
- Added lodash dependency as it is useful for utility/func to make the code easier to read
- Fixed NaN issue when wallet is not connected
- Made bonds in the bonds page also sorted by most profitable
- Refactored the code slightly

Before:

![image](https://user-images.githubusercontent.com/86227877/123081033-9fa95600-d471-11eb-9e52-39775539fdd5.png)


After:

![image](https://user-images.githubusercontent.com/86227877/123081680-5279b400-d472-11eb-9d12-fc05ea3a375b.png)

 
Wallet Disconnected:
![image](https://user-images.githubusercontent.com/86227877/123081806-763cfa00-d472-11eb-8e23-8050fa5b2fa1.png)


Bonds Page is also now sorted
![image](https://user-images.githubusercontent.com/86227877/123088419-d1261f80-d479-11eb-87c5-ae5a18a26ba9.png)
