### PR TITLE
fix dependabot target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
     schedule:
       interval: 'daily'
       time: '04:00'
-    target_branch: 'develop'
+target_branch: 'develop'


### PR DESCRIPTION
There was an error with the config file format.

<img width="904" alt="Screenshot 2021-06-30 at 18 20 46" src="https://user-images.githubusercontent.com/552769/123996717-e518d680-d9cf-11eb-871e-ef6908651d01.png">

According to https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates this should be it now. 