### PR TITLE
295: Bring nav icons to center align with nav text

### DIFF
--- a/src/components/Sidebar/sidebar.scss
+++ b/src/components/Sidebar/sidebar.scss
@@ -65,7 +65,7 @@
     width: 20px;
     height: 20px;
     margin-right: 12px;
-    vertical-align: middle;
+    vertical-align: -4px;
   }
 }
 


### PR DESCRIPTION
Fixes #295 