### PR TITLE
TOO MANY API CALLS - updated app.jsx loadDetails to ensure that child…

### DIFF
--- a/src/hooks/web3Context.tsx
+++ b/src/hooks/web3Context.tsx
@@ -73,6 +73,7 @@ type onChainProvider = {
   address: string;
   connected: Boolean;
   web3Modal: Web3Modal;
+  isWeb3Provider: Boolean;
 };
 
 export type Web3ContextData = {
@@ -105,6 +106,7 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
   const [uri, setUri] = useState(getMainnetURI(chainID));
   const [address, setAddress] = useState("");
   const [provider, setProvider] = useState<JsonRpcProvider>(new StaticJsonRpcProvider(uri));
+  const [isWeb3Provider, setIsWeb3Provider] = useState(false);
 
   const [web3Modal, setWeb3Modal] = useState<Web3Modal>(
     new Web3Modal({
@@ -176,24 +178,26 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
     setConnected(true);
     setAddress(connectedAddress);
     setProvider(connectedProvider);
+    setIsWeb3Provider(true);
     _initListeners();
 
     return connectedProvider;
-  }, [provider, web3Modal, connected]);
+  }, [provider, web3Modal, connected, isWeb3Provider]);
 
   const disconnect = useCallback(async () => {
     console.log("disconnecting");
     web3Modal.clearCachedProvider();
     setConnected(false);
+    setIsWeb3Provider(false);
 
     setTimeout(() => {
       window.location.reload();
     }, 1);
-  }, [provider, web3Modal, connected]);
+  }, [provider, web3Modal, connected, isWeb3Provider]);
 
   const onChainProvider = useMemo(
-    () => ({ connect, disconnect, provider, connected, address, chainID, web3Modal }),
-    [connect, disconnect, provider, connected, address, chainID, web3Modal],
+    () => ({ connect, disconnect, provider, connected, address, chainID, web3Modal, isWeb3Provider }),
+    [connect, disconnect, provider, connected, address, chainID, web3Modal, isWeb3Provider],
   );
 
   useEffect(() => {

--- a/src/views/ChooseBond/BondRow.jsx
+++ b/src/views/ChooseBond/BondRow.jsx
@@ -109,7 +109,7 @@ export function BondTableData({ bond }) {
       <TableCell align="center">
         <Typography>
           <>
-            <span class="currency-icon">{priceUnits(bond)}</span>{" "}
+            <span className="currency-icon">{priceUnits(bond)}</span>{" "}
             {isBondLoading ? <Skeleton width="50px" /> : trim(bondPrice, 2)}
           </>
         </Typography>


### PR DESCRIPTION
… functions only run 1 time rather than each of the 3 times that App.jsx useEffect runs on each app refresh

See the comments in `src/App.jsx` => `loadDetails()` runs three times on every app refresh, which resulted in 135 API calls to Infura/Alchemy on every app refresh. After adding the three if statements below we can prevent the `loadDetails()` child functions: `loadAppDetails`, `loadAccountDetails`, & `calcBondDetails` from running except the (1) time when `loadProvider` and `address` are appropriate for each.

After these if statements we can reduce API calls from 135 on each refresh down to 70 on each refresh

I verified this API calls reduction by running all API requests against my own Infura node.

One Note: `loadProvider.connection["url"] === "metamask")` should be optimized so that non-metamask wallets get through the if statement