### PR TITLE
Bond state fetch move global

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -127,6 +127,11 @@ function App() {
         await dispatch(calcBondDetails({ bond, value: null, provider: loadProvider, networkID: chainID }));
       });
     }
+    if (whichDetails === "userBonds" && address && connected) {
+      Object.values(BONDS).map(async bond => {
+        await dispatch(calculateUserBondDetails({ address, bond, provider, networkID: chainID }));
+      });
+    }
   }
 
   useEffect(() => {
@@ -137,6 +142,7 @@ function App() {
   useEffect(() => {
     // runs only when connected is changed
     loadDetails("account");
+    loadDetails("userBonds");
   }, [connected]);
 
   const handleDrawerToggle = () => {

--- a/src/slices/BondSlice.js
+++ b/src/slices/BondSlice.js
@@ -15,7 +15,7 @@ import { fetchPendingTxns, clearPendingTxn } from "./PendingTxnsSlice";
 import { createSlice, createSelector, createAsyncThunk, createEntityAdapter } from "@reduxjs/toolkit";
 
 const initialState = {
-  status: "idle",
+  loading: false,
 };
 
 export const changeApproval = createAsyncThunk(
@@ -285,6 +285,13 @@ export const redeemBond = createAsyncThunk(
   },
 );
 
+const setBondState = (state, payload) => {
+  const bond = payload.bond;
+  const newState = { ...state[bond], ...payload };
+  state[bond] = newState;
+  state.loading = false;
+};
+
 const bondingSlice = createSlice({
   name: "bonding",
   initialState,
@@ -299,7 +306,7 @@ const bondingSlice = createSlice({
         state.loading = true;
       })
       .addCase(calcBondDetails.fulfilled, (state, action) => {
-        state[action.payload.bond] = action.payload;
+        setBondState(state, action.payload);
         state.loading = false;
       })
       .addCase(calcBondDetails.rejected, (state, { error }) => {
@@ -310,9 +317,7 @@ const bondingSlice = createSlice({
         state.loading = true;
       })
       .addCase(calculateUserBondDetails.fulfilled, (state, action) => {
-        const bond = action.payload.bond;
-        const newState = { ...state[bond], ...action.payload };
-        state[bond] = newState;
+        setBondState(state, action.payload);
         state.loading = false;
       })
       .addCase(calculateUserBondDetails.rejected, (state, { error }) => {

--- a/src/views/Bond/Bond.jsx
+++ b/src/views/Bond/Bond.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { trim } from "../../helpers";
-import { calcBondDetails, calculateUserBondDetails } from "../../slices/BondSlice";
 import { Grid, Backdrop, Paper, Box, Tab, Tabs, Typography, Fade, Grow } from "@material-ui/core";
 import TabPanel from "../../components/TabPanel";
 import BondHeader from "./BondHeader";
@@ -44,16 +43,8 @@ function Bond({ bond }) {
     return setSlippage(e.target.value);
   };
 
-  async function loadBondDetails() {
-    if (provider) await dispatch(calcBondDetails({ bond, value: quantity, provider, networkID: chainID }));
-
-    if (provider && address) {
-      await dispatch(calculateUserBondDetails({ address, bond, provider, networkID: chainID }));
-    }
-  }
 
   useEffect(() => {
-    loadBondDetails();
     if (address) setRecipientAddress(address);
   }, [provider, quantity, address]);
 

--- a/src/views/Bond/Bond.jsx
+++ b/src/views/Bond/Bond.jsx
@@ -43,7 +43,6 @@ function Bond({ bond }) {
     return setSlippage(e.target.value);
   };
 
-
   useEffect(() => {
     if (address) setRecipientAddress(address);
   }, [provider, quantity, address]);

--- a/src/views/Bond/BondPurchase.jsx
+++ b/src/views/Bond/BondPurchase.jsx
@@ -12,7 +12,7 @@ import {
   Slide,
 } from "@material-ui/core";
 import { shorten, trim, secondsUntilBlock, prettifySeconds } from "../../helpers";
-import { changeApproval, calcBondDetails, calculateUserBondDetails, bondAsset } from "../../slices/BondSlice";
+import { changeApproval, bondAsset } from "../../slices/BondSlice";
 import { BONDS } from "../../constants";
 import { useWeb3Context } from "src/hooks/web3Context";
 import { isPendingTxn, txnButtonText } from "src/slices/PendingTxnsSlice";
@@ -126,16 +126,7 @@ function BondPurchase({ bond, slippage }) {
     else return "FRAX";
   };
 
-  async function loadBondDetails() {
-    if (provider) await dispatch(calcBondDetails({ bond, value: quantity, provider, networkID: chainID }));
-
-    if (provider && address) {
-      await dispatch(calculateUserBondDetails({ address, bond, provider, networkID: chainID }));
-    }
-  }
-
   useEffect(() => {
-    loadBondDetails();
     if (address) setRecipientAddress(address);
   }, [provider, quantity, address]);
 

--- a/src/views/Bond/BondRedeemV1.jsx
+++ b/src/views/Bond/BondRedeemV1.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { trim, prettyVestingPeriod } from "../../helpers";
-import { calculateUserBondDetails, redeemBond } from "../../slices/BondSlice";
+import { redeemBond } from "../../slices/BondSlice";
 import { useWeb3Context } from "src/hooks/web3Context";
 
 function BondRedeemV1({ bond }) {
@@ -28,16 +28,6 @@ function BondRedeemV1({ bond }) {
   async function onRedeem() {
     await dispatch(redeemBond({ address, bond, networkID: chainID, provider, autostake: null }));
   }
-
-  async function loadBondDetails() {
-    if (provider && address) {
-      await dispatch(calculateUserBondDetails({ address, bond, provider, networkID: chainID }));
-    }
-  }
-
-  useEffect(() => {
-    loadBondDetails();
-  }, [provider, address]);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
this PR limits fetching of all bond related data to app refreshes.  It will reduce our number of API calls but will need to be followed up with additional changes to allow the data to update sometimes when we choose.  

Plz don't merge this until you merge the provider-call-debug branch first this branch depends on those changes for these changes to work

