### PR TITLE
Treasury Dash Fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
   extends: ["plugin:prettier/recommended", "prettier/react", "prettier/@typescript-eslint"],
   plugins: ["prettier"],
   rules: {
-    "prettier/prettier": ["error", { endOfLine: "auto" }],
+    "prettier/prettier": ["error"],
     "import/prefer-default-export": "off",
     "prefer-destructuring": "off",
     "prefer-template": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
   extends: ["plugin:prettier/recommended", "prettier/react", "prettier/@typescript-eslint"],
   plugins: ["prettier"],
   rules: {
-    "prettier/prettier": ["error"],
+    "prettier/prettier": ["error", { endOfLine: "auto" }],
     "import/prefer-default-export": "off",
     "prefer-destructuring": "off",
     "prefer-template": "off",

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -269,7 +269,7 @@ const renderMultiLineChart = (
     />
     <Line dataKey={dataKey[0]} stroke={stroke[0]} dot={false} />;
     <Line dataKey={dataKey[1]} stroke={stroke[1]} dot={false} />;
-    <Line dataKey={dataKey[2]} stroke={stroke[2]} dot={false} />;{console.log(stroke)}
+    <Line dataKey={dataKey[2]} stroke={stroke[2]} dot={false} />;
     {renderExpandedChartStroke(isExpanded, expandedGraphStrokeColor)}
   </LineChart>
 );

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -233,8 +233,8 @@ const renderLineChart = (
 const renderMultiLineChart = (
   data,
   dataKey,
-  stroke,
   color,
+  stroke,
   dataFormat,
   bulletpointColors,
   itemNames,
@@ -267,9 +267,9 @@ const renderMultiLineChart = (
     <Tooltip
       content={<CustomTooltip bulletpointColors={bulletpointColors} itemNames={itemNames} itemType={itemType} />}
     />
-    <Line dataKey={dataKey[0]} stroke={stroke} dot={false} />;
-    <Line dataKey={dataKey[1]} stroke={stroke} dot={false} />;
-    <Line dataKey={dataKey[2]} stroke={stroke} dot={false} />;
+    <Line dataKey={dataKey[0]} stroke={stroke[0]} dot={false} />;
+    <Line dataKey={dataKey[1]} stroke={stroke[1]} dot={false} />;
+    <Line dataKey={dataKey[2]} stroke={stroke[2]} dot={false} />;{console.log(stroke)}
     {renderExpandedChartStroke(isExpanded, expandedGraphStrokeColor)}
   </LineChart>
 );

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -32,7 +32,8 @@ const formatCurrency = c => {
   }).format(c);
 };
 
-const tickCount = 5;
+const tickCount = 3;
+const expandedTickCount = 5;
 
 const renderExpandedChartStroke = (isExpanded, color) => {
   return isExpanded ? <CartesianGrid vertical={false} stroke={color} /> : "";
@@ -70,7 +71,7 @@ const renderAreaChart = (
       padding={{ right: 20 }}
     />
     <YAxis
-      tickCount={tickCount}
+      tickCount={isExpanded ? expandedTickCount : tickCount}
       axisLine={false}
       tickLine={false}
       width={dataFormat === "percent" ? 33 : 55}
@@ -139,7 +140,7 @@ const renderStackedAreaChart = (
       padding={{ right: 20 }}
     />
     <YAxis
-      tickCount={tickCount}
+      tickCount={isExpanded ? expandedTickCount : tickCount}
       axisLine={false}
       tickLine={false}
       width={dataFormat === "percent" ? 33 : 55}
@@ -207,7 +208,7 @@ const renderLineChart = (
       padding={{ right: 20 }}
     />
     <YAxis
-      tickCount={tickCount}
+      tickCount={isExpanded ? expandedTickCount : tickCount}
       axisLine={false}
       tickLine={false}
       width={27}
@@ -255,7 +256,7 @@ const renderMultiLineChart = (
       padding={{ right: 20 }}
     />
     <YAxis
-      tickCount={tickCount}
+      tickCount={isExpanded ? expandedTickCount : tickCount}
       axisLine={false}
       tickLine={false}
       width={25}
@@ -300,7 +301,7 @@ const renderBarChart = (
     <YAxis
       axisLine={false}
       tickLine={false}
-      tickCount={tickCount}
+      tickCount={isExpanded ? expandedTickCount : tickCount}
       width={33}
       domain={[0, "auto"]}
       allowDataOverflow={false}

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -50,6 +50,7 @@ const renderAreaChart = (
   isStaked,
   isExpanded,
   expandedGraphStrokeColor,
+  isPOL,
 ) => (
   <AreaChart data={data}>
     <defs>
@@ -91,6 +92,7 @@ const renderAreaChart = (
           itemNames={itemNames}
           itemType={itemType}
           isStaked={isStaked}
+          isPOL={isPOL}
         />
       }
     />
@@ -328,6 +330,7 @@ function Chart({
   isStaked,
   infoTooltipMessage,
   expandedGraphStrokeColor,
+  isPOL,
 }) {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -367,6 +370,7 @@ function Chart({
         isStaked,
         isExpanded,
         expandedGraphStrokeColor,
+        isPOL,
       );
     if (type === "stack")
       return renderStackedAreaChart(

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -3,7 +3,19 @@ import InfoTooltip from "../InfoTooltip/InfoTooltip";
 import ExpandedChart from "./ExpandedChart";
 import { useEffect, useState } from "react";
 import { ReactComponent as Fullscreen } from "../../assets/icons/fullscreen.svg";
-import { ResponsiveContainer, BarChart, Bar, AreaChart, LineChart, Line, XAxis, YAxis, Area, Tooltip } from "recharts";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  AreaChart,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Area,
+  CartesianGrid,
+  Tooltip,
+} from "recharts";
 import { Typography, Box, SvgIcon, CircularProgress } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 import { trim } from "../../helpers";
@@ -30,6 +42,7 @@ const renderAreaChart = (
   itemNames,
   itemType,
   isStaked,
+  isExpanded,
 ) => (
   <AreaChart data={data}>
     <defs>
@@ -49,7 +62,7 @@ const renderAreaChart = (
       padding={{ right: 20 }}
     />
     <YAxis
-      tickCount={3}
+      tickCount={4}
       axisLine={false}
       tickLine={false}
       width={dataFormat === "percent" ? 33 : 55}
@@ -75,6 +88,7 @@ const renderAreaChart = (
       }
     />
     <Area dataKey={dataKey[0]} stroke="none" fill={`url(#color-${dataKey[0]})`} fillOpacity={1} />
+    {isExpanded ? <CartesianGrid vertical={false} /> : ""}
   </AreaChart>
 );
 
@@ -87,6 +101,7 @@ const renderStackedAreaChart = (
   bulletpointColors,
   itemNames,
   itemType,
+  isExpanded,
 ) => (
   <AreaChart data={data}>
     <defs>
@@ -156,7 +171,17 @@ const renderStackedAreaChart = (
   </AreaChart>
 );
 
-const renderLineChart = (data, dataKey, stroke, color, dataFormat, bulletpointColors, itemNames, itemType) => (
+const renderLineChart = (
+  data,
+  dataKey,
+  stroke,
+  color,
+  dataFormat,
+  bulletpointColors,
+  itemNames,
+  itemType,
+  isExpanded,
+) => (
   <LineChart data={data}>
     <XAxis
       dataKey="timestamp"
@@ -192,7 +217,17 @@ const renderLineChart = (data, dataKey, stroke, color, dataFormat, bulletpointCo
   </LineChart>
 );
 
-const renderMultiLineChart = (data, dataKey, stroke, color, dataFormat, bulletpointColors, itemNames, itemType) => (
+const renderMultiLineChart = (
+  data,
+  dataKey,
+  stroke,
+  color,
+  dataFormat,
+  bulletpointColors,
+  itemNames,
+  itemType,
+  isExpanded,
+) => (
   <LineChart data={data}>
     <XAxis
       dataKey="timestamp"
@@ -225,7 +260,7 @@ const renderMultiLineChart = (data, dataKey, stroke, color, dataFormat, bulletpo
 );
 
 // JTBD: Bar chart for Holders
-const renderBarChart = (data, dataKey, stroke, dataFormat, bulletpointColors, itemNames, itemType) => (
+const renderBarChart = (data, dataKey, stroke, dataFormat, bulletpointColors, itemNames, itemType, isExpanded) => (
   <BarChart data={data}>
     <XAxis
       dataKey="timestamp"
@@ -280,7 +315,7 @@ function Chart({
     setOpen(false);
   };
 
-  const renderChart = type => {
+  const renderChart = (type, isExpanded) => {
     if (type === "line")
       return renderLineChart(data, dataKey, color, stroke, dataFormat, bulletpointColors, itemNames, itemType);
     if (type === "area")
@@ -294,6 +329,7 @@ function Chart({
         itemNames,
         itemType,
         isStaked,
+        isExpanded,
       );
     if (type === "stack")
       return renderStackedAreaChart(
@@ -305,12 +341,23 @@ function Chart({
         bulletpointColors,
         itemNames,
         itemType,
+        isExpanded,
       );
     if (type === "multi")
-      return renderMultiLineChart(data, dataKey, color, stroke, dataFormat, bulletpointColors, itemNames, itemType);
+      return renderMultiLineChart(
+        data,
+        dataKey,
+        color,
+        stroke,
+        dataFormat,
+        bulletpointColors,
+        itemNames,
+        itemType,
+        isExpanded,
+      );
 
     if (type === "bar")
-      return renderBarChart(data, dataKey, stroke, dataFormat, bulletpointColors, itemNames, itemType);
+      return renderBarChart(data, dataKey, stroke, dataFormat, bulletpointColors, itemNames, itemType, isExpanded);
   };
 
   const runwayExtraInfo = type =>
@@ -369,7 +416,7 @@ function Chart({
           <ExpandedChart
             open={open}
             handleClose={handleClose}
-            renderChart={renderChart(type)}
+            renderChart={renderChart(type, true)}
             uid={dataKey}
             data={data}
             infoTooltipMessage={infoTooltipMessage}
@@ -395,7 +442,7 @@ function Chart({
       <Box width="100%" minHeight={260} minWidth={310} className="ohm-chart">
         {loading || (data && data.length > 0) ? (
           <ResponsiveContainer minHeight={260} width="100%">
-            {renderChart(type)}
+            {renderChart(type, false)}
           </ResponsiveContainer>
         ) : (
           <Skeleton variant="rect" width="100%" height={260} />

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -32,6 +32,8 @@ const formatCurrency = c => {
   }).format(c);
 };
 
+const tickCount = 5;
+
 const renderAreaChart = (
   data,
   dataKey,

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -88,7 +88,7 @@ const renderAreaChart = (
       }
     />
     <Area dataKey={dataKey[0]} stroke="none" fill={`url(#color-${dataKey[0]})`} fillOpacity={1} />
-    {isExpanded ? <CartesianGrid vertical={false} /> : ""}
+    {isExpanded ? <CartesianGrid vertical={false} stroke="#BFC3C7" /> : ""}
   </AreaChart>
 );
 

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -34,6 +34,10 @@ const formatCurrency = c => {
 
 const tickCount = 5;
 
+const renderExpandedChartStroke = (isExpanded, color) => {
+  return isExpanded ? <CartesianGrid vertical={false} stroke={color} /> : "";
+};
+
 const renderAreaChart = (
   data,
   dataKey,
@@ -45,6 +49,7 @@ const renderAreaChart = (
   itemType,
   isStaked,
   isExpanded,
+  expandedGraphStrokeColor,
 ) => (
   <AreaChart data={data}>
     <defs>
@@ -64,7 +69,7 @@ const renderAreaChart = (
       padding={{ right: 20 }}
     />
     <YAxis
-      tickCount={4}
+      tickCount={tickCount}
       axisLine={false}
       tickLine={false}
       width={dataFormat === "percent" ? 33 : 55}
@@ -90,7 +95,7 @@ const renderAreaChart = (
       }
     />
     <Area dataKey={dataKey[0]} stroke="none" fill={`url(#color-${dataKey[0]})`} fillOpacity={1} />
-    {isExpanded ? <CartesianGrid vertical={false} stroke="#BFC3C7" /> : ""}
+    {renderExpandedChartStroke(isExpanded, expandedGraphStrokeColor)}
   </AreaChart>
 );
 
@@ -104,6 +109,7 @@ const renderStackedAreaChart = (
   itemNames,
   itemType,
   isExpanded,
+  expandedGraphStrokeColor,
 ) => (
   <AreaChart data={data}>
     <defs>
@@ -131,7 +137,7 @@ const renderStackedAreaChart = (
       padding={{ right: 20 }}
     />
     <YAxis
-      tickCount={3}
+      tickCount={tickCount}
       axisLine={false}
       tickLine={false}
       width={dataFormat === "percent" ? 33 : 55}
@@ -170,6 +176,7 @@ const renderStackedAreaChart = (
       fill={`url(#color-${dataKey[2]})`}
       fillOpacity={1}
     />
+    {renderExpandedChartStroke(isExpanded, expandedGraphStrokeColor)}
   </AreaChart>
 );
 
@@ -183,6 +190,7 @@ const renderLineChart = (
   itemNames,
   itemType,
   isExpanded,
+  expandedGraphStrokeColor,
 ) => (
   <LineChart data={data}>
     <XAxis
@@ -197,7 +205,7 @@ const renderLineChart = (
       padding={{ right: 20 }}
     />
     <YAxis
-      tickCount={3}
+      tickCount={tickCount}
       axisLine={false}
       tickLine={false}
       width={27}
@@ -216,6 +224,7 @@ const renderLineChart = (
       content={<CustomTooltip bulletpointColors={bulletpointColors} itemNames={itemNames} itemType={itemType} />}
     />
     <Line type="monotone" dataKey={dataKey[0]} stroke={stroke ? stroke : "none"} color={color} dot={false} />;
+    {renderExpandedChartStroke(isExpanded, expandedGraphStrokeColor)}
   </LineChart>
 );
 
@@ -229,6 +238,7 @@ const renderMultiLineChart = (
   itemNames,
   itemType,
   isExpanded,
+  expandedGraphStrokeColor,
 ) => (
   <LineChart data={data}>
     <XAxis
@@ -243,7 +253,7 @@ const renderMultiLineChart = (
       padding={{ right: 20 }}
     />
     <YAxis
-      tickCount={3}
+      tickCount={tickCount}
       axisLine={false}
       tickLine={false}
       width={25}
@@ -258,17 +268,28 @@ const renderMultiLineChart = (
     <Line dataKey={dataKey[0]} stroke={stroke} dot={false} />;
     <Line dataKey={dataKey[1]} stroke={stroke} dot={false} />;
     <Line dataKey={dataKey[2]} stroke={stroke} dot={false} />;
+    {renderExpandedChartStroke(isExpanded, expandedGraphStrokeColor)}
   </LineChart>
 );
 
 // JTBD: Bar chart for Holders
-const renderBarChart = (data, dataKey, stroke, dataFormat, bulletpointColors, itemNames, itemType, isExpanded) => (
+const renderBarChart = (
+  data,
+  dataKey,
+  stroke,
+  dataFormat,
+  bulletpointColors,
+  itemNames,
+  itemType,
+  isExpanded,
+  expandedGraphStrokeColor,
+) => (
   <BarChart data={data}>
     <XAxis
       dataKey="timestamp"
       interval={30}
       axisLine={false}
-      tickCount={3}
+      tickCount={tickCount}
       tickLine={false}
       reversed={true}
       tickFormatter={str => format(new Date(str * 1000), "MMM dd")}
@@ -277,7 +298,7 @@ const renderBarChart = (data, dataKey, stroke, dataFormat, bulletpointColors, it
     <YAxis
       axisLine={false}
       tickLine={false}
-      tickCount={3}
+      tickCount={tickCount}
       width={33}
       domain={[0, "auto"]}
       allowDataOverflow={false}
@@ -287,6 +308,7 @@ const renderBarChart = (data, dataKey, stroke, dataFormat, bulletpointColors, it
       content={<CustomTooltip bulletpointColors={bulletpointColors} itemNames={itemNames} itemType={itemType} />}
     />
     <Bar dataKey={dataKey[0]} fill={stroke[0]} />
+    {renderExpandedChartStroke(isExpanded, expandedGraphStrokeColor)}
   </BarChart>
 );
 
@@ -305,6 +327,7 @@ function Chart({
   itemType,
   isStaked,
   infoTooltipMessage,
+  expandedGraphStrokeColor,
 }) {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -319,7 +342,18 @@ function Chart({
 
   const renderChart = (type, isExpanded) => {
     if (type === "line")
-      return renderLineChart(data, dataKey, color, stroke, dataFormat, bulletpointColors, itemNames, itemType);
+      return renderLineChart(
+        data,
+        dataKey,
+        color,
+        stroke,
+        dataFormat,
+        bulletpointColors,
+        itemNames,
+        itemType,
+        isExpanded,
+        expandedGraphStrokeColor,
+      );
     if (type === "area")
       return renderAreaChart(
         data,
@@ -332,6 +366,7 @@ function Chart({
         itemType,
         isStaked,
         isExpanded,
+        expandedGraphStrokeColor,
       );
     if (type === "stack")
       return renderStackedAreaChart(
@@ -344,6 +379,7 @@ function Chart({
         itemNames,
         itemType,
         isExpanded,
+        expandedGraphStrokeColor,
       );
     if (type === "multi")
       return renderMultiLineChart(
@@ -356,10 +392,21 @@ function Chart({
         itemNames,
         itemType,
         isExpanded,
+        expandedGraphStrokeColor,
       );
 
     if (type === "bar")
-      return renderBarChart(data, dataKey, stroke, dataFormat, bulletpointColors, itemNames, itemType, isExpanded);
+      return renderBarChart(
+        data,
+        dataKey,
+        stroke,
+        dataFormat,
+        bulletpointColors,
+        itemNames,
+        itemType,
+        isExpanded,
+        expandedGraphStrokeColor,
+      );
   };
 
   const runwayExtraInfo = type =>

--- a/src/components/Chart/CustomTooltip.jsx
+++ b/src/components/Chart/CustomTooltip.jsx
@@ -22,7 +22,7 @@ const renderItem = (type, item) => {
   );
 };
 
-const renderTooltipItems = (payload, bulletpointColors, itemNames, itemType, isStaked = false) => {
+const renderTooltipItems = (payload, bulletpointColors, itemNames, itemType, isStaked = false, isPOL = false) => {
   return isStaked ? (
     <Box>
       <Box className="item" display="flex" justifyContent="space-between">
@@ -36,6 +36,24 @@ const renderTooltipItems = (payload, bulletpointColors, itemNames, itemType, isS
         <Typography variant="body2">
           <span className="tooltip-bulletpoint" style={bulletpointColors[1]}></span>
           Not staked
+        </Typography>
+        <Typography>{`${Math.round(100 - payload[0].value)}%`}</Typography>
+      </Box>
+      <Box>{renderDate(0, payload, payload[0])}</Box>
+    </Box>
+  ) : isPOL ? (
+    <Box>
+      <Box className="item" display="flex" justifyContent="space-between">
+        <Typography variant="body2">
+          <span className="tooltip-bulletpoint" style={bulletpointColors[0]}></span>
+          {itemNames[0]}
+        </Typography>
+        <Typography>{`${Math.round(payload[0].value)}%`}</Typography>
+      </Box>
+      <Box className="item" display="flex" justifyContent="space-between">
+        <Typography variant="body2">
+          <span className="tooltip-bulletpoint" style={bulletpointColors[1]}></span>
+          {itemNames[1]}
         </Typography>
         <Typography>{`${Math.round(100 - payload[0].value)}%`}</Typography>
       </Box>
@@ -59,11 +77,11 @@ const renderTooltipItems = (payload, bulletpointColors, itemNames, itemType, isS
   );
 };
 
-function CustomTooltip({ active, payload, bulletpointColors, itemNames, itemType, isStaked }) {
+function CustomTooltip({ active, payload, bulletpointColors, itemNames, itemType, isStaked, isPOL }) {
   if (active && payload && payload.length) {
     return (
       <Paper className={`ohm-card tooltip-container`}>
-        {renderTooltipItems(payload, bulletpointColors, itemNames, itemType, isStaked)}
+        {renderTooltipItems(payload, bulletpointColors, itemNames, itemType, isStaked, isPOL)}
       </Paper>
     );
   }

--- a/src/themes/dark.js
+++ b/src/themes/dark.js
@@ -38,6 +38,7 @@ const darkTheme = {
   outlinedSecondaryButtonHoverBG: "transparent",
   outlinedSecondaryButtonHoverColor: "#F8CC82", //gold
   containedSecondaryButtonHoverBG: "rgba(255, 255, 255, 0.15)",
+  graphStrokeColor: "rgba(255, 255, 255, .1)",
 };
 
 export const dark = responsiveFontSizes(
@@ -64,6 +65,7 @@ export const dark = responsiveFontSizes(
           primary: darkTheme.color,
           secondary: darkTheme.gray,
         },
+        graphStrokeColor: darkTheme.graphStrokeColor,
       },
       typography: {
         fontFamily: "Square",

--- a/src/themes/light.js
+++ b/src/themes/light.js
@@ -30,6 +30,7 @@ const lightTheme = {
   outlinedSecondaryButtonHoverBG: "#FCFCFC",
   outlinedSecondaryButtonHoverColor: "#333333",
   containedSecondaryButtonHoverBG: "#33333333",
+  graphStrokeColor: "rgba(37, 52, 73, .2)",
 };
 
 export const light = responsiveFontSizes(
@@ -56,6 +57,7 @@ export const light = responsiveFontSizes(
           primary: lightTheme.color,
           secondary: lightTheme.gray,
         },
+        graphStrokeColor: lightTheme.graphStrokeColor,
       },
       typography: {
         fontFamily: "Square",

--- a/src/views/TreasuryDashboard/TreasuryDashboard.jsx
+++ b/src/views/TreasuryDashboard/TreasuryDashboard.jsx
@@ -147,6 +147,7 @@ function TreasuryDashboard() {
                   itemNames={tooltipItems.tvl}
                   itemType={itemType.dollar}
                   infoTooltipMessage={tooltipInfoMessages.tvl}
+                  expandedGraphStrokeColor={theme.palette.graphStrokeColor}
                 />
               </Paper>
             </Grid>
@@ -168,6 +169,7 @@ function TreasuryDashboard() {
                   itemNames={tooltipItems.coin}
                   itemType={itemType.dollar}
                   infoTooltipMessage={tooltipInfoMessages.mvt}
+                  expandedGraphStrokeColor={theme.palette.graphStrokeColor}
                 />
               </Paper>
             </Grid>
@@ -190,6 +192,7 @@ function TreasuryDashboard() {
                   itemNames={tooltipItems.coin}
                   itemType={itemType.dollar}
                   infoTooltipMessage={tooltipInfoMessages.rfv}
+                  expandedGraphStrokeColor={theme.palette.graphStrokeColor}
                 />
               </Paper>
             </Grid>
@@ -212,6 +215,7 @@ function TreasuryDashboard() {
                   itemNames={tooltipItems.coin}
                   itemType={itemType.percentage}
                   infoTooltipMessage={tooltipInfoMessages.pol}
+                  expandedGraphStrokeColor={theme.palette.graphStrokeColor}
                 />
               </Paper>
             </Grid>
@@ -228,6 +232,7 @@ function TreasuryDashboard() {
                   itemNames={tooltipItems.holder}
                   itemType={""}
                   infoTooltipMessage={tooltipInfoMessages.holder}
+                  expandedGraphStrokeColor={theme.palette.graphStrokeColor}
                 />
               </Paper>
             </Grid>
@@ -245,6 +250,7 @@ function TreasuryDashboard() {
                   isStaked={true}
                   bulletpointColors={bulletpoints.staked}
                   infoTooltipMessage={tooltipInfoMessages.staked}
+                  expandedGraphStrokeColor={theme.palette.graphStrokeColor}
                 />
               </Paper>
             </Grid>
@@ -264,6 +270,7 @@ function TreasuryDashboard() {
                   itemNames={tooltipItems.apy}
                   itemType={itemType.percentage}
                   infoTooltipMessage={tooltipInfoMessages.apy}
+                  expandedGraphStrokeColor={theme.palette.graphStrokeColor}
                 />
               </Paper>
             </Grid>
@@ -283,6 +290,7 @@ function TreasuryDashboard() {
                   itemNames={tooltipItems.runway}
                   itemType={""}
                   infoTooltipMessage={tooltipInfoMessages.runway}
+                  expandedGraphStrokeColor={theme.palette.graphStrokeColor}
                 />
               </Paper>
             </Grid>

--- a/src/views/TreasuryDashboard/TreasuryDashboard.jsx
+++ b/src/views/TreasuryDashboard/TreasuryDashboard.jsx
@@ -200,22 +200,19 @@ function TreasuryDashboard() {
             <Grid item lg={6} md={12} sm={12} xs={12}>
               <Paper className="ohm-card">
                 <Chart
-                  type="stack"
+                  type="area"
                   data={data}
-                  dataKey={["treasuryOhmDaiPOL", "treasuryOhmFraxPOL", ""]}
-                  stopColor={[
-                    ["#F5AC37", "#EA9276"],
-                    ["#768299", "#98B3E9"],
-                    ["", ""],
-                  ]}
-                  headerText="Protocol-Owned Liquidity"
+                  dataKey={["treasuryOhmDaiPOL"]}
+                  stopColor={[["rgba(128, 204, 131, 1)", "rgba(128, 204, 131, 0)"]]}
+                  headerText="Protocol Owned Liquidity OHM-DAI"
                   headerSubText={`${data && trim(data[0].treasuryOhmDaiPOL, 2)}% `}
                   dataFormat="percent"
-                  bulletpointColors={bulletpoints.coin}
-                  itemNames={tooltipItems.coin}
+                  bulletpointColors={bulletpoints.pol}
+                  itemNames={tooltipItems.pol}
                   itemType={itemType.percentage}
                   infoTooltipMessage={tooltipInfoMessages.pol}
                   expandedGraphStrokeColor={theme.palette.graphStrokeColor}
+                  isPOL={true}
                 />
               </Paper>
             </Grid>

--- a/src/views/TreasuryDashboard/treasuryData.js
+++ b/src/views/TreasuryDashboard/treasuryData.js
@@ -113,6 +113,18 @@ export const bulletpoints = {
       background: "rgba(151, 196, 224, 0.2)",
     },
   ],
+  pol: [
+    {
+      right: 15,
+      top: -12,
+      background: "linear-gradient(180deg, rgba(56, 223, 63, 1) -10%, rgba(182, 233, 152, 1) 100%)",
+    },
+    {
+      right: 25,
+      top: -12,
+      background: "rgba(219, 242, 170, 1)",
+    },
+  ],
 };
 
 export const tooltipItems = {
@@ -121,6 +133,7 @@ export const tooltipItems = {
   holder: ["OHMies"],
   apy: ["APY"],
   runway: ["10K_APY", "20K_APY", "50K_APY"],
+  pol: ["SLP Treasury", "Market SLP"],
 };
 
 export const tooltipInfoMessages = {

--- a/src/views/TreasuryDashboard/treasuryData.js
+++ b/src/views/TreasuryDashboard/treasuryData.js
@@ -111,6 +111,7 @@ export const bulletpoints = {
       right: 68,
       top: -12,
       background: "rgba(151, 196, 224, 0.2)",
+      border: "1px solid rgba(54, 56, 64, 0.5)",
     },
   ],
   pol: [
@@ -123,6 +124,7 @@ export const bulletpoints = {
       right: 25,
       top: -12,
       background: "rgba(219, 242, 170, 1)",
+      border: "1px solid rgba(118, 130, 153, 1)",
     },
   ],
 };


### PR DESCRIPTION
- Added additional ticks (5 total) and horizontal grid lines to expanded view;
- Combined POL into single area with green gradient as per design (need to review to implement conditional tooltip bulletpoint colors according to chosen theme);
- Fixed colors for multiline chart;