### PR TITLE
bond modal background blur fallback in firefox

### DIFF
--- a/src/views/Bond/bond.scss
+++ b/src/views/Bond/bond.scss
@@ -3,22 +3,42 @@
   width: 100%;
   height: 100%;
   z-index: 69;
-  .MuiBackdrop-root {
-    background: rgba(100, 100, 100, 0.1) !important;
-    backdrop-filter: blur(33px) !important;
-    -webkit-backdrop-filter: blur(33px) !important;
-    .ohm-card {
-      opacity: 1 !important;
-      height: auto;
+
+  @supports (-webkit-backdrop-filter: none) or (backdrop-filter: none) {
+    .MuiBackdrop-root {
+      background: rgba(100, 100, 100, 0.1) !important;
+      backdrop-filter: blur(33px) !important;
+      -webkit-backdrop-filter: blur(33px) !important;
+      .ohm-card {
+        opacity: 1 !important;
+        height: auto;
+      }
+    }
+    .ohm-modal {
+      max-width: 688px;
+      min-height: 605px;
+    }
+  }
+  
+  /* slightly transparent fallback for Firefox (not supporting backdrop-filter) */
+  @supports not ((-webkit-backdrop-filter: none) or (backdrop-filter: none)) {
+    .MuiBackdrop-root {
+      background: rgba(100, 100, 100, 0.95);
+      .ohm-card {
+        height: auto;
+      }
+    }
+    .ohm-modal {
+      max-width: 688px;
+      min-height: 605px;
+      background-color:rgb(50, 50, 50);
+      opacity: .9
     }
   }
   .ohm-card {
     max-width: 803px;
   }
-  .ohm-modal {
-    max-width: 688px;
-    min-height: 605px;
-  }
+
   .bond-header {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
I added a fallback for firefox or any browser where the backdrop-blur is not supported. Also removed a !important tag that wasnt needed. Here are some screen shots for comparison.
firefox
![bond-firefox](https://user-images.githubusercontent.com/24912886/130516455-196d68ec-e66f-424b-9cd6-19c840c4d64a.PNG)
brave
![bond-brave](https://user-images.githubusercontent.com/24912886/130516528-c73dbd0e-b0cb-46de-ab44-976088b6065c.PNG)
