### PR TITLE
Api calls via Wallet (rather than JsonRpc) when possible

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -84,7 +84,7 @@ function App() {
   const isSmallScreen = useMediaQuery("(max-width: 600px)");
 
   // NOTE (appleseed): does an OnChainProvider NEED to be saved to context? Or can it be called freshly each time?
-  const { connect, _hasCachedProvider, provider, chainID, connected, web3Modal } = useWeb3Context();
+  const { connect, hasCachedProvider, provider, chainID, connected } = useWeb3Context();
   const address = useAddress();
 
   const [walletChecked, setWalletChecked] = useState(false);
@@ -145,8 +145,7 @@ function App() {
   // ... if we don't wait we'll ALWAYS fire API calls via JsonRpc because provider has not
   // ... been reloaded within App.
   useEffect(() => {
-    // below is the equivalent of _hasCachedProvider() in web3Context
-    if (_hasCachedProvider()) {
+    if (hasCachedProvider()) {
       // then user DOES have a wallet
       connect().then(() => {
         setWalletChecked(true);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -84,7 +84,7 @@ function App() {
   const isSmallScreen = useMediaQuery("(max-width: 600px)");
 
   // NOTE (appleseed): does an OnChainProvider NEED to be saved to context? Or can it be called freshly each time?
-  const { connect, provider, chainID, connected, web3Modal } = useWeb3Context();
+  const { connect, _hasCachedProvider, provider, chainID, connected, web3Modal } = useWeb3Context();
   const address = useAddress();
 
   const [walletChecked, setWalletChecked] = useState(false);
@@ -145,15 +145,15 @@ function App() {
   // ... if we don't wait we'll ALWAYS fire API calls via JsonRpc because provider has not
   // ... been reloaded within App.
   useEffect(() => {
-    // below is the equivalent of __hasCachedProvider() in web3Context
-    if (!web3Modal || !web3Modal.cachedProvider) {
-      // then user DOES NOT have a wallet
-      setWalletChecked(true);
-    } else {
+    // below is the equivalent of _hasCachedProvider() in web3Context
+    if (_hasCachedProvider()) {
       // then user DOES have a wallet
       connect().then(() => {
         setWalletChecked(true);
       });
+    } else {
+      // then user DOES NOT have a wallet
+      setWalletChecked(true);
     }
   }, []);
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -84,8 +84,10 @@ function App() {
   const isSmallScreen = useMediaQuery("(max-width: 600px)");
 
   // NOTE (appleseed): does an OnChainProvider NEED to be saved to context? Or can it be called freshly each time?
-  const { provider, chainID, connected } = useWeb3Context();
+  const { connect, provider, chainID, connected, web3Modal } = useWeb3Context();
   const address = useAddress();
+
+  const [walletChecked, setWalletChecked] = useState(false);
 
   const isAppLoading = useSelector(state => state.app.loading);
   const isAppLoaded = useSelector(state => typeof state.app.marketPrice != "undefined"); // Hacky way of determining if we were able to load app Details.
@@ -98,16 +100,6 @@ function App() {
     // we shouldn't be initializing to chainID=1 in web3Context without first listening for the
     // network. To actually test rinkeby, change setChainID equal to 4 before testing.
     let loadProvider = provider;
-
-    // NOTE (appleseed): loadDetails() runs three times on every app refresh (every time `connected` is set)...
-    // ... once with address === "" && loadProvider === StaticJsonRpcProvider (set inside of Web3ContextProvider)
-    // ... once with address === "[wallet address]" && loadProvider === StaticJsonRpcProvider (set inside of Web3Context.connect())
-    // ... once with address === "[wallet address]" && loadProvider === Web3Provider (set inside of Web3Context.connect() right after the above line)
-    // So we need to make sure we don't run `loadAccountDetails`, `loadAppDetails` & `calcBondDetails`...
-    // ... below each of the three times state is changed
-    // The below if statements are one way to prevent the 3x runs
-    //
-    // console.log(whichDetails, connected, address, provider);
 
     // run with loadProvider (backend provider) so that user doesn't need a connected wallet to see app details.
     if (whichDetails === "app") {
@@ -140,14 +132,41 @@ function App() {
     [connected],
   );
 
+  // The next 3 useEffects handle initializing API Loads AFTER wallet is checked
+  //
+  // this useEffect checks Wallet Connection & then sets State for reload...
+  // ... we don't try to fire Api Calls on initial load because web3Context is not set yet
+  // ... if we don't wait we'll ALWAYS fire API calls via JsonRpc because provider has not
+  // ... been reloaded within App.
   useEffect(() => {
-    // runs only on initial paint
-    loadDetails("app");
+    // below is the equivalent of __hasCachedProvider() in web3Context
+    if (!web3Modal || !web3Modal.cachedProvider) {
+      // then user DOES NOT have a wallet
+      setWalletChecked(true);
+    } else {
+      // then user DOES have a wallet
+      connect().then(() => {
+        setWalletChecked(true);
+      });
+    }
   }, []);
 
+  // this useEffect fires on state change from above. It will ALWAYS fire AFTER
   useEffect(() => {
-    // runs only when connected is changed
-    loadDetails("account");
+    // don't load ANY details until wallet is Checked
+    if (walletChecked) {
+      loadDetails("app");
+      loadDetails("account");
+    }
+  }, [walletChecked]);
+
+  // this useEffect picks up any time a user Connects via the button
+  useEffect(() => {
+    // don't load ANY details until wallet is Connected
+    if (connected) {
+      loadDetails("app");
+      loadDetails("account");
+    }
   }, [connected]);
 
   const handleDrawerToggle = () => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,7 +83,6 @@ function App() {
   const isSmallerScreen = useMediaQuery("(max-width: 960px)");
   const isSmallScreen = useMediaQuery("(max-width: 600px)");
 
-  // NOTE (appleseed): does an OnChainProvider NEED to be saved to context? Or can it be called freshly each time?
   const { connect, hasCachedProvider, provider, chainID, connected } = useWeb3Context();
   const address = useAddress();
 
@@ -101,7 +100,6 @@ function App() {
     // network. To actually test rinkeby, change setChainID equal to 4 before testing.
     let loadProvider = provider;
 
-    // run with loadProvider (backend provider) so that user doesn't need a connected wallet to see app details.
     if (whichDetails === "app") {
       loadApp(loadProvider);
     }

--- a/src/hooks/web3Context.tsx
+++ b/src/hooks/web3Context.tsx
@@ -203,8 +203,8 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
   }, [provider, web3Modal, connected]);
 
   const onChainProvider = useMemo(
-    () => ({ connect, disconnect, provider, connected, address, chainID, web3Modal }),
-    [connect, disconnect, provider, connected, address, chainID, web3Modal],
+    () => ({ connect, disconnect, _hasCachedProvider, provider, connected, address, chainID, web3Modal }),
+    [connect, disconnect, _hasCachedProvider, provider, connected, address, chainID, web3Modal],
   );
 
   useEffect(() => {

--- a/src/hooks/web3Context.tsx
+++ b/src/hooks/web3Context.tsx
@@ -123,7 +123,7 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
     }),
   );
 
-  const _hasCachedProvider = (): Boolean => {
+  const hasCachedProvider = (): Boolean => {
     if (!web3Modal) return false;
     if (!web3Modal.cachedProvider) return false;
     return true;
@@ -137,12 +137,12 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
     if (!provider || provider instanceof Web3Provider !== true) return;
 
     provider.on("accountsChanged", () => {
-      if (_hasCachedProvider()) return;
+      if (hasCachedProvider()) return;
       setTimeout(() => window.location.reload(), 1);
     });
 
     provider.on("chainChanged", (chain: number) => {
-      if (_hasCachedProvider()) return;
+      if (hasCachedProvider()) return;
       _checkNetwork(chain);
       setTimeout(() => window.location.reload(), 1);
     });
@@ -181,7 +181,7 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
       console.error("Wrong network, please switch to mainnet");
       return;
     }
-    // Save everything after we've validated the right nextwork.
+    // Save everything after we've validated the right network.
     // Eventually we'll be fine without doing network validations.
     setAddress(connectedAddress);
     setProvider(connectedProvider);
@@ -203,14 +203,14 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
   }, [provider, web3Modal, connected]);
 
   const onChainProvider = useMemo(
-    () => ({ connect, disconnect, _hasCachedProvider, provider, connected, address, chainID, web3Modal }),
-    [connect, disconnect, _hasCachedProvider, provider, connected, address, chainID, web3Modal],
+    () => ({ connect, disconnect, hasCachedProvider, provider, connected, address, chainID, web3Modal }),
+    [connect, disconnect, hasCachedProvider, provider, connected, address, chainID, web3Modal],
   );
 
   useEffect(() => {
     // Don't try to connect here. Do it in App.jsx
-    // console.log(_hasCachedProvider());
-    // if (_hasCachedProvider()) {
+    // console.log(hasCachedProvider());
+    // if (hasCachedProvider()) {
     //   connect();
     // }
   }, []);

--- a/src/hooks/web3Context.tsx
+++ b/src/hooks/web3Context.tsx
@@ -129,7 +129,7 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
     return true;
   };
 
-  // NOTE (appleseed): none of these listeners are needed for Backend API Providers, right?
+  // NOTE (appleseed): none of these listeners are needed for Backend API Providers
   // ... so I changed these listeners so that they only apply to walletProviders, eliminating
   // ... polling to the backend providers for network changes
   const _initListeners = useCallback(() => {

--- a/src/hooks/web3Context.tsx
+++ b/src/hooks/web3Context.tsx
@@ -27,6 +27,9 @@ const ALCHEMY_ID_LIST = [
   "DNj81sBwBcgdjHHBUse4naHaW82XSKtE", // this is Girth's
 ];
 
+// this is the ethers common api key, it is rate limited somewhat
+const defaultApiKey = "https://eth-mainnet.alchemyapi.io/v2/_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC";
+
 const TEMP_ALCHEMY_IDS = [
   // "rZD4Q_qiIlewksdYFDfM3Y0mzZy-8Naf", // appleseed-temp1
   "9GOp6SIgE0en92i3r0JSvxccZ0N2idmO", // appleseed-temp2
@@ -132,6 +135,7 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
   const _initListeners = useCallback(() => {
     // this IF stops the func if provider is !Web3Provider since we only want to run on WalletProviders
     if (!provider || provider instanceof Web3Provider !== true) return;
+
     provider.on("accountsChanged", () => {
       if (_hasCachedProvider()) return;
       setTimeout(() => window.location.reload(), 1);
@@ -166,6 +170,7 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
   // connect - only runs for WalletProviders
   const connect = useCallback(async () => {
     const rawProvider = await web3Modal.connect();
+
     const connectedProvider = new Web3Provider(rawProvider, "any");
 
     const chainId = await connectedProvider.getNetwork().then(network => network.chainId);
@@ -203,9 +208,11 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
   );
 
   useEffect(() => {
-    if (_hasCachedProvider()) {
-      connect();
-    }
+    // Don't try to connect here. Do it in App.jsx
+    // console.log(_hasCachedProvider());
+    // if (_hasCachedProvider()) {
+    //   connect();
+    // }
   }, []);
 
   // initListeners needs to be run after walletProvider is connected


### PR DESCRIPTION
The initial app paint includes the initial provider state (JsonRpc) set in `web3Context`. As a result, all API calls on initial app load are run via JsonRpc. App.jsx doesn't receive the provider state change until it's second paint. So this pr forces a second paint by checking wallet connection first:

1. Move `connect()` out of `Web3Context.useEffect` & into App.jsx
2. Run `connect()` on initial app paint in `App.useEffect`. If `connect` is successful provider state will change. App.jsx needs to re-paint to pick up that change. We force re-paint via `walletChecked` state.
3. On re-paint fire `loadDetails`
4. Also keep separate the useEffect that is dependent on `connect` so that when user's click the connect button the app will fire `loadDetails`

**End Result:**
If user has a connected wallet then API calls are fired from the wallet rather than via JsonRpc & avoids our API calls. On initial App load only (4) API calls will hit JsonRpc.
If a user does not have a connected wallet then API calls are fired from JsonRpc (there are 59 on app load).