### PR TITLE
Fix: Web3Modal Event Listeners Firing

### DIFF
--- a/src/hooks/web3Context.tsx
+++ b/src/hooks/web3Context.tsx
@@ -134,6 +134,9 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
   // ... polling to the backend providers for network changes
   const _initListeners = useCallback(
     rawProvider => {
+      if (!rawProvider.on) {
+        return;
+      }
       rawProvider.on("accountsChanged", async (accounts: string[]) => {
         setTimeout(() => window.location.reload(), 1);
       });

--- a/src/hooks/web3Context.tsx
+++ b/src/hooks/web3Context.tsx
@@ -132,26 +132,24 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
   // NOTE (appleseed): none of these listeners are needed for Backend API Providers
   // ... so I changed these listeners so that they only apply to walletProviders, eliminating
   // ... polling to the backend providers for network changes
-  const _initListeners = useCallback(() => {
-    // this IF stops the func if provider is !Web3Provider since we only want to run on WalletProviders
-    if (!provider || provider instanceof Web3Provider !== true) return;
+  const _initListeners = useCallback(
+    rawProvider => {
+      rawProvider.on("accountsChanged", async (accounts: string[]) => {
+        setTimeout(() => window.location.reload(), 1);
+      });
 
-    provider.on("accountsChanged", () => {
-      if (hasCachedProvider()) return;
-      setTimeout(() => window.location.reload(), 1);
-    });
+      rawProvider.on("chainChanged", async (chain: number) => {
+        _checkNetwork(chain);
+        setTimeout(() => window.location.reload(), 1);
+      });
 
-    provider.on("chainChanged", (chain: number) => {
-      if (hasCachedProvider()) return;
-      _checkNetwork(chain);
-      setTimeout(() => window.location.reload(), 1);
-    });
-
-    provider.on("network", (_newNetwork, oldNetwork) => {
-      if (!oldNetwork) return;
-      window.location.reload();
-    });
-  }, [provider]);
+      rawProvider.on("network", (_newNetwork: any, oldNetwork: any) => {
+        if (!oldNetwork) return;
+        window.location.reload();
+      });
+    },
+    [provider],
+  );
 
   // Eventually we will not need this method.
   const _checkNetwork = (otherChainID: number): Boolean => {
@@ -170,6 +168,10 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
   // connect - only runs for WalletProviders
   const connect = useCallback(async () => {
     const rawProvider = await web3Modal.connect();
+
+    // new _initListeners implementation matches Web3Modal Docs
+    // ... see here: https://github.com/Web3Modal/web3modal/blob/2ff929d0e99df5edf6bb9e88cff338ba6d8a3991/example/src/App.tsx#L185
+    _initListeners(rawProvider);
 
     const connectedProvider = new Web3Provider(rawProvider, "any");
 
@@ -215,10 +217,10 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
     // }
   }, []);
 
-  // initListeners needs to be run after walletProvider is connected
-  useEffect(() => {
-    _initListeners();
-  }, [connected]);
+  // initListeners needs to be run on rawProvider... see connect()
+  // useEffect(() => {
+  //   _initListeners();
+  // }, [connected]);
 
   return <Web3Context.Provider value={{ onChainProvider }}>{children}</Web3Context.Provider>;
 };


### PR DESCRIPTION
 - aka: '60% of the time they work every time'

Problem:
* In testing, Web3Modal Events 'accountsChanged' did not fire...
 ... & 'chainChanged' only fired on the 1st change.

Solution:
* Fix events so they fire each time, every time.

How:
* Attach event listeners to *rawProvider* rather than *provider*
* Took solution from Web3Modal repo example, linked in comments