### PR TITLE
[WIP] Catch Rejected Wallet connection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -145,9 +145,13 @@ function App() {
   useEffect(() => {
     if (hasCachedProvider()) {
       // then user DOES have a wallet
-      connect().then(() => {
-        setWalletChecked(true);
-      });
+      connect()
+        .then(() => {
+          setWalletChecked(true);
+        })
+        .catch(e => {
+          console.log(e);
+        });
     } else {
       // then user DOES NOT have a wallet
       setWalletChecked(true);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -145,8 +145,11 @@ function App() {
   useEffect(() => {
     if (hasCachedProvider()) {
       // then user DOES have a wallet
+      console.log("have cached provider");
       connect()
-        .then(() => {
+        .then(returnedProvider => {
+          console.log("here");
+          console.log(returnedProvider, address);
           setWalletChecked(true);
         })
         .catch(e => {

--- a/src/hooks/web3Context.tsx
+++ b/src/hooks/web3Context.tsx
@@ -171,7 +171,20 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
 
   // connect - only runs for WalletProviders
   const connect = useCallback(async () => {
-    const rawProvider = await web3Modal.connect();
+    const rawProvider = await web3Modal
+      .connect()
+      .then(resp => {
+        // resp == rawProvider
+        return resp;
+      })
+      .catch(error => {
+        // when the user rejects the connection (clicks X box)
+        // no error response is returned by web3Modal
+        // we throw undefined so that we know something's not right
+        return undefined;
+      });
+    // catch undefined from web3Modal to prevent setting the remaining state in connect block
+    if (rawProvider === undefined) return undefined;
 
     // new _initListeners implementation matches Web3Modal Docs
     // ... see here: https://github.com/Web3Modal/web3modal/blob/2ff929d0e99df5edf6bb9e88cff338ba6d8a3991/example/src/App.tsx#L185


### PR DESCRIPTION
Problem:
* User may reject the Connect wallet modal
* App may hang if rejection isn't caught

Solution:
* web3Modal does not return an error in that case...
* we immediately return undefined up to App.jsx to prevent connect block completion
* App.jsx will setWalletConnected(true) and load app with provider === JsonRpc.