### PR TITLE
Update "max" button next to input on bond purchases

### DIFF
--- a/src/views/Bond/BondPurchase.jsx
+++ b/src/views/Bond/BondPurchase.jsx
@@ -80,7 +80,8 @@ function BondPurchase({ bond, slippage }) {
   }, [bond.allowance]);
 
   const setMax = () => {
-    setQuantity((bond.balance || "").toString());
+    setQuantity((Math.min(bond.maxBondPrice * bond.bondPrice, bond.balance) || "").toString());
+    
   };
 
   useEffect(() => {


### PR DESCRIPTION
Take the minimum value between the total wallet balance of the quote currency and the max buyable bond amount, such that the user has a harder time entering an amount greater than the total available bonds in the system.

I tested this on rinkeby with dai bonds + console debugging, it seems to work as intended and should work across all bond types.