### PR TITLE
Add Websocket Support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,18 @@
+####### API KEYS #######
+#
+# in development environment none of the below api keys are necessary
+#
 # add your INFURA ID
 REACT_APP_INFURA_IDS=""
-
+#
 # add your ALCHEMY API KEY
 # NOTE: in development environment app will run without an ALCHEMY API KEY
 REACT_APP_ALCHEMY_IDS=""
-
+#
 # add a TESTNET ALCHEMY API KEY
 REACT_APP_TESTNET_ALCHEMY=""
+#
+# if you run your own node you set place your websocket address below
+REACT_APP_SELF_HOSTED_WEBSOCKETS="ws://ipAddress:port"
+#
+########################

--- a/src/helpers/Environment.ts
+++ b/src/helpers/Environment.ts
@@ -16,7 +16,7 @@ export class EnvHelper {
    */
   static getAlchemyAPIKeyList() {
     var ALCHEMY_ID_LIST: any[];
-    if (EnvHelper.env.NODE_ENV === "production" && EnvHelper.env.REACT_APP_ALCHEMY_IDS) {
+    if (EnvHelper.env.NODE_ENV !== "development" && EnvHelper.env.REACT_APP_ALCHEMY_IDS) {
       ALCHEMY_ID_LIST = EnvHelper.env.REACT_APP_ALCHEMY_IDS.split(" ");
     } else {
       // this is the ethers common API key, suitable for testing, not prod
@@ -36,5 +36,15 @@ export class EnvHelper {
       INFURA_ID_LIST = [];
     }
     return INFURA_ID_LIST;
+  }
+
+  static getSelfHostedSockets() {
+    var WS_LIST: any[];
+    if (EnvHelper.env.REACT_APP_SELF_HOSTED_WEBSOCKETS) {
+      WS_LIST = EnvHelper.env.REACT_APP_SELF_HOSTED_WEBSOCKETS.split(" ");
+    } else {
+      WS_LIST = [];
+    }
+    return WS_LIST;
   }
 }

--- a/src/helpers/Environment.ts
+++ b/src/helpers/Environment.ts
@@ -38,6 +38,9 @@ export class EnvHelper {
     return INFURA_ID_LIST;
   }
 
+  /**
+   * @returns {Array} Array of websocket addresses
+   */
   static getSelfHostedSockets() {
     var WS_LIST: any[];
     if (EnvHelper.env.REACT_APP_SELF_HOSTED_WEBSOCKETS) {


### PR DESCRIPTION
1. branched off of api-keys-env
2. adds websocket support to the same env implementation
3. load balances any Alchemy Keys and/or Websockets you provide
4. in Development environment Alchemy Keys revert to the Ethers
   community key
5. current websocket implementation has a little more latency than
   Alchemy. May need a little tuning of the ws server.