### PR TITLE
FIX: overlooked indexOf === 0 for websocket detection

### DIFF
--- a/src/hooks/web3Context.tsx
+++ b/src/hooks/web3Context.tsx
@@ -73,7 +73,8 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
 
   // if websocket we need to change providerType
   const providerType = () => {
-    if (uri.indexOf("ws://") > 0 || uri.indexOf("wss://") > 0) {
+    console.log("providerType", uri);
+    if (uri.indexOf("ws://") >= 0 || uri.indexOf("wss://") >= 0) {
       return new WebSocketProvider(uri);
     } else {
       return new StaticJsonRpcProvider(uri);

--- a/src/hooks/web3Context.tsx
+++ b/src/hooks/web3Context.tsx
@@ -73,8 +73,7 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
 
   // if websocket we need to change providerType
   const providerType = () => {
-    console.log("providerType", uri);
-    if (uri.indexOf("ws://") >= 0 || uri.indexOf("wss://") >= 0) {
+    if (uri.indexOf("ws://") === 0 || uri.indexOf("wss://") === 0) {
       return new WebSocketProvider(uri);
     } else {
       return new StaticJsonRpcProvider(uri);


### PR DESCRIPTION
I made a dum mistake, overlooking that `indexOf` would === 0 when the websocket addresses are pulled up in the load balancer.

With my mistake websocket connections always failed (because we loaded the wrong type of provider).
With this fix websocket connections will work properly.