### PR TITLE
Fix dapp-sidebar height

### DIFF
--- a/src/components/Sidebar/sidebar.scss
+++ b/src/components/Sidebar/sidebar.scss
@@ -9,7 +9,7 @@
 }
 
 .dapp-sidebar {
-  height: auto;
+  height: 100vh;
   border-radius: 0 !important;
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);


### PR DESCRIPTION
The sidebar was not extending to the bottom of the screen when set to `height: auto`.