### PR TITLE
Bug Fix: Handle no Segment Analytics blocking action completion

### DIFF
--- a/src/helpers/userAnalyticHelpers.js
+++ b/src/helpers/userAnalyticHelpers.js
@@ -1,8 +1,11 @@
 // Pushing data to segment analytics
 export function segmentUA(data) {
   const stringifiedData = JSON.stringify(data);
-  var analytics = (window.analytics = window.analytics || []);
-  analytics.track(data.type, {
-    data,
-  });
+  var analytics = (window.analytics = window.analytics);
+  // NOTE (appleseed): the analytics object may not exist (if there is no SEGMENT_API_KEY)
+  if (analytics) {
+    analytics.track(data.type, {
+      data,
+    });
+  }
 }


### PR DESCRIPTION
Bug Fix:

if the dev doesn't have SEGMENT_API_KEY in his environment then the call to `segmentUA` never returned back to StakeThunk, BondSlice, etc. since in that case `window.analytics` did not exist & did not have a `track` function.