### PR TITLE
fix output pending/claimable values for bonds on mobile screen

### DIFF
--- a/src/views/ChooseBond/ClaimRow.jsx
+++ b/src/views/ChooseBond/ClaimRow.jsx
@@ -108,12 +108,12 @@ export function ClaimBondCardData({ userBond }) {
 
       <div className="data-row">
         <Typography>Claimable</Typography>
-        <Typography>{bond.interestDue ? trim(bond.interestDue, 4) : <Skeleton width={100} />}</Typography>
+        <Typography>{bond.pendingPayout ? trim(bond.pendingPayout, 4) : <Skeleton width={100} />}</Typography>
       </div>
 
       <div className="data-row">
         <Typography>Pending</Typography>
-        <Typography>{bond.pendingPayout ? trim(bond.pendingPayout, 4) : <Skeleton width={100} />}</Typography>
+        <Typography>{bond.interestDue ? trim(bond.interestDue, 4) : <Skeleton width={100} />}</Typography>
       </div>
 
       <div className="data-row" style={{ marginBottom: "20px" }}>


### PR DESCRIPTION
On a desktop
![image](https://user-images.githubusercontent.com/6397708/135515860-4f803799-573b-41e8-be05-335796dccf18.png)

But on mobile view values for `claimable` and `pending` are swaped
![image](https://user-images.githubusercontent.com/6397708/135516002-815b337a-bbab-4ea3-8189-0f2b1a669489.png)
