### PR TITLE
apy chart uses log scale, runway chart uses currentRunway value

### DIFF
--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -204,6 +204,7 @@ const renderLineChart = (
   itemType,
   isExpanded,
   expandedGraphStrokeColor,
+  scale,
 ) => (
   <LineChart data={data}>
     <XAxis
@@ -218,18 +219,15 @@ const renderLineChart = (
       padding={{ right: 20 }}
     />
     <YAxis
-      tickCount={isExpanded ? expandedTickCount : tickCount}
+      tickCount={scale == "log" ? 1 : isExpanded ? expandedTickCount : tickCount}
       axisLine={false}
       tickLine={false}
-      width={27}
+      width={32}
+      scale={scale}
       tickFormatter={number =>
-        number !== 0
-          ? dataFormat !== "percent"
-            ? `${formatCurrency(parseFloat(number) / 1000000)}M`
-            : `${parseFloat(number) / 1000}k`
-          : ""
+        number !== 0 ? (dataFormat !== "percent" ? `${number}` : `${parseFloat(number) / 1000}k`) : ""
       }
-      domain={[0, "auto"]}
+      domain={[scale == "log" ? "dataMin" : 0, "auto"]}
       connectNulls={true}
       allowDataOverflow={false}
     />
@@ -328,6 +326,7 @@ const renderBarChart = (
 function Chart({
   type,
   data,
+  scale,
   dataKey,
   color,
   stopColor,
@@ -367,6 +366,7 @@ function Chart({
         itemType,
         isExpanded,
         expandedGraphStrokeColor,
+        scale,
       );
     if (type === "area")
       return renderAreaChart(

--- a/src/views/TreasuryDashboard/TreasuryDashboard.jsx
+++ b/src/views/TreasuryDashboard/TreasuryDashboard.jsx
@@ -255,6 +255,7 @@ function TreasuryDashboard() {
               <Paper className="ohm-card">
                 <Chart
                   type="line"
+                  scale="log"
                   data={apy}
                   dataKey={["apy"]}
                   color={theme.palette.text.primary}
@@ -274,11 +275,11 @@ function TreasuryDashboard() {
             <Grid item lg={6} md={6} sm={12} xs={12}>
               <Paper className="ohm-card">
                 <Chart
-                  type="multi"
+                  type="line"
                   data={runway}
-                  dataKey={["runway10k", "runway20k", "runway50k"]}
+                  dataKey={["runwayCurrent"]}
                   color={theme.palette.text.primary}
-                  stroke={[theme.palette.text.primary, "#2EC608", "#49A1F2"]}
+                  stroke={[theme.palette.text.primary]}
                   headerText="Runway Available"
                   headerSubText={`${data && trim(data[0].runwayCurrent, 1)} Days`}
                   dataFormat="days"

--- a/src/views/TreasuryDashboard/treasuryData.js
+++ b/src/views/TreasuryDashboard/treasuryData.js
@@ -140,7 +140,7 @@ export const tooltipItems = {
   coin: ["DAI", "FRAX", "ETH", "SUSHI"],
   holder: ["OHMies"],
   apy: ["APY"],
-  runway: ["10K APY", "20K APY", "50K APY"],
+  runway: ["Days"],
   pol: ["SLP Treasury", "Market SLP"],
 };
 


### PR DESCRIPTION
Make APY and Runway charts be more similar to dune ones

Before
![image](https://user-images.githubusercontent.com/6397708/135521347-08353920-2575-45f5-9a99-00cc2cf07dea.png)

After
![image](https://user-images.githubusercontent.com/6397708/135521271-76fbf7f5-2b2e-42dc-9c9f-1cfc20a55903.png)