### PR TITLE
Convert the user's IP address into a country and send to Segment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,4 +29,7 @@ REACT_APP_SELF_HOSTED_WEBSOCKETS="ws://ipAddress:port"
 # Segment Analytics
 # - not necessary in dev environment
 REACT_APP_SEGMENT_API_KEY=""
+
+# Required for IP -> Country lookup
+REACT_APP_GEOAPIFY_API_KEY=""
 ########################

--- a/src/helpers/Environment.ts
+++ b/src/helpers/Environment.ts
@@ -109,5 +109,7 @@ export class EnvHelper {
       console.warn("Missing REACT_APP_GEOAPIFY_API_KEY environment variable");
       return null;
     }
+
+    return apiKey;
   }
 }

--- a/src/helpers/Environment.ts
+++ b/src/helpers/Environment.ts
@@ -102,4 +102,11 @@ export class EnvHelper {
     if (ALL_URIs.length === 0) console.error("API keys must be set in the .env");
     return ALL_URIs;
   }
+
+  static getGeoapifyAPIKey() {
+    var apiKey = EnvHelper.env.REACT_APP_GEOAPIFY_API_KEY;
+    if (!apiKey) {
+      throw "Missing REACT_APP_GEOAPIFY_API_KEY environment variable";
+    }
+  }
 }

--- a/src/helpers/Environment.ts
+++ b/src/helpers/Environment.ts
@@ -106,7 +106,8 @@ export class EnvHelper {
   static getGeoapifyAPIKey() {
     var apiKey = EnvHelper.env.REACT_APP_GEOAPIFY_API_KEY;
     if (!apiKey) {
-      throw "Missing REACT_APP_GEOAPIFY_API_KEY environment variable";
+      console.warn("Missing REACT_APP_GEOAPIFY_API_KEY environment variable");
+      return null;
     }
   }
 }

--- a/src/helpers/userAnalyticHelpers.js
+++ b/src/helpers/userAnalyticHelpers.js
@@ -1,11 +1,16 @@
 import { EnvHelper } from "./Environment";
 import { retrieveUTMQueryParameters } from "./QueryParameterHelper";
 
-// Obtain country from IP address
+/**
+ * Obtain country from IP address
+ * @returns the country name or an empty string
+ */
 function countryLookup() {
   // Determine the country the user is from, based on IP
   // Geoapify offers 3000 lookups/day, so we should be fine
   var apiKey = EnvHelper.getGeoapifyAPIKey();
+
+  if (!apiKey) return "";
 
   fetch("https://api.geoapify.com/v1/ipinfo?apiKey=" + apiKey, {
     method: "GET",
@@ -21,9 +26,9 @@ function countryLookup() {
       return json.country.name;
     })
     .catch(function (error) {
-      console.log(error);
+      console.error(error);
       // Set the country to a default value
-      return "Unknown";
+      return "";
     });
 }
 

--- a/src/helpers/userAnalyticHelpers.js
+++ b/src/helpers/userAnalyticHelpers.js
@@ -1,7 +1,41 @@
+// Obtain country from IP address
+export function countryLookup() {
+  // Determine the country the user is from, based on IP
+  // Geoapify offers 3000 lookups/day, so we should be fine
+  var apiKey = process.env.REACT_APP_GEOAPIFY_API_KEY;
+  if (!apiKey) {
+    throw "Missing REACT_APP_GEOAPIFY_API_KEY environment variable";
+  }
+
+  fetch("https://api.geoapify.com/v1/ipinfo?apiKey=" + apiKey, {
+    method: "GET",
+  })
+    .then(function (response) {
+      if (response.ok) {
+        return response.json();
+      } else {
+        throw "Unable to determine country from IP lookup: " + response.body;
+      }
+    })
+    .then(function (json) {
+      return json.country.name;
+    })
+    .catch(function (error) {
+      console.log(error);
+      // Set the country to a default value
+      return "Unknown";
+    });
+}
+
 // Pushing data to segment analytics
 export function segmentUA(data) {
   const stringifiedData = JSON.stringify(data);
   var analytics = (window.analytics = window.analytics);
+
+  // We don't record the IP for privacy reasons, so we capture the country instead
+  var country = countryLookup();
+  data.country = country;
+
   // NOTE (appleseed): the analytics object may not exist (if there is no SEGMENT_API_KEY)
   if (analytics) {
     analytics.track(

--- a/src/helpers/userAnalyticHelpers.js
+++ b/src/helpers/userAnalyticHelpers.js
@@ -1,5 +1,5 @@
 // Obtain country from IP address
-export function countryLookup() {
+function countryLookup() {
   // Determine the country the user is from, based on IP
   // Geoapify offers 3000 lookups/day, so we should be fine
   var apiKey = process.env.REACT_APP_GEOAPIFY_API_KEY;

--- a/src/helpers/userAnalyticHelpers.js
+++ b/src/helpers/userAnalyticHelpers.js
@@ -1,11 +1,10 @@
+import { EnvHelper } from "./Environment";
+
 // Obtain country from IP address
 function countryLookup() {
   // Determine the country the user is from, based on IP
   // Geoapify offers 3000 lookups/day, so we should be fine
-  var apiKey = process.env.REACT_APP_GEOAPIFY_API_KEY;
-  if (!apiKey) {
-    throw "Missing REACT_APP_GEOAPIFY_API_KEY environment variable";
-  }
+  var apiKey = EnvHelper.getGeoapifyAPIKey();
 
   fetch("https://api.geoapify.com/v1/ipinfo?apiKey=" + apiKey, {
     method: "GET",

--- a/src/helpers/userAnalyticHelpers.js
+++ b/src/helpers/userAnalyticHelpers.js
@@ -5,14 +5,14 @@ import { retrieveUTMQueryParameters } from "./QueryParameterHelper";
  * Obtain country from IP address
  * @returns the country name or an empty string
  */
-function countryLookup() {
+export function countryLookup() {
   // Determine the country the user is from, based on IP
   // Geoapify offers 3000 lookups/day, so we should be fine
   var apiKey = EnvHelper.getGeoapifyAPIKey();
 
   if (!apiKey) return "";
 
-  fetch("https://api.geoapify.com/v1/ipinfo?apiKey=" + apiKey, {
+  var country = fetch("https://api.geoapify.com/v1/ipinfo?apiKey=" + apiKey, {
     method: "GET",
   })
     .then(function (response) {
@@ -30,6 +30,8 @@ function countryLookup() {
       // Set the country to a default value
       return "";
     });
+
+  return country;
 }
 
 // Pushing data to segment analytics

--- a/src/helpers/userAnalyticHelpers.js
+++ b/src/helpers/userAnalyticHelpers.js
@@ -5,33 +5,24 @@ import { retrieveUTMQueryParameters } from "./QueryParameterHelper";
  * Obtain country from IP address
  * @returns the country name or an empty string
  */
-export function countryLookup() {
+async function countryLookup() {
   // Determine the country the user is from, based on IP
   // Geoapify offers 3000 lookups/day, so we should be fine
   var apiKey = EnvHelper.getGeoapifyAPIKey();
 
   if (!apiKey) return "";
 
-  var country = fetch("https://api.geoapify.com/v1/ipinfo?apiKey=" + apiKey, {
+  var response = await fetch("https://api.geoapify.com/v1/ipinfo?apiKey=" + apiKey, {
     method: "GET",
-  })
-    .then(function (response) {
-      if (response.ok) {
-        return response.json();
-      } else {
-        throw "Unable to determine country from IP lookup: " + response.body;
-      }
-    })
-    .then(function (json) {
-      return json.country.name;
-    })
-    .catch(function (error) {
-      console.error(error);
-      // Set the country to a default value
-      return "";
-    });
+  });
 
-  return country;
+  if (!response.ok) {
+    console.error("Unable to determine country from IP lookup: " + response.body);
+    return "";
+  }
+
+  var json = await response.json();
+  return json.country.name;
 }
 
 // Pushing data to segment analytics
@@ -40,8 +31,7 @@ export function segmentUA(data) {
   var analytics = (window.analytics = window.analytics);
 
   // We don't record the IP for privacy reasons, so we capture the country instead
-  var country = countryLookup();
-  data.country = country;
+  countryLookup().then(country => (data.country = country));
 
   // Ensure that any UTM query parameters are sent along to Segment
   // var queryParameters = retrieveUTMQueryParameters();


### PR DESCRIPTION
This PR does a lookup on the user IP, extracts the country from the response and passes that into Segment. This is being done as we are not storing the user IP in the Segment event data, but we want some insights into user location.

This uses the Geoapify service, which provides 3000 requests/day for free. Please contact me on Discord for the API key.