### PR TITLE
Capture UTM parameters for Segment events

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "node-watch": "^0.7.1",
     "postcss": "^8.3.5",
     "qrcode.react": "^1.0.0",
+    "query-string": "7.0.1",
     "react": "^16.14.0",
     "react-blockies": "^1.4.1",
     "react-css-theme-switcher": "^0.2.2",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import useBonds from "./hooks/Bonds";
 import { useAddress, useWeb3Context } from "./hooks/web3Context";
 import useGoogleAnalytics from "./hooks/useGoogleAnalytics";
 import useSegmentAnalytics from "./hooks/useSegmentAnalytics";
+import { storeQueryParameters } from "./helpers/QueryParameterHelper";
 
 import { calcBondDetails } from "./slices/BondSlice";
 import { loadAppDetails } from "./slices/AppSlice";
@@ -148,6 +149,9 @@ function App() {
       // then user DOES NOT have a wallet
       setWalletChecked(true);
     }
+
+    // We want to ensure that we are storing the UTM parameters for later, even if the user follows links
+    storeQueryParameters();
   }, []);
 
   // this useEffect fires on state change from above. It will ALWAYS fire AFTER

--- a/src/helpers/QueryParameterHelper.ts
+++ b/src/helpers/QueryParameterHelper.ts
@@ -1,0 +1,76 @@
+import queryString from "query-string";
+
+const sessionStorageKey = "query";
+
+/**
+ * Stores the URL query parameters in session storage as a string.
+ *
+ * If the query parameters cannot be retrieved or parsed,
+ * the session storage will be cleared.
+ */
+export function storeQueryParameters() {
+  // We use session storage as it will be cleared when the tab is closed. The data is not needed any longer than that.
+  if (!window.sessionStorage) {
+    console.warn("Could not find session storage.");
+    return;
+  }
+
+  // window.location.search is supposed to be what contains the query parameters
+  // however it was not returning anything
+  // so we use href instead: https://app.olympusdao.finance/#/stake?utm_campaign=foo
+  if (!window.location || !window.location.href) {
+    console.warn("Unable to access window.location");
+    window.sessionStorage.removeItem(sessionStorageKey);
+    return;
+  }
+
+  // If we can't fetch the parameters, it's possible that:
+  // 1. There were no parameters to begin with
+  // 2. There were parameters, but a link was clicked and there parameters are no longer present
+  //
+  // Either way, we would have already captured any parameters that were present upon initial page load, and they have been saved.
+  var hrefParameters = window.location.href.split("?");
+  if (!hrefParameters || hrefParameters.length != 2) {
+    console.info("Unable to find query parameters");
+    return;
+  }
+
+  var parsedParameters = queryString.parse(hrefParameters.pop() || "");
+
+  window.sessionStorage.setItem(sessionStorageKey, queryString.stringify(parsedParameters));
+  console.debug("Stored query parameters in session storage: " + queryString.stringify(parsedParameters));
+}
+
+/**
+ * Fetches the query parameters from session storage
+ *
+ * @returns dictionary containing the query parameters
+ */
+export function retrieveQueryParameters() {
+  if (!window.sessionStorage) {
+    console.warn("Could not find session storage.");
+    return {};
+  }
+
+  var parsedParameters: queryString.ParsedQuery = queryString.parse(
+    window.sessionStorage.getItem(sessionStorageKey) || "",
+  );
+  console.debug("Retrieved query parameters from session storage: " + parsedParameters);
+
+  return parsedParameters;
+}
+
+export function retrieveUTMQueryParameters() {
+  var queryParameters: queryString.ParsedQuery = retrieveQueryParameters();
+
+  // Return only parameters with a "utm_" prefix
+  var filteredQueryParameters: queryString.ParsedQuery = {};
+  for (let key in queryParameters) {
+    if (key.indexOf("utm_") == -1) continue;
+
+    filteredQueryParameters[key] = queryParameters[key];
+  }
+
+  console.debug("Filtered query parameters for UTM prefix: " + filteredQueryParameters);
+  return filteredQueryParameters;
+}

--- a/src/helpers/userAnalyticHelpers.js
+++ b/src/helpers/userAnalyticHelpers.js
@@ -1,13 +1,20 @@
+import { retrieveUTMQueryParameters } from "./QueryParameterHelper";
+
 // Pushing data to segment analytics
 export function segmentUA(data) {
   const stringifiedData = JSON.stringify(data);
   var analytics = (window.analytics = window.analytics);
+
+  // Ensure that any UTM query parameters are sent along to Segment
+  var queryParameters = retrieveUTMQueryParameters();
+  var combinedData = Object.assign({}, data, queryParameters);
+
   // NOTE (appleseed): the analytics object may not exist (if there is no SEGMENT_API_KEY)
   if (analytics) {
     analytics.track(
       data.type,
       {
-        data,
+        combinedData,
       },
       { context: { ip: "0.0.0.0" } },
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -7562,6 +7562,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
+
 finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
@@ -9225,20 +9230,6 @@ is-color-stop@^1.0.0:
     rgba-regex "^1.0.0"
 
 is-core-module@^2.0.0, is-core-module@^2.2.0, is-core-module@^2.5.0, is-core-module@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.6.0.tgz#d7553b2526fe59b92ba3e40c8df757ec8a709e19"
-  integrity sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==
-  dependencies:
-    has "^1.0.3"
-
-is-core-module@^2.5.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.6.0.tgz#d7553b2526fe59b92ba3e40c8df757ec8a709e19"
-  integrity sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==
-  dependencies:
-    has "^1.0.3"
-
-is-core-module@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.6.0.tgz#d7553b2526fe59b92ba3e40c8df757ec8a709e19"
   integrity sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==
@@ -13515,6 +13506,16 @@ query-string@6.13.5:
   integrity sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==
   dependencies:
     decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
+query-string@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.0.1.tgz#45bd149cf586aaa582dffc7ec7a8ad97dd02f75d"
+  integrity sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 


### PR DESCRIPTION
We use the sessionStorage (not localStorage) to capture the parameters upon page load. When a user event is triggered for recording by Segment, the parameters are retrieved, filtered ("utm_" prefix) and included in the Segment data. This will enable tracking of campaign conversions.

Note: PR#503 is also pending, and will conflict with this. Once that is approved, I'll merge it into this.