### PR TITLE
BugFix: remove `retrieveQueryParameters` from userAnalyticHelpers (#512)

### DIFF
--- a/src/helpers/userAnalyticHelpers.js
+++ b/src/helpers/userAnalyticHelpers.js
@@ -6,11 +6,12 @@ export function segmentUA(data) {
   var analytics = (window.analytics = window.analytics);
 
   // Ensure that any UTM query parameters are sent along to Segment
-  var queryParameters = retrieveUTMQueryParameters();
-  var combinedData = Object.assign({}, data, queryParameters);
+  // var queryParameters = retrieveUTMQueryParameters();
+  // var combinedData = Object.assign({}, data, queryParameters);
+  var combinedData = stringifiedData;
 
   // NOTE (appleseed): the analytics object may not exist (if there is no SEGMENT_API_KEY)
-  if (analytics) {
+  try {
     analytics.track(
       data.type,
       {
@@ -18,5 +19,7 @@ export function segmentUA(data) {
       },
       { context: { ip: "0.0.0.0" } },
     );
+  } catch (e) {
+    console.log("segmentAnalytics", e);
   }
 }


### PR DESCRIPTION
UTM params will not be picked up by segment for now.