### PR TITLE
Fix hanging when fetching UTM parameters on Brave

### DIFF
--- a/src/helpers/QueryParameterHelper.ts
+++ b/src/helpers/QueryParameterHelper.ts
@@ -52,11 +52,10 @@ export function retrieveQueryParameters() {
     return {};
   }
 
-  // TODO (appleseed & Jem): I think the issue is here
   var parsedParameters: queryString.ParsedQuery = queryString.parse(
     window.sessionStorage.getItem(sessionStorageKey) || "",
   );
-  console.debug("Retrieved query parameters from session storage: " + parsedParameters);
+  console.debug("Retrieved query parameters from session storage: " + JSON.stringify(parsedParameters));
 
   return parsedParameters;
 }
@@ -72,6 +71,6 @@ export function retrieveUTMQueryParameters() {
     filteredQueryParameters[key] = queryParameters[key];
   }
 
-  console.debug("Filtered query parameters for UTM prefix: " + filteredQueryParameters);
+  console.debug("Filtered query parameters for UTM prefix: " + JSON.stringify(filteredQueryParameters));
   return filteredQueryParameters;
 }

--- a/src/helpers/userAnalyticHelpers.js
+++ b/src/helpers/userAnalyticHelpers.js
@@ -2,13 +2,10 @@ import { retrieveUTMQueryParameters } from "./QueryParameterHelper";
 
 // Pushing data to segment analytics
 export function segmentUA(data) {
-  const stringifiedData = JSON.stringify(data);
   var analytics = (window.analytics = window.analytics);
 
   // Ensure that any UTM query parameters are sent along to Segment
-  console.log("before queryParameters");
   var queryParameters = retrieveUTMQueryParameters();
-  console.log("afterQueryParameters");
   var combinedData = Object.assign({}, data, queryParameters);
 
   // NOTE (appleseed): the analytics object may not exist (if there is no SEGMENT_API_KEY)

--- a/src/slices/StakeThunk.ts
+++ b/src/slices/StakeThunk.ts
@@ -134,10 +134,7 @@ export const changeStake = createAsyncThunk(
       return;
     } finally {
       if (stakeTx) {
-        // TODO (appleseed & Jem): remove these console logs when done debugging.
-        console.log("before Segment");
         segmentUA(uaData);
-        console.log("after Segment");
 
         dispatch(clearPendingTxn(stakeTx.hash));
       }


### PR DESCRIPTION
The hanging was caused by a JS exception due to a debug log containing an object that could not be cast to a string.