### PR TITLE
handle Alchemy 403s && rework NodeHelper to test each node on every a…

### DIFF
--- a/src/helpers/NodeHelper.ts
+++ b/src/helpers/NodeHelper.ts
@@ -20,6 +20,12 @@ interface IInvalidNode {
  */
 export class NodeHelper {
   static _invalidNodesKey = "invalidNodes";
+  static _maxFailedConnections = 2;
+  /**
+   * failedConnectionsMinuteLimit is the number of minutes that _maxFailedConnections must occur within
+   * for the node to be blocked.
+   */
+  static _failedConnectionsMinutesLimit = 15;
 
   // use sessionStorage so that we don't have to worry about resetting the invalidNodes list
   static _storage = window.sessionStorage;
@@ -38,7 +44,10 @@ export class NodeHelper {
   static _updateConnectionStatsForProvider(currentStats: ICurrentStats) {
     const failedAt = new Date().getTime();
     const failedConnectionCount = currentStats.failedConnectionCount || 0;
-    if (failedConnectionCount > 0 && currentStats.lastFailedConnectionAt > minutesAgo(15)) {
+    if (
+      failedConnectionCount > 0 &&
+      currentStats.lastFailedConnectionAt > minutesAgo(NodeHelper._failedConnectionsMinutesLimit)
+    ) {
       // more than 0 failed connections in the last (15) minutes
       currentStats = {
         lastFailedConnectionAt: failedAt,
@@ -74,17 +83,16 @@ export class NodeHelper {
 
   /**
    * adds a bad connection stat to NodeHelper._storage for a given node
-   * if greater than 3 previous failures in last 15 minutes will remove node from list
+   * if greater than `_maxFailedConnections` previous failures in last `_failedConnectionsMinuteLimit` minutes will remove node from list
    * @param provider an Ethers provider
    */
-  static logBadConnectionWithTimer(provider: StaticJsonRpcProvider) {
-    const providerUrl: string = provider.connection.url;
+  static logBadConnectionWithTimer(providerUrl: string) {
     const providerKey: string = "-nodeHelper:" + providerUrl;
 
     let currentConnectionStats = JSON.parse(NodeHelper._storage.getItem(providerKey) || "{}");
     currentConnectionStats = NodeHelper._updateConnectionStatsForProvider(currentConnectionStats);
 
-    if (currentConnectionStats.failedConnectionCount > 3) {
+    if (currentConnectionStats.failedConnectionCount > NodeHelper._maxFailedConnections) {
       // then remove this node from our provider list for 24 hours
       NodeHelper._removeNodeFromProviders(providerKey, providerUrl);
     } else {
@@ -94,14 +102,13 @@ export class NodeHelper {
 
   /**
    * returns Array of APIURIs where NOT on invalidNodes list
-   * also removes nodes that have been invalid for > 24 hours
    */
   static getNodesUris = () => {
     let allURIs = EnvHelper.getAPIUris();
     let invalidNodes = NodeHelper.currentRemovedNodesURIs;
-
-    // iterate through invalid & remove each from allURIs.
-    invalidNodes.forEach(URI => allURIs.splice(allURIs.indexOf(URI), 1));
+    // filter invalidNodes out of allURIs
+    // this allows duplicates in allURIs, removes both if invalid, & allows both if valid
+    allURIs = allURIs.filter(item => !invalidNodes.includes(item));
 
     // return the remaining elements
     if (allURIs.length === 0) {
@@ -109,5 +116,60 @@ export class NodeHelper {
       allURIs = EnvHelper.getAPIUris();
     }
     return allURIs;
+  };
+
+  /**
+   * iterate through all the nodes we have with a chainId check.
+   * - log the failing nodes
+   * - 3 fails in < 15 minutes sends the node to the invalidNodes list
+   * returns an Array of working mainnet nodes
+   */
+  static checkAllNodesStatus = async () => {
+    let workingURI: string = "none";
+    var promises: any[] = [];
+    NodeHelper.getNodesUris().forEach(URI => {
+      promises.push(
+        NodeHelper.checkNodeStatus(URI).then(live => {
+          if (live) return (workingURI = URI);
+        }),
+      );
+    });
+    return Promise.all(promises);
+  };
+
+  /**
+   * 403 errors are not caught by fetch so we check response.status, too
+   */
+  static checkNodeStatus = async (url: string) => {
+    let liveStatus = true;
+    await fetch(url, {
+      method: "POST",
+      mode: "cors",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      // NOTE (appleseed): are there other basic requests for other chain types (Arbitrum)???
+      // https://documenter.getpostman.com/view/4117254/ethereum-json-rpc/RVu7CT5J
+      // chainId works... but is net_version lighter-weight?
+      // body: JSON.stringify({ method: "eth_chainId", params: [], id: 42, jsonrpc: "2.0" }),
+      body: JSON.stringify({ method: "net_version", params: [], id: 67, jsonrpc: "2.0" }),
+    })
+      .then(resp => {
+        if (resp.status >= 400) {
+          // probably 403 or 429 -> no more alchemy capacity
+          NodeHelper.logBadConnectionWithTimer(resp.url);
+          liveStatus = false;
+        } else {
+          // this is a working node, prioritize it
+          console.log("working node", url);
+          liveStatus = true;
+        }
+      })
+      .catch(e => {
+        // some other type of issue
+        NodeHelper.logBadConnectionWithTimer(url);
+        liveStatus = false;
+      });
+    return liveStatus;
   };
 }

--- a/src/helpers/index.tsx
+++ b/src/helpers/index.tsx
@@ -16,12 +16,7 @@ import { NodeHelper } from "./NodeHelper";
 export async function getMarketPrice({ networkID, provider }: { networkID: number; provider: StaticJsonRpcProvider }) {
   const ohm_dai_address = ohm_dai.getAddressForReserve(networkID);
   const pairContract = new ethers.Contract(ohm_dai_address, PairContract, provider);
-  let reserves;
-  try {
-    reserves = await pairContract.getReserves();
-  } catch (e) {
-    NodeHelper.logBadConnectionWithTimer(provider);
-  }
+  const reserves = await pairContract.getReserves();
   const marketPrice = reserves[1] / reserves[0];
 
   // commit('set', { marketPrice: marketPrice / Math.pow(10, 9) });

--- a/src/hooks/web3Context.tsx
+++ b/src/hooks/web3Context.tsx
@@ -185,7 +185,7 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
   );
 
   useEffect(() => {
-    // returns an array of working mainnet nodes, could be used to optimize connection
+    // logs non-functioning nodes && returns an array of working mainnet nodes, could be used to optimize connection
     NodeHelper.checkAllNodesStatus();
   }, []);
 

--- a/src/hooks/web3Context.tsx
+++ b/src/hooks/web3Context.tsx
@@ -151,15 +151,8 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
 
     const connectedProvider = new Web3Provider(rawProvider, "any");
 
-    let chainId;
-    let connectedAddress;
-    try {
-      chainId = await connectedProvider.getNetwork().then(network => network.chainId);
-      connectedAddress = await connectedProvider.getSigner().getAddress();
-    } catch (e) {
-      NodeHelper.logBadConnectionWithTimer(connectedProvider);
-      return;
-    }
+    const chainId = await connectedProvider.getNetwork().then(network => network.chainId);
+    const connectedAddress = await connectedProvider.getSigner().getAddress();
     const validNetwork = _checkNetwork(chainId);
     if (!validNetwork) {
       console.error("Wrong network, please switch to mainnet");
@@ -190,6 +183,11 @@ export const Web3ContextProvider: React.FC<{ children: ReactElement }> = ({ chil
     () => ({ connect, disconnect, hasCachedProvider, provider, connected, address, chainID, web3Modal }),
     [connect, disconnect, hasCachedProvider, provider, connected, address, chainID, web3Modal],
   );
+
+  useEffect(() => {
+    // returns an array of working mainnet nodes, could be used to optimize connection
+    NodeHelper.checkAllNodesStatus();
+  }, []);
 
   return <Web3Context.Provider value={{ onChainProvider }}>{children}</Web3Context.Provider>;
 };

--- a/src/slices/AppSlice.ts
+++ b/src/slices/AppSlice.ts
@@ -77,13 +77,7 @@ export const loadAppDetails = createAsyncThunk(
         totalSupply,
       };
     }
-    let currentBlock: number;
-    try {
-      currentBlock = await provider.getBlockNumber();
-    } catch (e) {
-      NodeHelper.logBadConnectionWithTimer(provider);
-      currentBlock = 0;
-    }
+    const currentBlock = await provider.getBlockNumber();
 
     const stakingContract = new ethers.Contract(
       addresses[networkID].STAKING_ADDRESS as string,
@@ -181,11 +175,10 @@ const loadMarketPrice = createAsyncThunk(
   async ({ networkID, provider }: { networkID: number; provider: StaticJsonRpcProvider }) => {
     let marketPrice: number;
     try {
-      marketPrice = await getTokenPrice("olympus");
-    } catch (e) {
-      console.log("Returned a null response when querying CoinGecko");
       marketPrice = await getMarketPrice({ networkID, provider });
       marketPrice = marketPrice / Math.pow(10, 9);
+    } catch (e) {
+      marketPrice = await getTokenPrice("olympus");
     }
     return { marketPrice };
   },


### PR DESCRIPTION
…pp load.

Optimization:
1. this change allows us to remove `try/catch` from various API calls since we move all the status checking into `NodeHelper.checkAllNodesStatus`

Also:
1. a future iteration of this could test each node & return the first successful one to web3Context so that we NEVER load unsuccessfully (unless all nodes are down)
2. item 1's future handling will require modifications to web3Context so it's postponed for now