### PR TITLE
overflow fix by storing bond.balance as string

### DIFF
--- a/src/slices/AccountSlice.ts
+++ b/src/slices/AccountSlice.ts
@@ -180,7 +180,7 @@ export const calculateUserBondDetails = createAsyncThunk(
         bondIconSvg: "",
         isLP: false,
         allowance: 0,
-        balance: 0,
+        balance: "0",
         interestDue: 0,
         bondMaturationBlock: 0,
         pendingPayout: "",
@@ -203,15 +203,16 @@ export const calculateUserBondDetails = createAsyncThunk(
       balance = 0;
     allowance = await reserveContract.allowance(address, bond.getAddressForBond(networkID));
     balance = await reserveContract.balanceOf(address);
+    // formatEthers takes BigNumber => String
     const balanceVal = ethers.utils.formatEther(balance);
-
+    // balanceVal should NOT be converted to a number. it loses decimal precision
     return {
       bond: bond.name,
       displayName: bond.displayName,
       bondIconSvg: bond.bondIconSvg,
       isLP: bond.isLP,
       allowance: Number(allowance),
-      balance: Number(balanceVal),
+      balance: balanceVal,
       interestDue,
       bondMaturationBlock,
       pendingPayout: ethers.utils.formatUnits(pendingPayout, "gwei"),

--- a/src/slices/BondSlice.ts
+++ b/src/slices/BondSlice.ts
@@ -173,8 +173,8 @@ export const bondAsset = createAsyncThunk(
   async ({ value, address, bond, networkID, provider, slippage }: IBondAsset, { dispatch }) => {
     const depositorAddress = address;
     const acceptedSlippage = slippage / 100 || 0.005; // 0.5% as default
+    // parseUnits takes String => BigNumber
     const valueInWei = ethers.utils.parseUnits(value.toString(), "ether");
-
     let balance;
     // Calculate maxPremium based on premium and slippage.
     // const calculatePremium = await bonding.calculatePremium();

--- a/src/views/33Together/33Together.jsx
+++ b/src/views/33Together/33Together.jsx
@@ -53,11 +53,11 @@ const PoolTogether = () => {
   const isAccountLoading = useSelector(state => state.account.loading ?? true);
 
   const sohmBalance = useSelector(state => {
-    return state.account.balances && parseFloat(state.account.balances.sohm);
+    return state.account.balances && state.account.balances.sohm;
   });
 
   const poolBalance = useSelector(state => {
-    return state.account.balances && parseFloat(state.account.balances.pool);
+    return state.account.balances && state.account.balances.pool;
   });
 
   // query correct pool subgraph depending on current chain

--- a/src/views/Bond/BondPurchase.jsx
+++ b/src/views/Bond/BondPurchase.jsx
@@ -87,7 +87,14 @@ function BondPurchase({ bond, slippage, recipientAddress }) {
   }, [bond.allowance]);
 
   const setMax = () => {
-    setQuantity((Math.min(bond.maxBondPrice * bond.bondPrice, bond.balance) || "").toString());
+    let maxQ;
+    if (bond.maxBondPrice * bond.bondPrice < Number(bond.balance)) {
+      // there is precision loss here on Number(bond.balance)
+      maxQ = bond.maxBondPrice * bond.bondPrice.toString();
+    } else {
+      maxQ = bond.balance;
+    }
+    setQuantity(maxQ);
   };
 
   const bondDetailsDebounce = useDebounce(quantity, 1000);


### PR DESCRIPTION
fixes issue where the `ethers` balance of a bond loses decimal precision when converted to a Javascript number, which allowed the possibility of passing a larger balance to the `bond` transaction than what was in your wallet.

and hopefully this is the root cause of:
![image](https://user-images.githubusercontent.com/80423742/137012322-f666ea22-0a02-41ed-9c4d-097de4fc5308.png)

example of decimal precision issue: 
1. Ethers returns that value as a Big Number. 
2. Then we parse it to a string (via ethers.utils.formatEther). 
3. Then we convert it to a Javascript number... however. Javascript Numbers don't have the same decimal precision as your wallet, so we lose decimal precision when converting between data types.

```javascript
let ethersParsedBN = "3001.933698344547875331";
let toNumber = Number(ethersParsedBN);
// toNumber = 3001.933698344548
let valueCheck = ethersParsedBN === toNumber.toString();
console.log(valueCheck); // => false
```

the above bug is resolved if you never convert `ethersParsedBN` to a javascript `Number`.