### PR TITLE
implement fallback only api keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,16 +5,20 @@
 # the only side effect may be some latency
 #
 
-# add your INFURA ID
-# - multiple IDS should be separated by whitespace
-# - you can pick up INFURA_IDS at https://infura.io/
-REACT_APP_INFURA_IDS=""
-
 # add your ALCHEMY API KEY
 # - multiple IDS should be separated by whitespace
 # - in development environment app will run without an ALCHEMY API KEY
 # - you can pick up Alchemy API Keys at https://auth.alchemyapi.io/
 REACT_APP_ALCHEMY_IDS=""
+
+# Alchemy fallback ids will run if the main ids & nodes are all failing
+REACT_APP_ALCHEMY_FALLBACK_IDS=""
+
+# add your INFURA ID
+# - Infura IDs are only used as fallbacks (in conjunction with ALCHEMY_FALLBACK_IDS)
+# - multiple IDS should be separated by whitespace
+# - you can pick up INFURA_IDS at https://infura.io/
+REACT_APP_INFURA_IDS=""
 
 # add a TESTNET ALCHEMY API KEY
 # - NOTE: does NOT allow multiple keys

--- a/.env.example
+++ b/.env.example
@@ -6,16 +6,14 @@
 #
 
 # add your ALCHEMY API KEY
+# - Alchemy IDs are only used as fallbacks (in conjunction with INFURA_IDS)
 # - multiple IDS should be separated by whitespace
 # - in development environment app will run without an ALCHEMY API KEY
 # - you can pick up Alchemy API Keys at https://auth.alchemyapi.io/
 REACT_APP_ALCHEMY_IDS=""
 
-# Alchemy fallback ids will run if the main ids & nodes are all failing
-REACT_APP_ALCHEMY_FALLBACK_IDS=""
-
 # add your INFURA ID
-# - Infura IDs are only used as fallbacks (in conjunction with ALCHEMY_FALLBACK_IDS)
+# - Infura IDs are only used as fallbacks (in conjunction with ALCHEMY_IDS)
 # - multiple IDS should be separated by whitespace
 # - you can pick up INFURA_IDS at https://infura.io/
 REACT_APP_INFURA_IDS=""

--- a/src/helpers/Environment.ts
+++ b/src/helpers/Environment.ts
@@ -38,31 +38,6 @@ export class EnvHelper {
     // split the provided API keys on whitespace
     if (EnvHelper.env.REACT_APP_ALCHEMY_IDS && EnvHelper.isNotEmpty(EnvHelper.env.REACT_APP_ALCHEMY_IDS)) {
       ALCHEMY_ID_LIST = EnvHelper.env.REACT_APP_ALCHEMY_IDS.split(EnvHelper.whitespaceRegex);
-    } else if (EnvHelper.env.NODE_ENV === "development") {
-      // this is the ethers common API key, suitable for testing, not prod
-      ALCHEMY_ID_LIST = ["_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC"];
-    } else {
-      ALCHEMY_ID_LIST = [];
-    }
-
-    // now add the uri path
-    if (ALCHEMY_ID_LIST.length > 0) {
-      ALCHEMY_ID_LIST = ALCHEMY_ID_LIST.map(alchemyID => `https://eth-mainnet.alchemyapi.io/v2/${alchemyID}`);
-    } else {
-      ALCHEMY_ID_LIST = [];
-    }
-    return ALCHEMY_ID_LIST;
-  }
-
-  static getAlchemyFallbackURIs() {
-    let ALCHEMY_ID_LIST: string[];
-
-    // split the provided API keys on whitespace
-    if (
-      EnvHelper.env.REACT_APP_ALCHEMY_FALLBACK_IDS &&
-      EnvHelper.isNotEmpty(EnvHelper.env.REACT_APP_ALCHEMY_FALLBACK_IDS)
-    ) {
-      ALCHEMY_ID_LIST = EnvHelper.env.REACT_APP_ALCHEMY_FALLBACK_IDS.split(EnvHelper.whitespaceRegex);
     } else {
       ALCHEMY_ID_LIST = [];
     }
@@ -121,13 +96,17 @@ export class EnvHelper {
    * @returns array of API urls
    */
   static getAPIUris() {
-    const ALL_URIs = [...EnvHelper.getAlchemyAPIKeyList(), ...EnvHelper.getSelfHostedNode()];
+    let ALL_URIs = EnvHelper.getSelfHostedNode();
+    if (EnvHelper.env.NODE_ENV === "development" && ALL_URIs.length === 0) {
+      // push in the common ethers key in development
+      ALL_URIs.push("https://eth-mainnet.alchemyapi.io/v2/_gg7wSSi0KMBsdKnGVfHDueq6xMB9EkC");
+    }
     if (ALL_URIs.length === 0) console.error("API keys must be set in the .env");
     return ALL_URIs;
   }
 
   static getFallbackURIs() {
-    const ALL_URIs = [...EnvHelper.getAlchemyFallbackURIs(), ...EnvHelper.getInfuraIdList()];
+    const ALL_URIs = [...EnvHelper.getAlchemyAPIKeyList(), ...EnvHelper.getInfuraIdList()];
     return ALL_URIs;
   }
 

--- a/src/helpers/Environment.ts
+++ b/src/helpers/Environment.ts
@@ -54,8 +54,30 @@ export class EnvHelper {
     return ALCHEMY_ID_LIST;
   }
 
+  static getAlchemyFallbackURIs() {
+    let ALCHEMY_ID_LIST: string[];
+
+    // split the provided API keys on whitespace
+    if (
+      EnvHelper.env.REACT_APP_ALCHEMY_FALLBACK_IDS &&
+      EnvHelper.isNotEmpty(EnvHelper.env.REACT_APP_ALCHEMY_FALLBACK_IDS)
+    ) {
+      ALCHEMY_ID_LIST = EnvHelper.env.REACT_APP_ALCHEMY_FALLBACK_IDS.split(EnvHelper.whitespaceRegex);
+    } else {
+      ALCHEMY_ID_LIST = [];
+    }
+
+    // now add the uri path
+    if (ALCHEMY_ID_LIST.length > 0) {
+      ALCHEMY_ID_LIST = ALCHEMY_ID_LIST.map(alchemyID => `https://eth-mainnet.alchemyapi.io/v2/${alchemyID}`);
+    } else {
+      ALCHEMY_ID_LIST = [];
+    }
+    return ALCHEMY_ID_LIST;
+  }
+
   /**
-   * NOTE(zx): Want to move away from infura. Will probably remove these.
+   * NOTE(appleseed): Infura IDs are only used as Fallbacks & are not Mandatory
    * @returns {Array} Array of Infura API Ids
    */
   static getInfuraIdList() {
@@ -99,10 +121,13 @@ export class EnvHelper {
    * @returns array of API urls
    */
   static getAPIUris() {
-    // Debug log
-    // console.log("uris", EnvHelper.getAlchemyAPIKeyList(), EnvHelper.getSelfHostedSockets());
     const ALL_URIs = [...EnvHelper.getAlchemyAPIKeyList(), ...EnvHelper.getSelfHostedNode()];
     if (ALL_URIs.length === 0) console.error("API keys must be set in the .env");
+    return ALL_URIs;
+  }
+
+  static getFallbackURIs() {
+    const ALL_URIs = [...EnvHelper.getAlchemyFallbackURIs(), ...EnvHelper.getInfuraIdList()];
     return ALL_URIs;
   }
 


### PR DESCRIPTION
Details:
1. if primary nodes are all down the fallbacks will take over
2. `NodeHelper.checkAllNodesStatus` will re-iterate the primary nodes on every new session
3. after two node failures in 15 minutes the fallback nodes will kick in
4. REACT_APP_SELF_HOSTED_NODE (space delimited) are the primaries
5. REACT_APP_INFURA_IDS & REACT_APP_ALCHEMY_IDS are used as the fallbacks