### PR TITLE
Added Backing per OHM to Dashboard metrics

### DIFF
--- a/src/slices/AppSlice.ts
+++ b/src/slices/AppSlice.ts
@@ -34,6 +34,7 @@ export const loadAppDetails = createAsyncThunk(
       ohmPrice
       marketCap
       totalValueLocked
+      treasuryMarketValue
       nextEpochRebase
       nextDistributedOhm
     }
@@ -65,6 +66,7 @@ export const loadAppDetails = createAsyncThunk(
     const marketCap = parseFloat(graphData.data.protocolMetrics[0].marketCap);
     const circSupply = parseFloat(graphData.data.protocolMetrics[0].ohmCirculatingSupply);
     const totalSupply = parseFloat(graphData.data.protocolMetrics[0].totalSupply);
+    const treasuryMarketValue = parseFloat(graphData.data.protocolMetrics[0].treasuryMarketValue);
     // const currentBlock = parseFloat(graphData.data._meta.block.number);
 
     if (!provider) {
@@ -75,6 +77,7 @@ export const loadAppDetails = createAsyncThunk(
         marketCap,
         circSupply,
         totalSupply,
+        treasuryMarketValue,
       };
     }
     const currentBlock = await provider.getBlockNumber();
@@ -114,6 +117,7 @@ export const loadAppDetails = createAsyncThunk(
       marketPrice,
       circSupply,
       totalSupply,
+      treasuryMarketValue,
     } as IAppData;
   },
 );
@@ -188,6 +192,7 @@ interface IAppData {
   readonly stakingTVL: number;
   readonly totalSupply: number;
   readonly treasuryBalance?: number;
+  readonly treasuryMarketValue?: number;
 }
 
 const appSlice = createSlice({

--- a/src/views/TreasuryDashboard/TreasuryDashboard.jsx
+++ b/src/views/TreasuryDashboard/TreasuryDashboard.jsx
@@ -42,6 +42,10 @@ function TreasuryDashboard() {
     return state.app.currentIndex;
   });
 
+  const backingPerOhm = useSelector(state => {
+    return state.app.treasuryMarketValue / state.app.circSupply;
+  });
+
   useEffect(() => {
     apollo(treasuryDataQuery).then(r => {
       let metrics = r.data.protocolMetrics.map(entry =>
@@ -108,6 +112,15 @@ function TreasuryDashboard() {
                   ) : (
                     <Skeleton type="text" />
                   )}
+                </Typography>
+              </Box>
+
+              <Box className="metric bpo">
+                <Typography variant="h6" color="textSecondary">
+                  Backing per OHM
+                </Typography>
+                <Typography variant="h4">
+                  {backingPerOhm ? formatCurrency(backingPerOhm, 2) : <Skeleton type="text" />}
                 </Typography>
               </Box>
 

--- a/src/views/TreasuryDashboard/treasury-dashboard.scss
+++ b/src/views/TreasuryDashboard/treasury-dashboard.scss
@@ -79,7 +79,8 @@
       width: 67% !important;
     }
     &.price,
-    &.index {
+    &.index,
+    &.bpo {
       width: 33% !important;
     }
   }


### PR DESCRIPTION
Per request of Zeus, I added a backing per ohm element to the Treasury Dashboard view. On mobile the various hero metrics now display 2, 2, 1 rather than a nice 2x2 grid. I can change them to be 1, 1, 1, 1, 1 but I thought this looked better.

Added treasuryMarketValue as one of the values outputted by AppSlice to make the code for setting backingPerOhm in TreasuryDashboard.jsx cleaner than building off of the Apollo query in the UseEffect hook and getting 100 elements when I only need one.