### PR TITLE
Added backing per ohm element to treasury dashboard

### DIFF
--- a/src/slices/AppSlice.ts
+++ b/src/slices/AppSlice.ts
@@ -34,6 +34,7 @@ export const loadAppDetails = createAsyncThunk(
       ohmPrice
       marketCap
       totalValueLocked
+      treasuryMarketValue
       nextEpochRebase
       nextDistributedOhm
     }
@@ -65,6 +66,7 @@ export const loadAppDetails = createAsyncThunk(
     const marketCap = parseFloat(graphData.data.protocolMetrics[0].marketCap);
     const circSupply = parseFloat(graphData.data.protocolMetrics[0].ohmCirculatingSupply);
     const totalSupply = parseFloat(graphData.data.protocolMetrics[0].totalSupply);
+    const treasuryMarketValue = parseFloat(graphData.data.protocolMetrics[0].treasuryMarketValue);
     // const currentBlock = parseFloat(graphData.data._meta.block.number);
 
     if (!provider) {
@@ -75,6 +77,7 @@ export const loadAppDetails = createAsyncThunk(
         marketCap,
         circSupply,
         totalSupply,
+        treasuryMarketValue,
       };
     }
     const currentBlock = await provider.getBlockNumber();
@@ -114,6 +117,7 @@ export const loadAppDetails = createAsyncThunk(
       marketPrice,
       circSupply,
       totalSupply,
+      treasuryMarketValue,
     } as IAppData;
   },
 );
@@ -185,6 +189,7 @@ interface IAppData {
   readonly stakingTVL: number;
   readonly totalSupply: number;
   readonly treasuryBalance?: number;
+  readonly treasuryMarketValue?: number;
 }
 
 const appSlice = createSlice({

--- a/src/views/TreasuryDashboard/TreasuryDashboard.jsx
+++ b/src/views/TreasuryDashboard/TreasuryDashboard.jsx
@@ -42,6 +42,10 @@ function TreasuryDashboard() {
     return state.app.currentIndex;
   });
 
+  const backingPerOhm = useSelector(state => {
+    return state.app.treasuryMarketValue / state.app.circSupply;
+  });
+
   useEffect(() => {
     apollo(treasuryDataQuery).then(r => {
       let metrics = r.data.protocolMetrics.map(entry =>
@@ -108,6 +112,15 @@ function TreasuryDashboard() {
                   ) : (
                     <Skeleton type="text" />
                   )}
+                </Typography>
+              </Box>
+
+              <Box className="metric bpo">
+                <Typography variant="h6" color="textSecondary">
+                  Backing per OHM
+                </Typography>
+                <Typography variant="h4">
+                  {backingPerOhm ? formatCurrency(backingPerOhm, 2) : <Skeleton type="text" />}
                 </Typography>
               </Box>
 

--- a/src/views/TreasuryDashboard/treasury-dashboard.scss
+++ b/src/views/TreasuryDashboard/treasury-dashboard.scss
@@ -79,7 +79,8 @@
       width: 67% !important;
     }
     &.price,
-    &.index {
+    &.index,
+    &.bpo {
       width: 33% !important;
     }
   }

--- a/src/views/TreasuryDashboard/treasury-dashboard.scss
+++ b/src/views/TreasuryDashboard/treasury-dashboard.scss
@@ -60,6 +60,8 @@
   }
   .hero-metrics .ohm-card {
     > .MuiBox-root {
+      flex-direction: column;
+      align-items: flex-start;
       flex-wrap: wrap;
     }
     div.metric {
@@ -74,14 +76,13 @@
     min-width: 30% !important;
     max-width: 60%;
     text-align: left !important;
-    &.circ,
-    &.market {
-      width: 67% !important;
-    }
+    &.market,
     &.price,
-    &.index,
-    &.bpo {
-      width: 33% !important;
+    &.circ,
+    &.bpo,
+    &.index {
+      flex-direction: column;
+      align-items: flex-start;
     }
   }
 }


### PR DESCRIPTION
Per request of Zeus, added backing per ohm to the treasury dashboard. Added treasuryMarketValue to the output of AppSlice so as to not have to call an additional 100 elements in the useEffect hook of treasuryDashboard when I only need the most current.