### PR TITLE
Fixed 33 together dashboard user odds display

### DIFF
--- a/src/views/33Together/PoolDeposit.jsx
+++ b/src/views/33Together/PoolDeposit.jsx
@@ -71,7 +71,12 @@ export const PoolDeposit = props => {
   }, [poolAllowance]);
 
   const setMax = () => {
-    setQuantity(sohmBalance);
+    const value = parseFloat(sohmBalance);
+    setQuantity(value);
+    let userBalanceAfterDeposit = poolBalance + value;
+
+    let userOdds = calculateOdds(userBalanceAfterDeposit, props.totalPoolDeposits + value, props.winners);
+    setNewOdds(trim(userOdds, 4));
   };
 
   const updateDepositQuantity = e => {


### PR DESCRIPTION
When selecting max quantity on the 33 together dashboard, the user odds would not update and the value being passed to setQuantity was a string. This pr fixes this.