### PR TITLE
cleanup errors for stake/unstake, also word-break long errors

### DIFF
--- a/src/components/Messages/Messages.jsx
+++ b/src/components/Messages/Messages.jsx
@@ -1,7 +1,7 @@
 import { useDispatch, useSelector } from "react-redux";
 import { close, handle_obsolete } from "../../slices/MessagesSlice";
 import store from "../../store";
-import Snackbar from "@material-ui/core/Snackbar";
+import { Typography, Snackbar } from "@material-ui/core";
 import Alert from "@material-ui/lab/Alert";
 import AlertTitle from "@material-ui/lab/AlertTitle";
 import "./ConsoleInterceptor.js";
@@ -22,7 +22,14 @@ function Messages() {
         {messages.items.map((message, index) => {
           return (
             <Snackbar open={message.open} key={index} anchorOrigin={{ vertical: "top", horizontal: "center" }}>
-              <Alert variant="filled" icon={false} severity={message.severity} onClose={handleClose(message)}>
+              <Alert
+                variant="filled"
+                icon={false}
+                severity={message.severity}
+                onClose={handleClose(message)}
+                // NOTE (appleseed): mui includes overflow-wrap: "break-word", but word-break: "break-word" is needed for webKit browsers
+                style={{ wordBreak: "break-word" }}
+              >
                 <AlertTitle>{message.title}</AlertTitle>
                 {message.text}
               </Alert>

--- a/src/views/Stake/Stake.jsx
+++ b/src/views/Stake/Stake.jsx
@@ -27,6 +27,7 @@ import { isPendingTxn, txnButtonText } from "src/slices/PendingTxnsSlice";
 import { Skeleton } from "@material-ui/lab";
 import ExternalStakePool from "./ExternalStakePool";
 import { error } from "../../slices/MessagesSlice";
+import { ethers } from "ethers";
 
 function a11yProps(index) {
   return {
@@ -109,6 +110,15 @@ function Stake() {
       // eslint-disable-next-line no-alert
       dispatch(error("Please enter a value!"));
     } else {
+      // 1st catch if quantity > balance
+      let gweiValue = ethers.utils.parseUnits(quantity, "gwei");
+      if (action === "stake" && gweiValue.gt(ethers.utils.parseUnits(ohmBalance, "gwei"))) {
+        console.log("in stake ok");
+        return dispatch(error("You cannot stake more than your OHM balance."));
+      } else if (action === "unstake" && gweiValue.gt(ethers.utils.parseUnits(sohmBalance, "gwei"))) {
+        return dispatch(error("You cannot unstake more than your sOHM balance."));
+      }
+
       await dispatch(changeStake({ address, action, value: quantity.toString(), provider, networkID: chainID }));
     }
   };

--- a/src/views/Stake/Stake.jsx
+++ b/src/views/Stake/Stake.jsx
@@ -108,19 +108,20 @@ function Stake() {
     // eslint-disable-next-line no-restricted-globals
     if (isNaN(quantity) || quantity === 0 || quantity === "") {
       // eslint-disable-next-line no-alert
-      dispatch(error("Please enter a value!"));
-    } else {
-      // 1st catch if quantity > balance
-      let gweiValue = ethers.utils.parseUnits(quantity, "gwei");
-      if (action === "stake" && gweiValue.gt(ethers.utils.parseUnits(ohmBalance, "gwei"))) {
-        console.log("in stake ok");
-        return dispatch(error("You cannot stake more than your OHM balance."));
-      } else if (action === "unstake" && gweiValue.gt(ethers.utils.parseUnits(sohmBalance, "gwei"))) {
-        return dispatch(error("You cannot unstake more than your sOHM balance."));
-      }
-
-      await dispatch(changeStake({ address, action, value: quantity.toString(), provider, networkID: chainID }));
+      return dispatch(error("Please enter a value!"));
     }
+
+    // 1st catch if quantity > balance
+    let gweiValue = ethers.utils.parseUnits(quantity, "gwei");
+    if (action === "stake" && gweiValue.gt(ethers.utils.parseUnits(ohmBalance, "gwei"))) {
+      return dispatch(error("You cannot stake more than your OHM balance."));
+    }
+
+    if (action === "unstake" && gweiValue.gt(ethers.utils.parseUnits(sohmBalance, "gwei"))) {
+      return dispatch(error("You cannot unstake more than your sOHM balance."));
+    }
+
+    await dispatch(changeStake({ address, action, value: quantity.toString(), provider, networkID: chainID }));
   };
 
   const hasAllowance = useCallback(


### PR DESCRIPTION
1. catch when user tries to stake/unstake more than their balance & throw explanatory error
2. add word-break to handle long errors (often returned via backend)

### trying to overstake

before:
![image](https://user-images.githubusercontent.com/80423742/138001920-7130d089-fcbd-4e5a-8c79-82ef4278e40e.png)

after:
![image](https://user-images.githubusercontent.com/80423742/138001876-40714275-3a14-4b67-94d0-3eba4070b03b.png)

### Handling Long errors:

Before:
![image](https://user-images.githubusercontent.com/80423742/138001791-24d78ecb-9f25-49de-81b6-9689a2e53919.png)

After:
![image](https://user-images.githubusercontent.com/80423742/138001975-917fc03f-f112-4e48-a59e-d6a830bc9cd3.png)
