### PR TITLE
UI adjustments for improving approval ux

### DIFF
--- a/src/views/Bond/BondPurchase.jsx
+++ b/src/views/Bond/BondPurchase.jsx
@@ -135,7 +135,7 @@ function BondPurchase({ bond, slippage, recipientAddress }) {
             {!hasAllowance() ? (
               <div className="help-text">
                 <em>
-                  <Typography variant="body1" align="center">
+                  <Typography variant="body1" align="center" color="textSecondary">
                     First time bonding <b>{bond.displayName}</b>? <br /> Please approve Olympus Dao to use your{" "}
                     <b>{bond.displayName}</b> for bonding.
                   </Typography>

--- a/src/views/Bond/BondPurchase.jsx
+++ b/src/views/Bond/BondPurchase.jsx
@@ -123,60 +123,69 @@ function BondPurchase({ bond, slippage, recipientAddress }) {
 
   const displayUnits = bond.displayUnits;
 
+  const isAllowanceDataLoading = bond.allowance == null;
+
   return (
     <Box display="flex" flexDirection="column">
       <Box display="flex" justifyContent="space-around" flexWrap="wrap">
-        <FormControl className="ohm-input" variant="outlined" color="primary" fullWidth>
-          <InputLabel htmlFor="outlined-adornment-amount">Amount</InputLabel>
-          <OutlinedInput
-            id="outlined-adornment-amount"
-            type="number"
-            value={quantity}
-            onChange={e => setQuantity(e.target.value)}
-            // startAdornment={<InputAdornment position="start">$</InputAdornment>}
-            labelWidth={55}
-            endAdornment={
-              <InputAdornment position="end">
-                <Button variant="text" onClick={setMax}>
-                  Max
-                </Button>
-              </InputAdornment>
-            }
-          />
-        </FormControl>
-        {hasAllowance() ? (
-          <Button
-            variant="contained"
-            color="primary"
-            id="bond-btn"
-            className="transaction-button"
-            disabled={isPendingTxn(pendingTransactions, "bond_" + bond.name)}
-            onClick={onBond}
-          >
-            {txnButtonText(pendingTransactions, "bond_" + bond.name, "Bond")}
-          </Button>
+        {isAllowanceDataLoading ? (
+          <Skeleton width="200px" />
         ) : (
-          <Button
-            variant="contained"
-            color="primary"
-            id="bond-approve-btn"
-            className="transaction-button"
-            disabled={isPendingTxn(pendingTransactions, "approve_" + bond.name)}
-            onClick={onSeekApproval}
-          >
-            {txnButtonText(pendingTransactions, "approve_" + bond.name, "Approve")}
-          </Button>
-        )}
+          <>
+            {!hasAllowance() ? (
+              <div className="help-text">
+                <em>
+                  <Typography variant="body1" align="center">
+                    First time bonding <b>{bond.displayName}</b>? <br /> Please approve Olympus Dao to use your{" "}
+                    <b>{bond.displayName}</b> for bonding.
+                  </Typography>
+                </em>
+              </div>
+            ) : (
+              <FormControl className="ohm-input" variant="outlined" color="primary" fullWidth>
+                <InputLabel htmlFor="outlined-adornment-amount">Amount</InputLabel>
+                <OutlinedInput
+                  id="outlined-adornment-amount"
+                  type="number"
+                  value={quantity}
+                  onChange={e => setQuantity(e.target.value)}
+                  // startAdornment={<InputAdornment position="start">$</InputAdornment>}
+                  labelWidth={55}
+                  endAdornment={
+                    <InputAdornment position="end">
+                      <Button variant="text" onClick={setMax}>
+                        Max
+                      </Button>
+                    </InputAdornment>
+                  }
+                />
+              </FormControl>
+            )}
 
-        {!hasAllowance() && (
-          <div className="help-text">
-            <em>
-              <Typography variant="body2">
-                Note: The "Approve" transaction is only needed when bonding for the first time; subsequent bonding only
-                requires you to perform the "Bond" transaction.
-              </Typography>
-            </em>
-          </div>
+            {hasAllowance() ? (
+              <Button
+                variant="contained"
+                color="primary"
+                id="bond-btn"
+                className="transaction-button"
+                disabled={isPendingTxn(pendingTransactions, "bond_" + bond.name)}
+                onClick={onBond}
+              >
+                {txnButtonText(pendingTransactions, "bond_" + bond.name, "Bond")}
+              </Button>
+            ) : (
+              <Button
+                variant="contained"
+                color="primary"
+                id="bond-approve-btn"
+                className="transaction-button"
+                disabled={isPendingTxn(pendingTransactions, "approve_" + bond.name)}
+                onClick={onSeekApproval}
+              >
+                {txnButtonText(pendingTransactions, "approve_" + bond.name, "Approve")}
+              </Button>
+            )}
+          </>
         )}
       </Box>
 

--- a/src/views/Bond/BondRedeem.jsx
+++ b/src/views/Bond/BondRedeem.jsx
@@ -56,7 +56,7 @@ function BondRedeem({ bond }) {
           id="bond-claim-btn"
           className="transaction-button"
           fullWidth
-          disabled={isPendingTxn(pendingTransactions, "redeem_bond_" + bond.name)}
+          disabled={isPendingTxn(pendingTransactions, "redeem_bond_" + bond.name) || bond.pendingPayout == 0.0}
           onClick={() => {
             onRedeem({ autostake: false });
           }}
@@ -69,7 +69,9 @@ function BondRedeem({ bond }) {
           id="bond-claim-autostake-btn"
           className="transaction-button"
           fullWidth
-          disabled={isPendingTxn(pendingTransactions, "redeem_bond_" + bond.name + "_autostake")}
+          disabled={
+            isPendingTxn(pendingTransactions, "redeem_bond_" + bond.name + "_autostake") || bond.pendingPayout == 0.0
+          }
           onClick={() => {
             onRedeem({ autostake: true });
           }}

--- a/src/views/Stake/Stake.jsx
+++ b/src/views/Stake/Stake.jsx
@@ -127,8 +127,10 @@ function Stake() {
       if (token === "sohm") return unstakeAllowance > 0;
       return 0;
     },
-    [stakeAllowance],
+    [stakeAllowance, unstakeAllowance],
   );
+
+  const isAllowanceDataLoading = !((stakeAllowance == null && view === 0) || (unstakeAllowance == null && view === 1));
 
   let modalButton = [];
 
@@ -254,38 +256,56 @@ function Stake() {
                       <Tab label="Stake" {...a11yProps(0)} />
                       <Tab label="Unstake" {...a11yProps(1)} />
                     </Tabs>
-                    <Box className="help-text">
-                      {address && ((!hasAllowance("ohm") && view === 0) || (!hasAllowance("sohm") && view === 1)) && (
-                        <Typography variant="body2" className="stake-note" color="textSecondary">
-                          Note: The "Approve" transaction is only needed when staking/unstaking for the first time;
-                          subsequent staking/unstaking only requires you to perform the "Stake" or "Unstake"
-                          transaction.
-                        </Typography>
-                      )}
-                    </Box>
+
                     <Box className="stake-action-row " display="flex" alignItems="center">
-                      <FormControl className="ohm-input" variant="outlined" color="primary">
-                        <InputLabel htmlFor="amount-input"></InputLabel>
-                        <OutlinedInput
-                          id="amount-input"
-                          type="number"
-                          placeholder="Enter an amount"
-                          className="stake-input"
-                          value={quantity}
-                          onChange={e => setQuantity(e.target.value)}
-                          labelWidth={0}
-                          endAdornment={
-                            <InputAdornment position="end">
-                              <Button variant="text" onClick={setMax} color="inherit">
-                                Max
-                              </Button>
-                            </InputAdornment>
-                          }
-                        />
-                      </FormControl>
+                      {address && !isAllowanceDataLoading ? (
+                        (!hasAllowance("ohm") && view === 0) || (!hasAllowance("sohm") && view === 1) ? (
+                          <Box className="help-text">
+                            <Typography variant="body1" className="stake-note" color="textSecondary">
+                              {view === 0 ? (
+                                <>
+                                  First time staking <b>OHM</b>?
+                                  <br />
+                                  Please approve Olympus Dao to use your <b>OHM</b> for staking.
+                                </>
+                              ) : (
+                                <>
+                                  First time unstaking <b>sOHM</b>?
+                                  <br />
+                                  Please approve Olympus Dao to use your <b>sOHM</b> for unstaking.
+                                </>
+                              )}
+                            </Typography>
+                          </Box>
+                        ) : (
+                          <FormControl className="ohm-input" variant="outlined" color="primary">
+                            <InputLabel htmlFor="amount-input"></InputLabel>
+                            <OutlinedInput
+                              id="amount-input"
+                              type="number"
+                              placeholder="Enter an amount"
+                              className="stake-input"
+                              value={quantity}
+                              onChange={e => setQuantity(e.target.value)}
+                              labelWidth={0}
+                              endAdornment={
+                                <InputAdornment position="end">
+                                  <Button variant="text" onClick={setMax} color="inherit">
+                                    Max
+                                  </Button>
+                                </InputAdornment>
+                              }
+                            />
+                          </FormControl>
+                        )
+                      ) : (
+                        <Skeleton width="150px" />
+                      )}
 
                       <TabPanel value={view} index={0} className="stake-tab-panel">
-                        {address && hasAllowance("ohm") ? (
+                        {isAllowanceDataLoading ? (
+                          <Skeleton />
+                        ) : address && hasAllowance("ohm") ? (
                           <Button
                             className="stake-button"
                             variant="contained"
@@ -311,9 +331,10 @@ function Stake() {
                           </Button>
                         )}
                       </TabPanel>
-
                       <TabPanel value={view} index={1} className="stake-tab-panel">
-                        {address && hasAllowance("sohm") ? (
+                        {isAllowanceDataLoading ? (
+                          <Skeleton />
+                        ) : address && hasAllowance("sohm") ? (
                           <Button
                             className="stake-button"
                             variant="contained"

--- a/src/views/Stake/Stake.jsx
+++ b/src/views/Stake/Stake.jsx
@@ -130,7 +130,7 @@ function Stake() {
     [stakeAllowance, unstakeAllowance],
   );
 
-  const isAllowanceDataLoading = !((stakeAllowance == null && view === 0) || (unstakeAllowance == null && view === 1));
+  const isAllowanceDataLoading = (stakeAllowance == null && view === 0) || (unstakeAllowance == null && view === 1);
 
   let modalButton = [];
 


### PR DESCRIPTION
Use skeleton instead of showing an Approval button by default before user token allowance has loaded:
<img width="800" alt="Screen Shot 2021-10-20 at 10 39 19 PM" src="https://user-images.githubusercontent.com/92614968/138219024-f0c8121c-08db-410f-9298-b552e8a2dec7.png">
<img width="828" alt="Screen Shot 2021-10-20 at 10 21 52 PM" src="https://user-images.githubusercontent.com/92614968/138219029-7b110de8-c2b3-4f0c-a8bc-7c8f89e1a384.png">

<img width="796" alt="Screen Shot 2021-10-20 at 10 54 02 PM" src="https://user-images.githubusercontent.com/92614968/138219556-9fe8b66c-9247-4153-bb29-45dfcdbfa4da.png">
* Changes to the bond purchase screen for approval
* Changes to the Stake/Unstake screens for approval
* When the page is loading instead of Approval button appearing now just a skeleton appears until the token allowances are resolved
* Disable Claim button for bond redemption if there is nothing to claim

Let me know if I can make further improvements to the visuals or code style