### PR TITLE
Fixed overflow issue for wrap sOHM on Abracadabra

### DIFF
--- a/src/components/TopBar/ohmmenu.scss
+++ b/src/components/TopBar/ohmmenu.scss
@@ -20,8 +20,6 @@
     padding: 16px 6px;
     display: flex;
     flex-direction: column;
-    width: 250px;
-    max-width: 250px;
     button {
       display: block;
       width: 100%;


### PR DESCRIPTION
Fixed an issue where "Wrap sOHM on Abracadabra" would overflow beyond the parent box

![image](https://user-images.githubusercontent.com/92545857/138483880-8e4dadbc-e04a-4e91-9177-289dc6310ab6.png)
