### PR TITLE
Add Banner Reminder to verify app.olympusdao domain

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -151,7 +151,7 @@ function App() {
       setWalletChecked(true);
     }
 
-    // We want to ensure that we are storing the UTM parameters for later, evex if the user follows links
+    // We want to ensure that we are storing the UTM parameters for later, even if the user follows links
     storeQueryParameters();
     if (shouldTriggerSafetyCheck()) {
       dispatch(info("Safety Check: Always verify you're on app.olympusdao.finance!"));

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import { ThemeProvider } from "@material-ui/core/styles";
 import { useEffect, useState, useCallback } from "react";
 import { Route, Redirect, Switch, useLocation } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
-import { Hidden, useMediaQuery } from "@material-ui/core";
+import { useMediaQuery } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import CssBaseline from "@material-ui/core/CssBaseline";
 import useTheme from "./hooks/useTheme";
@@ -11,10 +11,12 @@ import { useAddress, useWeb3Context } from "./hooks/web3Context";
 import useGoogleAnalytics from "./hooks/useGoogleAnalytics";
 import useSegmentAnalytics from "./hooks/useSegmentAnalytics";
 import { storeQueryParameters } from "./helpers/QueryParameterHelper";
+import { shouldTriggerSafetyCheck } from "./helpers";
 
 import { calcBondDetails } from "./slices/BondSlice";
 import { loadAppDetails } from "./slices/AppSlice";
 import { loadAccountDetails, calculateUserBondDetails } from "./slices/AccountSlice";
+import { info } from "./slices/MessagesSlice";
 
 import { Stake, ChooseBond, Bond, Dashboard, TreasuryDashboard, PoolTogether } from "./views";
 import Sidebar from "./components/Sidebar/Sidebar.jsx";
@@ -149,8 +151,11 @@ function App() {
       setWalletChecked(true);
     }
 
-    // We want to ensure that we are storing the UTM parameters for later, even if the user follows links
+    // We want to ensure that we are storing the UTM parameters for later, evex if the user follows links
     storeQueryParameters();
+    if (shouldTriggerSafetyCheck()) {
+      dispatch(info("Safety Check: Always verify you're on app.olympusdao.finance!"));
+    }
   }, []);
 
   // this useEffect fires on state change from above. It will ALWAYS fire AFTER

--- a/src/components/Messages/Messages.jsx
+++ b/src/components/Messages/Messages.jsx
@@ -1,10 +1,48 @@
+import { useState, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { close, handle_obsolete } from "../../slices/MessagesSlice";
 import store from "../../store";
-import { Typography, Snackbar } from "@material-ui/core";
+import { LinearProgress, Snackbar, makeStyles } from "@material-ui/core";
 import Alert from "@material-ui/lab/Alert";
 import AlertTitle from "@material-ui/lab/AlertTitle";
 import "./ConsoleInterceptor.js";
+
+const useStyles = makeStyles({
+  root: {
+    width: "100%",
+    marginTop: "10px",
+  },
+});
+
+function Linear({ message }) {
+  const [progress, setProgress] = useState(100);
+  const classes = useStyles();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setProgress(oldProgress => {
+        if (oldProgress === 0) {
+          clearInterval(timer);
+          dispatch(close(message));
+          return 0;
+        }
+        const diff = oldProgress - 5;
+        return diff;
+      });
+    }, 333);
+
+    return () => {
+      clearInterval(timer);
+    };
+  }, []);
+
+  return (
+    <div className={classes.root}>
+      <LinearProgress variant="determinate" value={progress} />
+    </div>
+  );
+}
 
 // A component that displays error messages
 function Messages() {
@@ -32,6 +70,7 @@ function Messages() {
               >
                 <AlertTitle>{message.title}</AlertTitle>
                 {message.text}
+                <Linear message={message} />
               </Alert>
             </Snackbar>
           );

--- a/src/helpers/index.tsx
+++ b/src/helpers/index.tsx
@@ -138,6 +138,21 @@ export function contractForRedeemHelper({
 }
 
 /**
+ * returns false if SafetyCheck has fired in this Session. True otherwise
+ * @returns boolean
+ */
+export const shouldTriggerSafetyCheck = () => {
+  const _storage = window.sessionStorage;
+  const _safetyCheckKey = "-oly-safety";
+  // check if sessionStorage item exists for SafetyCheck
+  if (!_storage.getItem(_safetyCheckKey)) {
+    _storage.setItem(_safetyCheckKey, "true");
+    return true;
+  }
+  return false;
+};
+
+/**
  * returns unix timestamp for x minutes ago
  * @param x minutes as a number
  */


### PR DESCRIPTION
* also add progress bar with timer to Messages.jsx; progress bar autoclears each message from the view & applies to all messages including the existing `error` messages. See examples below.

Info message loads once per session:
![image](https://user-images.githubusercontent.com/80423742/138937951-7c8ce723-7fd5-4738-bfaa-367dd74f5381.png)

Sample Error with progress bar: 
![image](https://user-images.githubusercontent.com/80423742/138937843-8c6e8aa2-c986-494f-9809-74f1ff6a9716.png)

