### PR TITLE
Bond/dashboard format issues

### DIFF
--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -83,6 +83,7 @@ const renderAreaChart = (
           : ""
       }
       domain={[0, "auto"]}
+      dx={2.5}
       connectNulls={true}
       allowDataOverflow={false}
     />

--- a/src/components/TopBar/ohmmenu.scss
+++ b/src/components/TopBar/ohmmenu.scss
@@ -20,8 +20,6 @@
     padding: 16px 6px;
     display: flex;
     flex-direction: column;
-    width: 250px;
-    max-width: 250px;
     button {
       display: block;
       width: 100%;

--- a/src/slices/AccountSlice.ts
+++ b/src/slices/AccountSlice.ts
@@ -44,6 +44,9 @@ interface IUserAccountDetails {
     ohmStake: number;
     ohmUnstake: number;
   };
+  streaming: {
+    sohmStream: number;
+  };
   bonding: {
     daiAllowance: number;
   };
@@ -58,6 +61,7 @@ export const loadAccountDetails = createAsyncThunk(
     let wsohmBalance = 0;
     let stakeAllowance = 0;
     let unstakeAllowance = 0;
+    let streamAllowance = 0;
     let lpStaked = 0;
     let pendingRewards = 0;
     let lpBondAllowance = 0;
@@ -79,6 +83,7 @@ export const loadAccountDetails = createAsyncThunk(
       const sohmContract = new ethers.Contract(addresses[networkID].SOHM_ADDRESS as string, sOHMv2, provider);
       sohmBalance = await sohmContract.balanceOf(address);
       unstakeAllowance = await sohmContract.allowance(address, addresses[networkID].STAKING_ADDRESS);
+      streamAllowance = await sohmContract.allowance(address, addresses[networkID].STAKING_ADDRESS);
       poolAllowance = await sohmContract.allowance(address, addresses[networkID].PT_PRIZE_POOL_ADDRESS);
     }
 
@@ -119,6 +124,9 @@ export const loadAccountDetails = createAsyncThunk(
       staking: {
         ohmStake: +stakeAllowance,
         ohmUnstake: +unstakeAllowance,
+      },
+      streaming: {
+        sohmStream: +streamAllowance,
       },
       bonding: {
         daiAllowance: daiBondAllowance,

--- a/src/views/ChooseBond/BondRow.jsx
+++ b/src/views/ChooseBond/BondRow.jsx
@@ -92,8 +92,16 @@ export function BondTableData({ bond }) {
       <TableCell align="left">
         <Typography>
           <>
-            <span className="currency-icon">$</span>
-            {isBondLoading ? <Skeleton width="50px" /> : trim(bond.bondPrice, 2)}
+            {isBondLoading ? (
+              <Skeleton width="50px" />
+            ) : (
+              new Intl.NumberFormat("en-US", {
+                style: "currency",
+                currency: "USD",
+                maximumFractionDigits: 2,
+                minimumFractionDigits: 2,
+              }).format(bond.bondPrice)
+            )}
           </>
         </Typography>
       </TableCell>


### PR DESCRIPTION
Fox brought up two issues in the bugs channel. One was that there was no left margin for the Total Value Deposited chart. I tried to come up a solution but couldn't find anything that worked well within the Rechart framework, so I just created a small 2.5px buffer as a temp solution. Didn't make a ton of difference so if anyone has a better solution please implement.
Before: 
![image](https://user-images.githubusercontent.com/92545857/138943358-b6ffe794-0cd7-4212-80ea-6b8aa245dda9.png)
After: 
![image](https://user-images.githubusercontent.com/92545857/138943426-486f695b-bb4b-4346-baa5-47b878e5ce85.png)


The other issue was that there was a massive space between the "$" and the bond price on the bond page. This was a clearer solution switching from a span with "$" to using the Intl.NumberFormat object.
Before: 
![image](https://user-images.githubusercontent.com/92545857/138943743-d618ef8b-62b4-4b59-bd4d-ce5266764efc.png)
After: 
![image](https://user-images.githubusercontent.com/92545857/138943820-bd13ffa5-f620-400e-b7e1-633ccf31e14f.png)
