### PR TITLE
Fixed bond price format issues

### DIFF
--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -83,6 +83,7 @@ const renderAreaChart = (
           : ""
       }
       domain={[0, "auto"]}
+      dx={3}
       connectNulls={true}
       allowDataOverflow={false}
     />

--- a/src/views/ChooseBond/BondRow.jsx
+++ b/src/views/ChooseBond/BondRow.jsx
@@ -92,8 +92,16 @@ export function BondTableData({ bond }) {
       <TableCell align="left">
         <Typography>
           <>
-            <span className="currency-icon">$</span>
-            {isBondLoading ? <Skeleton width="50px" /> : trim(bond.bondPrice, 2)}
+            {isBondLoading ? (
+              <Skeleton width="50px" />
+            ) : (
+              new Intl.NumberFormat("en-US", {
+                style: "currency",
+                currency: "USD",
+                maximumFractionDigits: 2,
+                minimumFractionDigits: 2,
+              }).format(bond.bondPrice)
+            )}
           </>
         </Typography>
       </TableCell>

--- a/src/views/ChooseBond/BondRow.jsx
+++ b/src/views/ChooseBond/BondRow.jsx
@@ -34,7 +34,18 @@ export function BondDataCard({ bond }) {
         <div className="data-row">
           <Typography>Price</Typography>
           <Typography className="bond-price">
-            <>{isBondLoading ? <Skeleton width="50px" /> : trim(bond.bondPrice, 2)}</>
+            <>
+              {isBondLoading ? (
+                <Skeleton width="50px" />
+              ) : (
+                new Intl.NumberFormat("en-US", {
+                  style: "currency",
+                  currency: "USD",
+                  maximumFractionDigits: 2,
+                  minimumFractionDigits: 2,
+                }).format(bond.bondPrice)
+              )}
+            </>
           </Typography>
         </div>
 


### PR DESCRIPTION
Fox brought up two issues in the bugs channel. First was an issue with the bond price format on the bonds page where the "$" had a huge space after it. I fixed that by switching to using the Intl.NumberFormat object

Before: 
![image](https://user-images.githubusercontent.com/92545857/138947062-26f1540d-ae7b-49f1-891e-84e9c67e631c.png)
After:
![image](https://user-images.githubusercontent.com/92545857/138947077-0499c6e3-73a0-43be-adcf-c847c9d0dbc8.png)


The other thing he brought up was harder to fix because it's part of an external library, Rechart, where for large y-tick labels there wasn't much padding on the left side of the chart. I made a temp fix of shifting the y-labels over 3 pixels but I'm hoping someone has a better solution
Before: 
![image](https://user-images.githubusercontent.com/92545857/138947300-2140e7b6-e131-4bb5-bcd6-c8ee72bd011a.png)
After:
![image](https://user-images.githubusercontent.com/92545857/138947359-69382864-cc7a-4381-880d-83e6339529a1.png)
