### PR TITLE
fix: remove unused lodash import & only import single required function

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "s3": "node ./scripts/s3.js",
     "ship": "yarn surge",
     "theme": "npx gulp less",
+    "stats": "yarn build --stats && npx webpack-bundle-analyzer ./build/bundle-stats.json",
     "watch": "node ./scripts/watch.js"
   }
 }

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -19,7 +19,6 @@ import {
 import { Typography, Box, SvgIcon, CircularProgress } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 import { trim } from "../../helpers";
-import _ from "lodash";
 import { format } from "date-fns";
 import "./chart.scss";
 

--- a/src/views/ChooseBond/ChooseBond.jsx
+++ b/src/views/ChooseBond/ChooseBond.jsx
@@ -1,5 +1,4 @@
 import { useSelector } from "react-redux";
-import { useEffect } from "react";
 import {
   Box,
   Grid,
@@ -20,7 +19,7 @@ import useBonds from "../../hooks/Bonds";
 import "./choosebond.scss";
 import { Skeleton } from "@material-ui/lab";
 import ClaimBonds from "./ClaimBonds";
-import _ from "lodash";
+import isEmpty from "lodash/isEmpty";
 import { allBondsMap } from "src/helpers/AllBonds";
 
 function ChooseBond() {
@@ -59,7 +58,7 @@ function ChooseBond() {
 
   return (
     <div id="choose-bond-view">
-      {!isAccountLoading && !_.isEmpty(accountBonds) && <ClaimBonds activeBonds={accountBonds} />}
+      {!isAccountLoading && !isEmpty(accountBonds) && <ClaimBonds activeBonds={accountBonds} />}
 
       <Zoom in={true}>
         <Paper className="ohm-card">


### PR DESCRIPTION
Made a small improvement to the overall bundle size by not importing the full lodash library. 
Also added a command to generate a bundle size report and run it in the browser; `yarn stats`  

Overall Gzipped Size: 980.47 KB -> 956.91 KB

Before:
<img width="800" alt="Screenshot 2021-10-20 at 09 39 56" src="https://user-images.githubusercontent.com/92357475/139219747-2f3cb24c-a71a-442e-a38f-b5e87f16b738.png">

After:
<img width="800" alt="Screenshot 2021-10-20 at 09 48 46" src="https://user-images.githubusercontent.com/92357475/139219761-021a5dc0-34f5-43f7-94aa-c52befab8368.png">
ll