### PR TITLE
format fsOHM balance as string, secondary color for subbalances

### DIFF
--- a/src/slices/AccountSlice.ts
+++ b/src/slices/AccountSlice.ts
@@ -74,6 +74,7 @@ export const loadAccountDetails = createAsyncThunk(
     let ohmBalance = BigNumber.from(0);
     let sohmBalance = BigNumber.from(0);
     let fsohmBalance = 0;
+    let fsohmString = "0.0";
     let wsohmBalance = BigNumber.from(0);
     let wsohmAsSohm = BigNumber.from(0);
     let wrapAllowance = BigNumber.from(0);
@@ -131,6 +132,9 @@ export const loadAccountDetails = createAsyncThunk(
         fsohmBalance += Number(balance) * Number(exchangeRate);
       }
     }
+    // return fsohm as a String since all other returned vals are strings
+    // && if fsohmBalance === 0 then return "0.0" for formatting purposes
+    if (fsohmBalance !== 0) fsohmString = fsohmBalance.toString();
 
     if (addresses[networkID].WSOHM_ADDRESS) {
       const wsohmContract = new ethers.Contract(addresses[networkID].WSOHM_ADDRESS as string, wsOHM, provider) as WsOHM;
@@ -145,7 +149,7 @@ export const loadAccountDetails = createAsyncThunk(
         dai: ethers.utils.formatEther(daiBalance),
         ohm: ethers.utils.formatUnits(ohmBalance, "gwei"),
         sohm: ethers.utils.formatUnits(sohmBalance, "gwei"),
-        fsohm: fsohmBalance,
+        fsohm: fsohmString,
         wsohm: ethers.utils.formatEther(wsohmBalance),
         wsohmAsSohm: ethers.utils.formatUnits(wsohmAsSohm, "gwei"),
         pool: ethers.utils.formatUnits(poolBalance, "gwei"),

--- a/src/views/Stake/Stake.jsx
+++ b/src/views/Stake/Stake.jsx
@@ -383,22 +383,28 @@ function Stake() {
                     </div>
 
                     <div className="data-row" style={{ paddingLeft: "10px" }}>
-                      <Typography variant="body2">Single Staking</Typography>
-                      <Typography variant="body2">
+                      <Typography variant="body2" color="textSecondary">
+                        Single Staking
+                      </Typography>
+                      <Typography variant="body2" color="textSecondary">
                         {isAppLoading ? <Skeleton width="80px" /> : <>{trim(sohmBalance, 4)} sOHM</>}
                       </Typography>
                     </div>
 
                     <div className="data-row" style={{ paddingLeft: "10px" }}>
-                      <Typography variant="body2">Staked Balance in Fuse</Typography>
-                      <Typography variant="body2">
+                      <Typography variant="body2" color="textSecondary">
+                        Staked Balance in Fuse
+                      </Typography>
+                      <Typography variant="body2" color="textSecondary">
                         {isAppLoading ? <Skeleton width="80px" /> : <>{trim(fsohmBalance, 4)} fsOHM</>}
                       </Typography>
                     </div>
 
                     <div className="data-row" style={{ paddingLeft: "10px" }}>
-                      <Typography variant="body2">Wrapped Balance</Typography>
-                      <Typography variant="body2">
+                      <Typography variant="body2" color="textSecondary">
+                        Wrapped Balance
+                      </Typography>
+                      <Typography variant="body2" color="textSecondary">
                         {isAppLoading ? <Skeleton width="80px" /> : <>{trim(wsohmBalance, 4)} wsOHM</>}
                       </Typography>
                     </div>


### PR DESCRIPTION
1. format fsOHM balance as a string so that it matches the formatting of other staking balances
2. format all staking sub-balances as secondary color 

![image](https://user-images.githubusercontent.com/80423742/140796945-c6a3cb0e-eec5-4e67-af59-0f128bd8a24e.png)
