### PR TITLE
Remove Geoapify

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,4 @@ REACT_APP_SELF_HOSTED_NODE="https://ipAddress:port"
 # Segment Analytics
 # - not necessary in dev environment
 REACT_APP_SEGMENT_API_KEY=""
-
-# Required for IP -> Country lookup
-REACT_APP_GEOAPIFY_API_KEY=""
 ########################

--- a/src/helpers/Environment.ts
+++ b/src/helpers/Environment.ts
@@ -109,14 +109,4 @@ export class EnvHelper {
     const ALL_URIs = [...EnvHelper.getAlchemyAPIKeyList(), ...EnvHelper.getInfuraIdList()];
     return ALL_URIs;
   }
-
-  static getGeoapifyAPIKey() {
-    var apiKey = EnvHelper.env.REACT_APP_GEOAPIFY_API_KEY;
-    if (!apiKey) {
-      console.warn("Missing REACT_APP_GEOAPIFY_API_KEY environment variable");
-      return null;
-    }
-
-    return apiKey;
-  }
 }

--- a/src/hooks/useSegmentAnalytics.js
+++ b/src/hooks/useSegmentAnalytics.js
@@ -27,6 +27,10 @@ export default function useSegmentAnalytics() {
       };
       initSegmentAnalytics(utm);
       setLoadedSegment(true);
+    } else {
+      console.error(
+        "The Segment API key (REACT_APP_SEGMENT_API_KEY) was empty, so Segment analytics will be disabled.",
+      );
     }
   }, []);
 


### PR DESCRIPTION
- No longer needed, as we will use BigQuery lookups
- Add some error messages when the Segment API key is missing

This was requested by EdgeCaser (PM): https://trello.com/c/2P4wHK9C/42-shift-country-lookup-to-google-apis