### PR TITLE
Fix 33T menu highlight and tab underline

### DIFF
--- a/src/components/Sidebar/NavContent.jsx
+++ b/src/components/Sidebar/NavContent.jsx
@@ -31,6 +31,12 @@ function NavContent() {
     if ((currentPath.indexOf("bonds") >= 0 || currentPath.indexOf("choose_bond") >= 0) && page === "bonds") {
       return true;
     }
+    if (
+      (currentPath.indexOf("33-together") >= 0 || currentPath.indexOf("33-together") >= 0) &&
+      page === "33-together"
+    ) {
+      return true;
+    }
     return false;
   }, []);
 

--- a/src/components/Sidebar/NavContent.jsx
+++ b/src/components/Sidebar/NavContent.jsx
@@ -31,10 +31,7 @@ function NavContent() {
     if ((currentPath.indexOf("bonds") >= 0 || currentPath.indexOf("choose_bond") >= 0) && page === "bonds") {
       return true;
     }
-    if (
-      (currentPath.indexOf("33-together") >= 0 || currentPath.indexOf("33-together") >= 0) &&
-      page === "33-together"
-    ) {
+    if (currentPath.indexOf("33-together") >= 0 && page === "33-together") {
       return true;
     }
     return false;

--- a/src/views/33Together/33Together.jsx
+++ b/src/views/33Together/33Together.jsx
@@ -28,6 +28,7 @@ function a11yProps(index) {
 
 const PoolTogether = () => {
   const [view, setView] = useState(0);
+  const [zoomed, setZoomed] = useState(false);
 
   const changeView = (event, newView) => {
     setView(newView);
@@ -142,13 +143,14 @@ const PoolTogether = () => {
   return (
     <div id="pool-together-view">
       <PoolPrize />
-      <Zoom in={true}>
+      <Zoom in={true} onEntered={() => setZoomed(true)}>
         <Paper className="ohm-card">
           <Box display="flex">
             <CardHeader title="3, 3 Together" />
             <InfoTooltipMulti messagesArray={infoTooltipMessage} />
           </Box>
           <Tabs
+            key={String(zoomed)}
             centered
             value={view}
             textColor="primary"
@@ -156,6 +158,8 @@ const PoolTogether = () => {
             onChange={changeView}
             className="pt-tabs"
             aria-label="pool tabs"
+            //hides the tab underline sliding animation in while <Zoom> is loading
+            TabIndicatorProps={!zoomed && { style: { display: "none" } }}
           >
             <Tab label="Deposit" {...a11yProps(0)} />
             <Tab label="Withdraw" {...a11yProps(1)} />

--- a/src/views/33Together/33Together.jsx
+++ b/src/views/33Together/33Together.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
-import { Paper, Tab, Tabs, Box } from "@material-ui/core";
+import { Paper, Tab, Tabs, Box, Zoom } from "@material-ui/core";
 import InfoTooltipMulti from "../../components/InfoTooltip/InfoTooltipMulti";
 
 import TabPanel from "../../components/TabPanel";
@@ -142,40 +142,41 @@ const PoolTogether = () => {
   return (
     <div id="pool-together-view">
       <PoolPrize />
+      <Zoom in={true}>
+        <Paper className="ohm-card">
+          <Box display="flex">
+            <CardHeader title="3, 3 Together" />
+            <InfoTooltipMulti messagesArray={infoTooltipMessage} />
+          </Box>
+          <Tabs
+            centered
+            value={view}
+            textColor="primary"
+            indicatorColor="primary"
+            onChange={changeView}
+            className="pt-tabs"
+            aria-label="pool tabs"
+          >
+            <Tab label="Deposit" {...a11yProps(0)} />
+            <Tab label="Withdraw" {...a11yProps(1)} />
+          </Tabs>
 
-      <Paper className="ohm-card">
-        <Box display="flex">
-          <CardHeader title="3, 3 Together" />
-          <InfoTooltipMulti messagesArray={infoTooltipMessage} />
-        </Box>
-        <Tabs
-          centered
-          value={view}
-          textColor="primary"
-          indicatorColor="primary"
-          onChange={changeView}
-          className="pt-tabs"
-          aria-label="pool tabs"
-        >
-          <Tab label="Deposit" {...a11yProps(0)} />
-          <Tab label="Withdraw" {...a11yProps(1)} />
-        </Tabs>
-
-        <TabPanel value={view} index={0} className="pool-tab">
-          <PoolDeposit
-            totalPoolDeposits={totalDeposits}
-            winners={winners}
-            setInfoTooltipMessage={setInfoTooltipMessage}
-          />
-        </TabPanel>
-        <TabPanel value={view} index={1} className="pool-tab">
-          <PoolWithdraw
-            totalPoolDeposits={totalDeposits}
-            winners={winners}
-            setInfoTooltipMessage={setInfoTooltipMessage}
-          />
-        </TabPanel>
-      </Paper>
+          <TabPanel value={view} index={0} className="pool-tab">
+            <PoolDeposit
+              totalPoolDeposits={totalDeposits}
+              winners={winners}
+              setInfoTooltipMessage={setInfoTooltipMessage}
+            />
+          </TabPanel>
+          <TabPanel value={view} index={1} className="pool-tab">
+            <PoolWithdraw
+              totalPoolDeposits={totalDeposits}
+              winners={winners}
+              setInfoTooltipMessage={setInfoTooltipMessage}
+            />
+          </TabPanel>
+        </Paper>
+      </Zoom>
 
       <PoolInfo
         graphLoading={graphLoading}

--- a/src/views/Stake/Stake.jsx
+++ b/src/views/Stake/Stake.jsx
@@ -256,6 +256,8 @@ function Stake() {
                       className="stake-tab-buttons"
                       onChange={changeView}
                       aria-label="stake tabs"
+                      //hides the tab underline sliding animation in while <Zoom> is loading
+                      TabIndicatorProps={!zoomed && { style: { display: "none" } }}
                     >
                       <Tab label="Stake" {...a11yProps(0)} />
                       <Tab label="Unstake" {...a11yProps(1)} />


### PR DESCRIPTION
Described and started in #612 

This fixes the tab underline sliding in from the left in both the `Stake` and `33Together` views.
I ended up adding the same fix to the `Stake` view too because, while way more subtle than on `33Together`, the sliding animation also happens there. 
You can try out by commenting the `TabIndicatorProps` on either view and going back and forth between views to notice the differences. 

Tested on Chrome and Brave

Closes #612 


