### PR TITLE
fix mismatch between chart legend and color on Runway Available chart

### DIFF
--- a/src/views/TreasuryDashboard/components/Graph/Graph.js
+++ b/src/views/TreasuryDashboard/components/Graph/Graph.js
@@ -181,17 +181,21 @@ export const RunwayAvailableGraph = () => {
 
   const runway = data && data.filter(metric => metric.runway10k > 5);
 
+  const [current, ...others] = bulletpoints.runway;
+  const runwayBulletpoints = [{ ...current, background: theme.palette.text.primary }, ...others];
+  const colors = runwayBulletpoints.map(b => b.background);
+
   return (
     <Chart
       type="multi"
       data={runway}
       dataKey={["runwayCurrent", "runway7dot5k", "runway5k", "runway2dot5k"]}
       color={theme.palette.text.primary}
-      stroke={[theme.palette.text.primary, "#2EC608", "#49A1F2", "#ff758f"]}
+      stroke={colors}
       headerText="Runway Available"
       headerSubText={`${data && trim(data[0].runwayCurrent, 1)} Days`}
       dataFormat="days"
-      bulletpointColors={bulletpoints.runway}
+      bulletpointColors={runwayBulletpoints}
       itemNames={tooltipItems.runway}
       itemType={""}
       infoTooltipMessage={tooltipInfoMessages.runway}


### PR DESCRIPTION
[gordob pointed out](https://discord.com/channels/838651642190495804/869279336405028884/906802410628972584) that on the Dark theme there was a mismatch [between legend and actual color](https://cdn.discordapp.com/attachments/869279336405028884/906802513636900914/IMG_8886.png) for the Current APY being displayed on the Available Runway chart in the dashboard.

Fixed by using the primary theme color for the Current APY instead of black