### PR TITLE
convex v1 bonds with new convex bonds

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,7 +89,8 @@ function App() {
 
   const [walletChecked, setWalletChecked] = useState(false);
 
-  const { bonds } = useBonds(chainID);
+  // TODO (appleseed-expiredBonds): there may be a smarter way to refactor this
+  const { bonds, expiredBonds } = useBonds(chainID);
   async function loadDetails(whichDetails: string) {
     // NOTE (unbanksy): If you encounter the following error:
     // Unhandled Rejection (Error): call revert exception (method="balanceOf(address)", errorArgs=null, errorName=null, errorSignature=null, reason=null, code=CALL_EXCEPTION, version=abi/5.4.0)
@@ -123,6 +124,9 @@ function App() {
     loadProvider => {
       dispatch(loadAccountDetails({ networkID: chainID, address, provider: loadProvider }));
       bonds.map(bond => {
+        dispatch(calculateUserBondDetails({ address, bond, provider, networkID: chainID }));
+      });
+      expiredBonds.map(bond => {
         dispatch(calculateUserBondDetails({ address, bond, provider, networkID: chainID }));
       });
     },

--- a/src/helpers/AllBonds.ts
+++ b/src/helpers/AllBonds.ts
@@ -134,6 +134,37 @@ export const cvx = new CustomBond({
   reserveContract: ierc20Abi, // The Standard ierc20Abi since they're normal tokens
   networkAddrs: {
     [NetworkID.Mainnet]: {
+      bondAddress: "0x767e3459A35419122e5F6274fB1223d75881E0a9",
+      reserveAddress: "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
+    },
+    [NetworkID.Testnet]: {
+      bondAddress: "0xd43940687f6e76056789d00c43A40939b7a559b5",
+      reserveAddress: "0xB2180448f8945C8Cc8AE9809E67D6bd27d8B2f2C", // using DAI per `principal` address
+      // reserveAddress: "0x6761Cb314E39082e08e1e697eEa23B6D1A77A34b", // guessed
+    },
+  },
+  customTreasuryBalanceFunc: async function (this: CustomBond, networkID, provider) {
+    let cvxPrice: number = await getTokenPrice("convex-finance");
+    const token = this.getContractForReserve(networkID, provider);
+    let cvxAmount: BigNumberish = await token.balanceOf(addresses[networkID].TREASURY_ADDRESS);
+    cvxAmount = Number(cvxAmount.toString()) / Math.pow(10, 18);
+    return cvxAmount * cvxPrice;
+  },
+});
+
+// the old convex bonds. Just need to be claimable for the users who previously purchased
+export const cvx_expired = new CustomBond({
+  name: "cvx-v1",
+  displayName: "CVX-V1",
+  lpUrl: "",
+  bondType: BondType.StableAsset,
+  bondToken: "CVX",
+  isAvailable: { [NetworkID.Mainnet]: false, [NetworkID.Testnet]: true },
+  bondIconSvg: CvxImg,
+  bondContractABI: CvxBondContract,
+  reserveContract: ierc20Abi, // The Standard ierc20Abi since they're normal tokens
+  networkAddrs: {
+    [NetworkID.Mainnet]: {
       bondAddress: "0x6754c69fe02178f54ADa19Ebf1C5569826021920",
       reserveAddress: "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
     },
@@ -275,6 +306,8 @@ export const ohm_weth = new CustomBond({
 // Is it an LP Bond? use `new LPBond`
 // Add new bonds to this array!!
 export const allBonds = [dai, frax, eth, cvx, ohm_dai, ohm_frax, lusd, ohm_lusd, ohm_weth];
+// TODO (appleseed-expiredBonds): there may be a smarter way to refactor this
+export const allExpiredBonds = [cvx_expired];
 export const allBondsMap = allBonds.reduce((prevVal, bond) => {
   return { ...prevVal, [bond.name]: bond };
 }, {});

--- a/src/helpers/AllBonds.ts
+++ b/src/helpers/AllBonds.ts
@@ -155,7 +155,7 @@ export const cvx = new CustomBond({
 // the old convex bonds. Just need to be claimable for the users who previously purchased
 export const cvx_expired = new CustomBond({
   name: "cvx-v1",
-  displayName: "CVX-V1",
+  displayName: "CVX OLD",
   lpUrl: "",
   bondType: BondType.StableAsset,
   bondToken: "CVX",

--- a/src/hooks/Bonds.ts
+++ b/src/hooks/Bonds.ts
@@ -1,6 +1,6 @@
 import { useSelector } from "react-redux";
 import { useEffect, useState } from "react";
-import allBonds from "src/helpers/AllBonds";
+import allBonds, { allExpiredBonds } from "src/helpers/AllBonds";
 import { IUserBondDetails } from "src/slices/AccountSlice";
 import { Bond } from "src/lib/Bond";
 import { IBondDetails } from "src/slices/BondSlice";
@@ -21,12 +21,14 @@ interface IBondingStateView {
 interface IAllBondData extends Bond, IBondDetails, IUserBondDetails {}
 
 const initialBondArray = allBonds;
+const initialExpiredArray = allExpiredBonds;
 // Slaps together bond data within the account & bonding states
 function useBonds(chainID: number) {
   const bondLoading = useSelector((state: IBondingStateView) => !state.bonding.loading);
   const bondState = useSelector((state: IBondingStateView) => state.bonding);
   const accountBondsState = useSelector((state: IBondingStateView) => state.account.bonds);
   const [bonds, setBonds] = useState<Bond[] | IAllBondData[]>(initialBondArray);
+  const [expiredBonds, setExpiredBonds] = useState<Bond[] | IAllBondData[]>(initialExpiredArray);
 
   useEffect(() => {
     let bondDetails: IAllBondData[];
@@ -49,13 +51,29 @@ function useBonds(chainID: number) {
       if (b.getAvailability(chainID) === false) return -1;
       return a["bondDiscount"] > b["bondDiscount"] ? -1 : b["bondDiscount"] > a["bondDiscount"] ? 1 : 0;
     });
-
     setBonds(mostProfitableBonds);
+
+    // TODO (appleseed-expiredBonds): there may be a smarter way to refactor this
+    let expiredDetails: IAllBondData[];
+    expiredDetails = allExpiredBonds
+      .flatMap(bond => {
+        if (bondState[bond.name] && bondState[bond.name].bondDiscount) {
+          return Object.assign(bond, bondState[bond.name]); // Keeps the object type
+        }
+        return bond;
+      })
+      .flatMap(bond => {
+        if (accountBondsState[bond.name]) {
+          return Object.assign(bond, accountBondsState[bond.name]);
+        }
+        return bond;
+      });
+    setExpiredBonds(expiredDetails);
   }, [bondState, accountBondsState, bondLoading]);
 
   // Debug Log:
   // console.log(bonds);
-  return { bonds, loading: bondLoading };
+  return { bonds, loading: bondLoading, expiredBonds };
 }
 
 export default useBonds;

--- a/src/views/ChooseBond/ClaimRow.jsx
+++ b/src/views/ChooseBond/ClaimRow.jsx
@@ -15,7 +15,7 @@ import { isPendingTxn, txnButtonTextGeneralPending } from "src/slices/PendingTxn
 export function ClaimBondTableData({ userBond }) {
   const dispatch = useDispatch();
   const { address, chainID, provider } = useWeb3Context();
-  const { bonds } = useBonds(chainID);
+  const { bonds, expiredBonds } = useBonds(chainID);
 
   const bond = userBond[1];
   const bondName = bond.bond;
@@ -35,7 +35,8 @@ export function ClaimBondTableData({ userBond }) {
   };
 
   async function onRedeem({ autostake }) {
-    let currentBond = bonds.find(bnd => bnd.name === bondName);
+    // TODO (appleseed-expiredBonds): there may be a smarter way to refactor this
+    let currentBond = [...bonds, ...expiredBonds].find(bnd => bnd.name === bondName);
     await dispatch(redeemBond({ address, bond: currentBond, networkID: chainID, provider, autostake }));
   }
 
@@ -75,7 +76,7 @@ export function ClaimBondTableData({ userBond }) {
 export function ClaimBondCardData({ userBond }) {
   const dispatch = useDispatch();
   const { address, chainID, provider } = useWeb3Context();
-  const { bonds } = useBonds(chainID);
+  const { bonds, expiredBonds } = useBonds(chainID);
 
   const bond = userBond[1];
   const bondName = bond.bond;
@@ -93,7 +94,8 @@ export function ClaimBondCardData({ userBond }) {
   };
 
   async function onRedeem({ autostake }) {
-    let currentBond = bonds.find(bnd => bnd.name === bondName);
+    // TODO (appleseed-expiredBonds): there may be a smarter way to refactor this
+    let currentBond = [...bonds, ...expiredBonds].find(bnd => bnd.name === bondName);
     await dispatch(redeemBond({ address, bond: currentBond, networkID: chainID, provider, autostake }));
   }
 


### PR DESCRIPTION
Implementation details:
1. The "expired" convex bonds are no longer bondable, but do need to remain claimable (at least until all the currently issued are claimed) 
2. The previous iteration of `all_bonds` is still used to calculate bond pricing & User Account balances against for ACTIVE bonds.
3. This PR creates an `expired_bonds` function that is called ONLY to check User Account Balances against for EXPIRED bonds. 

Question:
- [ ] do we like the naming of the "expired" convex bond in the claim section (see 1st screenshot below), "CVX-V1"

Screenshot below shows UI for a user who has both the NEW CVX bonds & the OLD "expired" CVX bonds to claim. Ignore the numbers, they are forced:
![image](https://user-images.githubusercontent.com/80423742/142260157-8c5a5db3-582b-4aad-8d3c-5e7ad21729c5.png)

Screenshot below shows that the old, "expired" Convex V1 bond is not shown in the Bondable section:
![image](https://user-images.githubusercontent.com/80423742/142260603-a33ac915-a995-4cac-b4fd-2b76f30fb1bf.png)
