### PR TITLE
I18n fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/locales/translations"]
 	path = src/locales/translations
 	url = https://github.com/OlympusDAO/olympus-translations
+	branch = develop

--- a/.linguirc
+++ b/.linguirc
@@ -5,5 +5,8 @@
       "path": "src/locales/translations/olympus-frontend/{locale}/messages",
       "include": ["src"]
    }],
+   "fallbackLocales": {
+      "default": "en"
+   },
    "format": "po"
 }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ The language files are located in a submodule deployed in `src/locales/translati
 In order to mark text for translation you can use:
 - The <Trans> component in jsx templates eg. `<Trans>Translate me!</Trans>`
 - The t function in javascript code and jsx templates. ``` t`Translate me` ```
+You can also add comments for the translators. eg.
+```
+t({
+	id: "do_bond",
+	comment: "The action of bonding (verb)",
+})
+```
+
 
 When new texts are created or existing texts are modified in the application please leave a message in the OlympusDao app-translation channel for the translators to translate them.
 

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "extends": "react-app"
   },
   "scripts": {
+    "prebuild": "git submodule update --init --recursive --remote && yarn lingui:compile",
     "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "postbuild": "yarn lingui:compile",
     "eject": "react-scripts eject",
@@ -134,7 +135,7 @@
     "lingui:compile": "lingui compile",
     "typechain:build": "yarn run typechain --target ethers-v5 --out-dir src/typechain src/abi/*.json src/abi/**/*.json",
     "preinstall": "[ ! -f src/locales/translations/.git ] && git submodule deinit --all -f; git submodule update --init --recursive",
-    "postinstall": "yarn typechain:build && yarn lingui:compile"
+    "postinstall": "yarn typechain:build && git submodule update --init --recursive --remote && yarn lingui:compile"
   },
   "resolutions": {
     "**/immer": "9.0.6",

--- a/package.json
+++ b/package.json
@@ -117,9 +117,7 @@
     "extends": "react-app"
   },
   "scripts": {
-    "prebuild": "git submodule update --init --recursive --remote && yarn lingui:compile",
     "build": "GENERATE_SOURCEMAP=false react-scripts build",
-    "postbuild": "yarn lingui:compile",
     "eject": "react-scripts eject",
     "start": "react-scripts start",
     "test": "react-scripts test",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "lingui:compile": "lingui compile",
     "typechain:build": "yarn run typechain --target ethers-v5 --out-dir src/typechain src/abi/*.json src/abi/**/*.json",
     "preinstall": "[ ! -f src/locales/translations/.git ] && git submodule deinit --all -f; git submodule update --init --recursive --remote",
-    "postinstall": "yarn typechain:build && git submodule update --init --recursive --remote && yarn lingui:compile"
+    "postinstall": "yarn typechain:build && yarn lingui:compile"
   },
   "resolutions": {
     "**/immer": "9.0.6",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "lingui:extract": "lingui extract",
     "lingui:compile": "lingui compile",
     "typechain:build": "yarn run typechain --target ethers-v5 --out-dir src/typechain src/abi/*.json src/abi/**/*.json",
-    "preinstall": "[ ! -f src/locales/translations/.git ] && git submodule deinit --all -f; git submodule update --init --recursive",
+    "preinstall": "[ ! -f src/locales/translations/.git ] && git submodule deinit --all -f; git submodule update --init --recursive --remote",
     "postinstall": "yarn typechain:build && git submodule update --init --recursive --remote && yarn lingui:compile"
   },
   "resolutions": {

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -21,7 +21,7 @@ for (var [key, locale] of Object.entries(locales)) {
   i18n.loadLocaleData(key, { plurals: locale.plurals });
 }
 
-async function fetchLocale(locale: string) {
+async function fetchLocale(locale: string = "en") {
   const { messages } = await import(
     /* webpackChunkName: "[request]" */ `../locales/translations/olympus-frontend/${locale}/messages`
   );
@@ -33,5 +33,7 @@ export function selectLocale(locale: string) {
   return fetchLocale(locale);
 }
 export function initLocale() {
-  fetchLocale(window.localStorage.getItem("locale") || "en");
+  var locale = window.localStorage.getItem("locale") as string;
+  if (!Object.keys(locales).includes(locale)) locale = "en";
+  fetchLocale(locale);
 }

--- a/src/views/Bond/Bond.jsx
+++ b/src/views/Bond/Bond.jsx
@@ -87,7 +87,14 @@ function Bond({ bond }) {
                 onChange={changeView}
                 aria-label="bond tabs"
               >
-                <Tab aria-label="bond-tab-button" label={t`do_bond`} {...a11yProps(0)} />
+                <Tab
+                  aria-label="bond-tab-button"
+                  label={t({
+                    id: "do_bond",
+                    comment: "The action of bonding (verb)",
+                  })}
+                  {...a11yProps(0)}
+                />
                 <Tab aria-label="redeem-tab-button" label={t`Redeem`} {...a11yProps(1)} />
               </Tabs>
 

--- a/src/views/Bond/BondPurchase.jsx
+++ b/src/views/Bond/BondPurchase.jsx
@@ -145,7 +145,7 @@ function BondPurchase({ bond, slippage, recipientAddress }) {
                       <Typography variant="body1" align="center" color="textSecondary">
                         <Trans>First time bonding</Trans> <b>{bond.displayName}</b>? <br />{" "}
                         <Trans>Please approve Olympus Dao to use your</Trans> <b>{bond.displayName}</b>{" "}
-                        <b>{bond.displayName}</b> <Trans>for bonding</Trans>.
+                        <Trans>for bonding</Trans>.
                       </Typography>
                     </em>
                   </div>

--- a/src/views/Stake/Stake.jsx
+++ b/src/views/Stake/Stake.jsx
@@ -272,7 +272,13 @@ function Stake() {
                       //hides the tab underline sliding animation in while <Zoom> is loading
                       TabIndicatorProps={!zoomed && { style: { display: "none" } }}
                     >
-                      <Tab label={t`do_stake`} {...a11yProps(0)} />
+                      <Tab
+                        label={t({
+                          id: "do_stake",
+                          comment: "The action of staking (verb)",
+                        })}
+                        {...a11yProps(0)}
+                      />
                       <Tab label={t`Unstake`} {...a11yProps(1)} />
                     </Tabs>
                     <Box className="stake-action-row " display="flex" alignItems="center">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2710,10 +2710,10 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.5.tgz#75a2a8e7d8ab4b230414505d92335d1dcb53a6df"
   integrity sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==
 
-"@types/react-dom@^17.0.10":
-  version "17.0.10"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.10.tgz#d6972ec018d23cf22b99597f1289343d99ea9d9d"
-  integrity sha512-8oz3NAUId2z/zQdFI09IMhQPNgIbiP8Lslhv39DIDamr846/0spjZK0vnrMak0iB8EKb9QFTTIdg2Wj2zH5a3g==
+"@types/react-dom@^17.0.11":
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
+  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
- Merges locale submodule with remote repo
- Fixes translations fallback to English
- Adds comments abouts `do_stake` and `do_bond` translations
- Fixes bond name displayed twice when purchasing a bond