### PR TITLE
update ohm menu to remove 2x unstake text

### DIFF
--- a/src/components/TopBar/OhmMenu.jsx
+++ b/src/components/TopBar/OhmMenu.jsx
@@ -225,7 +225,6 @@ function OhmMenu() {
                     <Typography align="left">
                       <Trans>Unstake Legacy LP Token</Trans>
                     </Typography>
-                    <Typography align="left">Unstake Legacy LP Token</Typography>
                   </Button>
                 </Link>
               </Paper>


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/80423742/142504461-28f56335-bba2-4107-8418-e050bf0c6a57.png)


after:
![image](https://user-images.githubusercontent.com/80423742/142504496-96c7379d-4d51-40d6-a18e-edd57705f779.png)
