### PR TITLE
Lingui:Build update

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ $ cp .env.example .env
 # fill in your own values in .env, then =>
 $ yarn
 $ yarn start
+
+# to populate the translations (optional)
+$ yarn lingui:build
 ```
 
 The site is now running at `http://localhost:3000`!

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "extends": "react-app"
   },
   "scripts": {
+    "prebuild": "yarn lingui:build",
     "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "eject": "react-scripts eject",
     "start": "react-scripts start",
@@ -128,8 +129,8 @@
     "watch": "node ./scripts/watch.js",
     "lingui:extract": "lingui extract",
     "lingui:compile": "lingui compile",
+    "lingui:build": "[ ! -f src/locales/translations/.git ] && git submodule deinit --all -f; git submodule update --init --recursive --remote",
     "typechain:build": "yarn run typechain --target ethers-v5 --out-dir src/typechain src/abi/*.json src/abi/**/*.json",
-    "preinstall": "[ ! -f src/locales/translations/.git ] && git submodule deinit --all -f; git submodule update --init --recursive --remote",
     "postinstall": "yarn typechain:build && yarn lingui:compile"
   },
   "resolutions": {


### PR DESCRIPTION
1. make lingui:build explicit to avoid pulling in lingui changes on every yarn run
2. periodically the lingui changes would cuck my git log when I wasn't expecting
3. with these changes lingui:build must be explicitly called by the dev
4. meanwhile, lingui:build is still part of the build process so it will run on deploy