### PR TITLE
tiny typo?

### DIFF
--- a/src/views/TreasuryDashboard/components/Metric/Metric.js
+++ b/src/views/TreasuryDashboard/components/Metric/Metric.js
@@ -84,7 +84,7 @@ export const WSOHMPrice = () => {
         wsOHM Price
         <InfoTooltip
           message={
-            "wsOHM = sOHM * index\n\nThe price of wsOHM is equal to the price of OHM multiplied by the current index"
+            "wsOHM = OHM * index\n\nThe price of wsOHM is equal to the price of OHM multiplied by the current index"
           }
         />
       </Metric.Title>

--- a/src/views/Wrap/Wrap.jsx
+++ b/src/views/Wrap/Wrap.jsx
@@ -196,7 +196,7 @@ function Wrap() {
                         wsOHM Price
                         <InfoTooltip
                           message={
-                            "wsOHM = sOHM * index\n\nThe price of wsOHM is equal to the price of OHM multiplied by the current index"
+                            "wsOHM = OHM * index\n\nThe price of wsOHM is equal to the price of OHM multiplied by the current index"
                           }
                         />
                       </Typography>


### PR DESCRIPTION
Shouldnt this be just `OHM`, since it says "the price of OHM multiplied..", not "the price of Staked OHM"?