### PR TITLE
add tooltip to TVD in External Staking

### DIFF
--- a/src/components/InfoTooltip/InfoTooltip.jsx
+++ b/src/components/InfoTooltip/InfoTooltip.jsx
@@ -3,7 +3,7 @@ import { ReactComponent as Info } from "../../assets/icons/info.svg";
 import { SvgIcon, Paper, Typography, Box, Popper } from "@material-ui/core";
 import "./infotooltip.scss";
 
-function InfoTooltip({ message }) {
+function InfoTooltip({ message, children }) {
   const [anchorEl, setAnchorEl] = useState(null);
 
   const handleHover = event => {
@@ -25,7 +25,7 @@ function InfoTooltip({ message }) {
       <Popper id={id} open={open} anchorEl={anchorEl} placement="bottom" className="tooltip">
         <Paper className="info-tooltip ohm-card">
           <Typography variant="body2" className="info-tooltip-text">
-            {message}
+            {children || message}
           </Typography>
         </Paper>
       </Popper>

--- a/src/views/Stake/ExternalStakePool.jsx
+++ b/src/views/Stake/ExternalStakePool.jsx
@@ -25,6 +25,7 @@ import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
 import { getLusdData } from "../../slices/LusdSlice";
 import { useWeb3Context } from "src/hooks/web3Context";
 import { trim } from "../../helpers";
+import InfoTooltip from "src/components/InfoTooltip/InfoTooltip";
 
 export default function ExternalStakePool() {
   const dispatch = useDispatch();
@@ -88,6 +89,9 @@ export default function ExternalStakePool() {
                     </TableCell>
                     <TableCell align="left">
                       <Trans>TVD</Trans>
+                      <InfoTooltip>
+                        <Trans>Total Value Deposited</Trans>
+                      </InfoTooltip>
                     </TableCell>
                     <TableCell align="left">
                       <Trans>Balance</Trans>
@@ -170,6 +174,9 @@ export default function ExternalStakePool() {
                 <div className="data-row">
                   <Typography>
                     <Trans>TVD</Trans>
+                    <InfoTooltip>
+                      <Trans>Total Value Deposited</Trans>
+                    </InfoTooltip>
                   </Typography>
                   <Typography>
                     {isLusdLoading ? (


### PR DESCRIPTION

Adding a tooltip to TVD to make it easier to abbreviate across translations without compromising style. 
Also InfoTooltip component is now able to render children which useful to add translations 

[context/discussion in DAO server](https://discord.com/channels/838651642190495804/896953911385161750/911635201011118141)