### PR TITLE
mobile wrap ui fix

### DIFF
--- a/src/views/Stake/stake.scss
+++ b/src/views/Stake/stake.scss
@@ -100,6 +100,7 @@
   .stake-index {
     align-items: flex-start;
   }
+    text-align: left;
 }
 
 .ohm-logo-tiny {

--- a/src/views/Wrap/Wrap.jsx
+++ b/src/views/Wrap/Wrap.jsx
@@ -432,9 +432,9 @@ function Wrap() {
                       <div className="stake-tab-panel wrap-page">
                         {chooseInputArea()}
                         {/* <Box width="1px" /> */}
-                        {chooseButtonArea()}
                       </div>
                     </Box>
+                    {chooseButtonArea()}
                     {quantity && (
                       <Box padding={1}>
                         <Typography variant="body2" className={classes.textHighlight}>


### PR DESCRIPTION
1. Small change making approve button extend to 100% of width
2. Switch mobile view on wrap ui to align to left of parent box