### PR TITLE
update gohm & fiatdao wsohm calcs

### DIFF
--- a/src/views/Stake/Stake.tsx
+++ b/src/views/Stake/Stake.tsx
@@ -77,9 +77,11 @@ function Stake() {
   const fiatDaowsohmBalance = useAppSelector(state => {
     return state.account.balances && state.account.balances.fiatDaowsohm;
   });
+  const fiatDaoAsSohm = Number(fiatDaowsohmBalance) * Number(currentIndex);
   const gOhmBalance = useAppSelector(state => {
     return state.account.balances && state.account.balances.gohm;
   });
+  const gOhmAsSohm = Number(gOhmBalance) * Number(currentIndex);
   const wsohmAsSohm = useAppSelector(state => {
     return state.account.balances && state.account.balances.wsohmAsSohm;
   });
@@ -168,7 +170,7 @@ function Stake() {
   };
 
   const trimmedBalance = Number(
-    [sohmBalance, fsohmBalance, wsohmAsSohm, gOhmBalance]
+    [sohmBalance, fsohmBalance, wsohmAsSohm, gOhmAsSohm, fiatDaoAsSohm]
       .filter(Boolean)
       .map(balance => Number(balance))
       .reduce((a, b) => a + b, 0)


### PR DESCRIPTION
`Total Staked Balance` in sOHM was not properly converting gOHM & fiatDAO wsOHM into sOHM quantity.
This pr takes gOHM & fiatDAO wsOHM & multiplies each by the current Index to get proper sOHM quantity.
![image](https://user-images.githubusercontent.com/80423742/144268437-8ddec655-a216-44db-9d82-ccc648d189a4.png)
