### PR TITLE
convert `uri` to `uri()` to force parsing the function

### DIFF
--- a/src/hooks/web3Context.tsx
+++ b/src/hooks/web3Context.tsx
@@ -62,12 +62,12 @@ const initModal = new Web3Modal({
       package: WalletConnectProvider,
       options: {
         rpc: {
-          1: NETWORKS[1].uri,
-          4: NETWORKS[4].uri,
-          42161: NETWORKS[42161].uri,
-          421611: NETWORKS[421611].uri,
-          43113: NETWORKS[43113].uri,
-          43114: NETWORKS[43114].uri,
+          1: NETWORKS[1].uri(),
+          4: NETWORKS[4].uri(),
+          42161: NETWORKS[42161].uri(),
+          421611: NETWORKS[421611].uri(),
+          43113: NETWORKS[43113].uri(),
+          43114: NETWORKS[43114].uri(),
         },
       },
     },


### PR DESCRIPTION
should fix this issue: 

![image](https://user-images.githubusercontent.com/80423742/144337481-748cefe1-7ef1-4b5d-aca4-ef2b25736007.png)
