### PR TITLE
force loadAccount callback update on address change, too

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,7 +135,6 @@ function App() {
           dispatch(calcBondDetails({ bond, value: "", provider: loadProvider, networkID: networkId }));
         }
       });
-      dispatch(getMigrationAllowances({ address, provider, networkID: networkId }));
     },
     [networkId],
   );
@@ -143,6 +142,7 @@ function App() {
   const loadAccount = useCallback(
     loadProvider => {
       dispatch(loadAccountDetails({ networkID: networkId, address, provider: loadProvider }));
+      dispatch(getMigrationAllowances({ address, provider, networkID: networkId }));
       bonds.map(bond => {
         if (bond.getAvailability(networkId)) {
           dispatch(calculateUserBondDetails({ address, bond, provider, networkID: networkId }));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -155,7 +155,7 @@ function App() {
         }
       });
     },
-    [networkId],
+    [networkId, address],
   );
 
   // The next 3 useEffects handle initializing API Loads AFTER wallet is checked


### PR DESCRIPTION
this fixes the issue where on initial connect the app does not load balances.

To test disconnect your wallet. Then reconnect. 
1. When app loads on current prod it WILL NOT load your balances.
2. When app loads on this PR it WILL load your balances.