### PR TITLE
turn off 33-t deposits

### DIFF
--- a/src/helpers/33Together.ts
+++ b/src/helpers/33Together.ts
@@ -62,6 +62,7 @@ export const secondsToDaysForInput = (seconds: number) => {
  * @returns [PrizePoolURI, PoolDetailsURI]
  */
 export const poolTogetherUILinks = (networkId: number): Array<string> => {
+  if (networkId === -1) networkId = 1;
   const contractAddress = addresses[networkId].PT_PRIZE_POOL_ADDRESS;
 
   if (networkId === 4) {

--- a/src/views/33Together/33together.tsx
+++ b/src/views/33Together/33together.tsx
@@ -44,7 +44,7 @@ const PoolTogether = () => {
   const { connect, address, provider, hasCachedProvider } = useWeb3Context();
   const networkId = useAppSelector(state => state.network.networkId);
   const dispatch = useDispatch();
-  const [graphUrl, setGraphUrl] = useState(POOL_GRAPH_URLS[networkId.toString()]);
+  const [graphUrl, setGraphUrl] = useState(POOL_GRAPH_URLS[1]);
   const [poolData, setPoolData] = useState(null);
   const [poolDataError, setPoolDataError] = useState(null);
   const [graphLoading, setGraphLoading] = useState(true);
@@ -71,12 +71,23 @@ const PoolTogether = () => {
 
   // query correct pool subgraph depending on current chain
   useEffect(() => {
-    setGraphUrl(POOL_GRAPH_URLS[networkId]);
+    if (networkId === -1) {
+      setGraphUrl(POOL_GRAPH_URLS[1]);
+    } else {
+      setGraphUrl(POOL_GRAPH_URLS[networkId]);
+    }
   }, [networkId]);
 
   useEffect(() => {
+    console.log("apollo", networkId);
+    let apolloUrl: string;
+    if (networkId === -1) {
+      apolloUrl = poolDataQuery(addresses[1].PT_PRIZE_POOL_ADDRESS);
+    } else {
+      apolloUrl = poolDataQuery(addresses[networkId].PT_PRIZE_POOL_ADDRESS);
+    }
     // get poolData
-    apolloExt(poolDataQuery(addresses[networkId].PT_PRIZE_POOL_ADDRESS), graphUrl)
+    apolloExt(apolloUrl, graphUrl)
       .then(poolData => {
         const prizePool: PrizePool = poolData?.data.prizePool;
 
@@ -165,18 +176,18 @@ const PoolTogether = () => {
           className="pt-tabs"
           aria-label="pool tabs"
         >
-          <Tab label={t`Deposit`} {...a11yProps(0)} />
-          <Tab label={t`Withdraw`} {...a11yProps(1)} />
+          {/* <Tab label={t`Deposit`} {...a11yProps(0)} /> */}
+          <Tab label={t`Withdraw`} {...a11yProps(0)} />
         </Tabs>
 
-        <TabPanel value={view} index={0} className="pool-tab">
+        {/* <TabPanel value={view} index={0} className="pool-tab">
           <PoolDeposit
             totalPoolDeposits={totalDeposits}
             winners={winners}
             setInfoTooltipMessage={setInfoTooltipMessage}
           />
-        </TabPanel>
-        <TabPanel value={view} index={1} className="pool-tab">
+        </TabPanel> */}
+        <TabPanel value={view} index={0} className="pool-tab">
           <PoolWithdraw
             totalPoolDeposits={totalDeposits}
             winners={winners}

--- a/src/views/33Together/PoolPrize.jsx
+++ b/src/views/33Together/PoolPrize.jsx
@@ -83,18 +83,18 @@ export const PoolPrize = () => {
     } else if (poolIsLocked) {
       setShowAwardStart(false);
       // wait 30 seconds... we're just waiting for award
-      setTimeout(() => {
-        // retry until Pool Is Not Locked, then go get new time
-        rngQueryFunc();
-      }, 30000);
+      // setTimeout(() => {
+      //   // retry until Pool Is Not Locked, then go get new time
+      //   rngQueryFunc();
+      // }, 30000);
     } else if (parseInt(poolAwardTimeRemaining, 10) <= 0) {
       setShowAwardStart(true);
       // There is no time left, attach RNG (Award) Start listener
       // the rngQueryFunc will run repeatedly once the above conditions are true;
-      setTimeout(() => {
-        // retry until pool is locked, then hits above block
-        rngQueryFunc();
-      }, 10000);
+      // setTimeout(() => {
+      //   // retry until pool is locked, then hits above block
+      //   rngQueryFunc();
+      // }, 10000);
     }
   }, [poolAwardTimeRemaining, poolIsLocked, rngRequestCompleted]);
 
@@ -127,9 +127,10 @@ export const PoolPrize = () => {
               <Trans>Prize is being awarded</Trans>
             </Typography>
           ) : (
-            <Typography variant="h6">
-              <Trans>Next award</Trans>
-            </Typography>
+            <Typography></Typography>
+            // <Typography variant="h6">
+            //   <Trans>Next award</Trans>
+            // </Typography>
           )}
           <Box className="pool-timer">
             {timer && poolIsLocked !== true && (

--- a/src/views/33Together/PoolWithdraw.jsx
+++ b/src/views/33Together/PoolWithdraw.jsx
@@ -113,95 +113,100 @@ export const PoolWithdraw = props => {
   }
 
   return (
-    <Box display="flex" justifyContent="center" className="pool-deposit-ui">
-      {!address ? (
-        <ConnectButton />
-      ) : (
-        <Box className="withdrawal-container">
-          <Box display="flex" alignItems="center" flexDirection={`${isMobileScreen ? "column" : "row"}`}>
-            <FormControl className="ohm-input" variant="outlined" color="primary">
-              <InputLabel htmlFor="amount-input"></InputLabel>
-              <OutlinedInput
-                id="amount-input"
-                type="number"
-                placeholder="Enter an amount"
-                className="pool-input"
-                value={quantity}
-                onChange={e => setQuantity(parseFloat(e.target.value))}
-                startAdornment={
-                  <InputAdornment position="start">
-                    <div className="logo-holder">{sohmImg}</div>
-                  </InputAdornment>
-                }
-                labelWidth={0}
-                endAdornment={
-                  <InputAdornment position="end">
-                    <Button variant="text" onClick={setMax}>
-                      <Trans>Max</Trans>
-                    </Button>
-                  </InputAdornment>
-                }
-              />
-            </FormControl>
-            <Button
-              className="pool-withdraw-button"
-              variant="contained"
-              color="primary"
-              disabled={isPendingTxn(pendingTransactions, "pool_withdraw")}
-              onClick={() => onWithdraw("withdraw")}
-              style={{ margin: "5px" }}
-            >
-              {exitFee > 0
-                ? txnButtonText(pendingTransactions, "pool_withdraw", t`Withdraw Early & pay` + exitFee + " sOHM")
-                : txnButtonText(pendingTransactions, "pool_withdraw", t`Withdraw sOHM`)}
-              {/* Withdraw sOHM */}
-            </Button>
-          </Box>
-          {newOdds > 0 && quantity > 0 && (
-            <Box padding={1}>
-              <Typography color="error" variant="body2">
-                <Trans>
-                  Withdrawing {quantity} sOHM reduces your odds of winning to 1 in {newOdds}
-                </Trans>
-                &nbsp;
-              </Typography>
+    <>
+      <Typography variant="body1" style={{ margin: "0.5rem" }} align="center">
+        <Trans>The pool has been temporarily disabled for V2 Migration. Please withdraw your 33T</Trans>
+      </Typography>
+      <Box display="flex" justifyContent="center" className="pool-deposit-ui">
+        {!address ? (
+          <ConnectButton />
+        ) : (
+          <Box className="withdrawal-container">
+            <Box display="flex" alignItems="center" flexDirection={`${isMobileScreen ? "column" : "row"}`}>
+              <FormControl className="ohm-input" variant="outlined" color="primary">
+                <InputLabel htmlFor="amount-input"></InputLabel>
+                <OutlinedInput
+                  id="amount-input"
+                  type="number"
+                  placeholder="Enter an amount"
+                  className="pool-input"
+                  value={quantity}
+                  onChange={e => setQuantity(parseFloat(e.target.value))}
+                  startAdornment={
+                    <InputAdornment position="start">
+                      <div className="logo-holder">{sohmImg}</div>
+                    </InputAdornment>
+                  }
+                  labelWidth={0}
+                  endAdornment={
+                    <InputAdornment position="end">
+                      <Button variant="text" onClick={setMax}>
+                        <Trans>Max</Trans>
+                      </Button>
+                    </InputAdornment>
+                  }
+                />
+              </FormControl>
+              <Button
+                className="pool-withdraw-button"
+                variant="contained"
+                color="primary"
+                disabled={isPendingTxn(pendingTransactions, "pool_withdraw")}
+                onClick={() => onWithdraw("withdraw")}
+                style={{ margin: "5px" }}
+              >
+                {exitFee > 0
+                  ? txnButtonText(pendingTransactions, "pool_withdraw", t`Withdraw Early & pay` + exitFee + " sOHM")
+                  : txnButtonText(pendingTransactions, "pool_withdraw", t`Withdraw sOHM`)}
+                {/* Withdraw sOHM */}
+              </Button>
             </Box>
-          )}
-          {exitFee > 0 && (
-            <Box margin={1}>
-              <Typography color="error">
-                <Trans>Early withdraw will incur a fairness fee of {exitFee}.</Trans> &nbsp;
-                <Link
-                  href="https://v3.docs.pooltogether.com/protocol/prize-pool/fairness"
-                  target="_blank"
-                  rel="noreferrer"
-                  color="primary"
-                >
-                  <br />
-                  <Trans>Read more about Fairness</Trans>{" "}
-                  <SvgIcon component={ArrowUp} style={{ fontSize: "1rem", verticalAlign: "middle" }} />
-                </Link>
-              </Typography>
-            </Box>
-          )}
-          {/* NOTE (Appleseed): added this bc I kept losing track of which accounts I had sOHM in during testing */}
-          <div className={`stake-user-data`}>
-            <div className="data-row">
-              <Typography variant="body1" align="left">
-                <Trans>Your Pooled Balance (withdrawable)</Trans>
-              </Typography>
-              <Typography variant="body1" align="right">
-                {isPoolLoading ? (
-                  <Skeleton width="80px" />
-                ) : (
-                  <>{new Intl.NumberFormat("en-US").format(poolBalance)} 33T</>
-                )}
-              </Typography>
+            {newOdds > 0 && quantity > 0 && (
+              <Box padding={1}>
+                <Typography color="error" variant="body2">
+                  <Trans>
+                    Withdrawing {quantity} sOHM reduces your odds of winning to 1 in {newOdds}
+                  </Trans>
+                  &nbsp;
+                </Typography>
+              </Box>
+            )}
+            {exitFee > 0 && (
+              <Box margin={1}>
+                <Typography color="error">
+                  <Trans>Early withdraw will incur a fairness fee of {exitFee}.</Trans> &nbsp;
+                  <Link
+                    href="https://v3.docs.pooltogether.com/protocol/prize-pool/fairness"
+                    target="_blank"
+                    rel="noreferrer"
+                    color="primary"
+                  >
+                    <br />
+                    <Trans>Read more about Fairness</Trans>{" "}
+                    <SvgIcon component={ArrowUp} style={{ fontSize: "1rem", verticalAlign: "middle" }} />
+                  </Link>
+                </Typography>
+              </Box>
+            )}
+            {/* NOTE (Appleseed): added this bc I kept losing track of which accounts I had sOHM in during testing */}
+            <div className={`stake-user-data`}>
+              <div className="data-row">
+                <Typography variant="body1" align="left">
+                  <Trans>Your Pooled Balance (withdrawable)</Trans>
+                </Typography>
+                <Typography variant="body1" align="right">
+                  {isPoolLoading ? (
+                    <Skeleton width="80px" />
+                  ) : (
+                    <>{new Intl.NumberFormat("en-US").format(poolBalance)} 33T</>
+                  )}
+                </Typography>
+              </div>
             </div>
-          </div>
-        </Box>
-      )}
-    </Box>
+          </Box>
+        )}
+      </Box>
+    </>
   );
 };
 


### PR DESCRIPTION
Nuances:
1. 33-t is not properly refreshing due to networkId issues relating to the previous network Redux changes, so we quickly forced networkId = 1 when the default networkId state (-1) is present
2. turned off `rngQueryFunc` which polled the backend for current pool status, this will reduce unnecessary contract calls until the pool is turned back on
3. added `The pool has been temporarily disabled for V2 Migration` text in `PoolWithdraw.jsx`