### PR TITLE
Moving Treasury Top Level Metrics to Shared Metric Component

### DIFF
--- a/src/components/Metric/Metric.tsx
+++ b/src/components/Metric/Metric.tsx
@@ -1,20 +1,27 @@
-import { Typography } from "@material-ui/core";
+import { Typography, TypographyTypeMap } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
+import InfoTooltip from "src/components/InfoTooltip/InfoTooltip";
 
 interface MetricProps {
   className?: string;
   label?: string;
   metric?: string;
   isLoading?: boolean;
+  labelVariant?: TypographyTypeMap["props"]["variant"];
+  metricVariant?: TypographyTypeMap["props"]["variant"];
+  tooltip?: string;
 }
 
 const Metric = (props: MetricProps) => {
   return (
     <div className={props.className}>
-      <Typography variant="h5" color="textSecondary">
+      <Typography variant={props.labelVariant || `h5`} color="textSecondary">
         {props.label}
+        {props.tooltip && <InfoTooltip message={props.tooltip} children={undefined} />}
       </Typography>
-      <Typography variant="h4">{props.isLoading ? <span>{props.metric}</span> : <Skeleton width="150px" />}</Typography>
+      <Typography variant={props.metricVariant || `h4`} style={{ width: "100%" }}>
+        {props.isLoading ? <Skeleton width="100%" /> : <span>{props.metric}</span>}
+      </Typography>
     </div>
   );
 };

--- a/src/views/Stake/Stake.tsx
+++ b/src/views/Stake/Stake.tsx
@@ -217,7 +217,7 @@ function Stake() {
                       className="stake-apy"
                       label={t`APY`}
                       metric={`${formattedTrimmedStakingAPY}%`}
-                      isLoading={stakingAPY ? true : false}
+                      isLoading={stakingAPY ? false : true}
                     />
                   </Grid>
 
@@ -226,7 +226,7 @@ function Stake() {
                       className="stake-tvl"
                       label={t`Total Value Deposited`}
                       metric={formattedStakingTVL}
-                      isLoading={stakingTVL ? true : false}
+                      isLoading={stakingTVL ? false : true}
                     />
                   </Grid>
 
@@ -235,7 +235,7 @@ function Stake() {
                       className="stake-index"
                       label={t`Current Index`}
                       metric={`${formattedCurrentIndex} OHM`}
-                      isLoading={currentIndex ? true : false}
+                      isLoading={currentIndex ? false : true}
                     />
                   </Grid>
                 </Grid>

--- a/src/views/TreasuryDashboard/components/Metric/Metric.js
+++ b/src/views/TreasuryDashboard/components/Metric/Metric.js
@@ -1,94 +1,91 @@
 import { useSelector } from "react-redux";
-import { Skeleton } from "@material-ui/lab";
-import { Typography, Box } from "@material-ui/core";
 import { trim, formatCurrency } from "../../../../helpers";
-import InfoTooltip from "src/components/InfoTooltip/InfoTooltip.jsx";
+import Metric from "src/components/Metric/Metric";
+import { t } from "@lingui/macro";
 
-export const Metric = props => <Box className={`metric ${props.className}`}>{props.children}</Box>;
-
-Metric.Value = props => <Typography variant="h5">{props.children || <Skeleton type="text" />}</Typography>;
-
-Metric.Title = props => (
-  <Typography variant="h6" color="textSecondary">
-    {props.children}
-  </Typography>
-);
+const sharedProps = {
+  labelVariant: "h6",
+  metricVariant: "h5",
+};
 
 export const MarketCap = () => {
-  const marketCap = useSelector(state => state.app.marketCap);
-
+  const marketCap = useSelector(state => state.app.marketCap || 0);
   return (
-    <Metric className="market">
-      <Metric.Title>Market Cap</Metric.Title>
-      <Metric.Value>{marketCap && formatCurrency(marketCap, 0)}</Metric.Value>
-    </Metric>
+    <Metric
+      className="metric market"
+      label={t`Market Cap`}
+      metric={formatCurrency(marketCap, 0)}
+      isLoading={marketCap ? false : true}
+      {...sharedProps}
+    />
   );
 };
 
 export const OHMPrice = () => {
   const marketPrice = useSelector(state => state.app.marketPrice);
-
   return (
-    <Metric className="price">
-      <Metric.Title>OHM Price</Metric.Title>
-      <Metric.Value>{marketPrice && formatCurrency(marketPrice, 2)}</Metric.Value>
-    </Metric>
+    <Metric
+      className="metric price"
+      label={t`OHM Price`}
+      metric={marketPrice && formatCurrency(marketPrice, 2)}
+      isLoading={marketPrice ? false : true}
+      {...sharedProps}
+    />
   );
 };
 
 export const CircSupply = () => {
   const circSupply = useSelector(state => state.app.circSupply);
   const totalSupply = useSelector(state => state.app.totalSupply);
-
   const isDataLoaded = circSupply && totalSupply;
-
   return (
-    <Metric className="circ">
-      <Metric.Title>Circulating Supply (total)</Metric.Title>
-      <Metric.Value>{isDataLoaded && parseInt(circSupply) + " / " + parseInt(totalSupply)}</Metric.Value>
-    </Metric>
+    <Metric
+      className="metric circ"
+      label={t`Circulating Supply (total)`}
+      metric={isDataLoaded && parseInt(circSupply) + " / " + parseInt(totalSupply)}
+      isLoading={isDataLoaded ? false : true}
+      {...sharedProps}
+    />
   );
 };
 
 export const BackingPerOHM = () => {
   const backingPerOhm = useSelector(state => state.app.treasuryMarketValue / state.app.circSupply);
-
   return (
-    <Metric className="bpo">
-      <Metric.Title>Backing per OHM</Metric.Title>
-      <Metric.Value>{!isNaN(backingPerOhm) && formatCurrency(backingPerOhm, 2)}</Metric.Value>
-    </Metric>
+    <Metric
+      className="metric bpo"
+      label={t`Backing per OHM`}
+      metric={!isNaN(backingPerOhm) && formatCurrency(backingPerOhm, 2)}
+      isLoading={backingPerOhm ? false : true}
+      {...sharedProps}
+    />
   );
 };
 
 export const CurrentIndex = () => {
   const currentIndex = useSelector(state => state.app.currentIndex);
-
   return (
-    <Metric className="index">
-      <Metric.Title>
-        Current Index
-        <InfoTooltip message="The current index tracks the amount of sOHM accumulated since the beginning of staking. Basically, how much sOHM one would have if they staked and held a single OHM from day 1." />
-      </Metric.Title>
-      <Metric.Value>{currentIndex && trim(currentIndex, 2) + " sOHM"}</Metric.Value>
-    </Metric>
+    <Metric
+      className="metric index"
+      label={t`Current Index`}
+      metric={currentIndex && trim(currentIndex, 2) + " sOHM"}
+      isLoading={currentIndex ? false : true}
+      {...sharedProps}
+      tooltip="The current index tracks the amount of sOHM accumulated since the beginning of staking. Basically, how much sOHM one would have if they staked and held a single OHM from day 1."
+    />
   );
 };
 
 export const WSOHMPrice = () => {
   const wsOhmPrice = useSelector(state => state.app.marketPrice * state.app.currentIndex);
-
   return (
-    <Metric className="wsoprice">
-      <Metric.Title>
-        wsOHM Price
-        <InfoTooltip
-          message={
-            "wsOHM = sOHM * index\n\nThe price of wsOHM is equal to the price of OHM multiplied by the current index"
-          }
-        />
-      </Metric.Title>
-      <Metric.Value>{wsOhmPrice && formatCurrency(wsOhmPrice, 2)}</Metric.Value>
-    </Metric>
+    <Metric
+      className="metric wsoprice"
+      label={t`wsOHM Price`}
+      metric={wsOhmPrice && formatCurrency(wsOhmPrice, 2)}
+      isLoading={wsOhmPrice ? false : true}
+      {...sharedProps}
+      tooltip={`wsOHM = sOHM * index\n\nThe price of wsOHM is equal to the price of OHM multiplied by the current index`}
+    />
   );
 };


### PR DESCRIPTION
This PR migrates the current Treasury Metrics into the shared component that's live on the Stake view.

Highlights to help with review: 
- Functionality of `Metric` Component expanded to support additional functionality from Treasury Dashboard. 
- Specifically:
-- Tooltip support
-- Default Typography variant override for both label and metric

As an added bonus I discovered there was no l10n support on the treasury dashboard top level metrics. This change also brings l10n support.

Before (FR l10n):
![image](https://user-images.githubusercontent.com/95196612/145144623-00f45f14-6844-4e1c-a6e5-abd366cbef86.png)

After (FR l10n): 
![image](https://user-images.githubusercontent.com/95196612/145144546-fcf6225c-2232-4e83-b3b9-e1e533c033c6.png)

