### PR TITLE
make stake-v2 show up when no assets are detected (not old assets && …

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -296,7 +296,8 @@ function App() {
             </Route>
 
             <Route path="/stake">
-              {newAssetsDetected ? (
+              {/* if newAssets or 0 assets */}
+              {newAssetsDetected || (!newAssetsDetected && !oldAssetsDetected) ? (
                 <Stake />
               ) : (
                 <V1Stake


### PR DESCRIPTION
…not new assets).

Previously when a wallet connects to the site & that wallet as 0 assets (0 new assets & 0 old assets) then Stake-v1 would appear & prompt the user to migrate.

This change detects when a user has both 0 new & 0 old & shows stake v2.