### PR TITLE
clean up migrate modal when no Old Assets Detected & add link to Stak…

### DIFF
--- a/src/components/Migration/MigrationModal.jsx
+++ b/src/components/Migration/MigrationModal.jsx
@@ -66,6 +66,17 @@ function MigrationModal({ open, handleOpen, handleClose }) {
     return state.pendingTransactions;
   });
 
+  const oldAssetsDetected = useAppSelector(state => {
+    return (
+      state.account.balances &&
+      (Number(state.account.balances.sohmV1) ||
+      Number(state.account.balances.ohmV1) ||
+      Number(state.account.balances.wsohm)
+        ? true
+        : false)
+    );
+  });
+
   let rows = [];
   let isMigrationComplete = useSelector(state => state.account.isMigrationComplete);
   const networkId = useAppSelector(state => state.network.networkId);
@@ -160,7 +171,7 @@ function MigrationModal({ open, handleOpen, handleClose }) {
               </Button>
               <Box paddingRight={6}>
                 <Typography id="migration-modal-title" variant="h6" component="h2">
-                  {isMigrationComplete
+                  {isMigrationComplete || !oldAssetsDetected
                     ? "Migration complete"
                     : isAllApproved
                     ? "You are now ready to migrate"
@@ -169,7 +180,7 @@ function MigrationModal({ open, handleOpen, handleClose }) {
               </Box>
               <Box />
             </Box>
-            {isMigrationComplete ? null : (
+            {isMigrationComplete || !oldAssetsDetected ? null : (
               <Box paddingTop={4}>
                 <Typography id="migration-modal-description" variant="body1">
                   {isAllApproved
@@ -243,7 +254,7 @@ function MigrationModal({ open, handleOpen, handleClose }) {
                         </Typography>
                       </TableCell>
                       <TableCell align="left">
-                        {isMigrationComplete ? (
+                        {isMigrationComplete || !oldAssetsDetected ? (
                           <Typography align="center" className={classes.custom}>
                             Migrated
                           </Typography>
@@ -280,11 +291,13 @@ function MigrationModal({ open, handleOpen, handleClose }) {
                 color="primary"
                 variant="contained"
                 disabled={!isAllApproved || isPendingTxn(pendingTransactions, "migrate_all")}
-                onClick={isMigrationComplete ? handleClose : onMigrate}
+                onClick={isMigrationComplete || !oldAssetsDetected ? handleClose : onMigrate}
               >
                 <Box marginX={4} marginY={0.5}>
                   <Typography>
-                    {isMigrationComplete ? "Close" : txnButtonText(pendingTransactions, "migrate_all", "Migrate")}
+                    {isMigrationComplete || !oldAssetsDetected
+                      ? "Close"
+                      : txnButtonText(pendingTransactions, "migrate_all", "Migrate")}
                   </Typography>
                 </Box>
               </Button>

--- a/src/views/V1-Stake/V1-Stake.jsx
+++ b/src/views/V1-Stake/V1-Stake.jsx
@@ -344,9 +344,9 @@ function V1Stake({ oldAssetsDetected, setMigrationModalOpen, hasActiveV1Bonds })
                           )}
                         </TabPanel>
                       ) : (
-                        <TabPanel value={view} index={0} className="stake-tab-panel">
+                        <TabPanel value={view} index={0} className="stake-tab-panel call-to-action">
                           <Button
-                            className="stake-button"
+                            className="migrate-button"
                             variant="contained"
                             color="primary"
                             onClick={() => {

--- a/src/views/V1-Stake/V1-Stake.jsx
+++ b/src/views/V1-Stake/V1-Stake.jsx
@@ -39,6 +39,7 @@ import { error } from "../../slices/MessagesSlice";
 import { ethers } from "ethers";
 import { getMigrationAllowances } from "src/slices/AccountSlice";
 import { useAppSelector } from "src/hooks";
+import { useHistory } from "react-router-dom";
 
 function a11yProps(index) {
   return {
@@ -52,6 +53,7 @@ const ohmImg = getOhmTokenImage(16, 16);
 
 function V1Stake({ oldAssetsDetected, setMigrationModalOpen, hasActiveV1Bonds }) {
   const dispatch = useDispatch();
+  const history = useHistory();
   const { provider, address, connect } = useWeb3Context();
 
   const chainID = useAppSelector(state => state.network.networkId);
@@ -175,6 +177,16 @@ function V1Stake({ oldAssetsDetected, setMigrationModalOpen, hasActiveV1Bonds })
   const stakingRebasePercentage = trim(stakingRebase * 100, 4);
   const nextRewardValue = trim((stakingRebasePercentage / 100) * trimmedBalance, 4);
 
+  const goToV2Stake = () => {
+    history.push("/stake");
+  };
+
+  // useEffect(() => {
+  //   if (!oldAssetsDetected) {
+  //     history.push("/stake");
+  //   }
+  // }, []);
+
   return (
     <div id="v1-stake-view">
       <Zoom in={true} onEntered={() => setZoomed(true)}>
@@ -270,6 +282,8 @@ function V1Stake({ oldAssetsDetected, setMigrationModalOpen, hasActiveV1Bonds })
                           <>
                             {hasActiveV1Bonds
                               ? "Once your current bonds have been claimed, you can migrate your assets to stake more OHM"
+                              : !oldAssetsDetected
+                              ? "All your assets are migrated"
                               : "You must complete the migration of your assest to stake additional OHM"}
                           </>
                         ) : (
@@ -321,13 +335,26 @@ function V1Stake({ oldAssetsDetected, setMigrationModalOpen, hasActiveV1Bonds })
                         <Skeleton width="150px" />
                       )}
 
-                      {!hasActiveV1Bonds && (
+                      {!hasActiveV1Bonds && oldAssetsDetected ? (
                         <TabPanel value={view} index={0} className="stake-tab-panel">
                           {isAllowanceDataLoading ? (
                             <Skeleton />
                           ) : (
                             <MigrateButton setMigrationModalOpen={setMigrationModalOpen} btnText={"Migrate"} />
                           )}
+                        </TabPanel>
+                      ) : (
+                        <TabPanel value={view} index={0} className="stake-tab-panel">
+                          <Button
+                            className="stake-button"
+                            variant="contained"
+                            color="primary"
+                            onClick={() => {
+                              goToV2Stake();
+                            }}
+                          >
+                            Go to Stake V2
+                          </Button>
                         </TabPanel>
                       )}
 


### PR DESCRIPTION
…e V2

 If user navigates to `/v1-stake` && no Old Assets are detected the stake view still shows "Migrate" button. Potentially a user doesn't realize their on the `/v1-stake`... so update the view in this case to hide the "Migrate" button & show a "Go to Stake V2" button.
 
 Previous Implementation for user with no Old Assets
![image](https://user-images.githubusercontent.com/80423742/145932468-50243027-ba9a-446f-ac2a-c6eed1159e88.png)

New Implementation
![image](https://user-images.githubusercontent.com/80423742/145932808-5f83a51c-7faa-45d5-9f8e-868e1982e668.png)

