### PR TITLE
default staking to sOHM, fix staking conversion text, smaller textbox

### DIFF
--- a/src/views/Stake/Stake.tsx
+++ b/src/views/Stake/Stake.tsx
@@ -219,7 +219,7 @@ function Stake() {
   }).format(stakingTVL);
   const formattedCurrentIndex = trim(Number(currentIndex), 1);
 
-  const [checked, setChecked] = useState(true);
+  const [checked, setChecked] = useState(false);
 
   const handleCheck = (e: ChangeEvent<HTMLInputElement>) => {
     setChecked(e.target.checked);
@@ -238,6 +238,7 @@ function Stake() {
               onChange={e => handleCheck(e)}
               color="primary"
               inputProps={{ "aria-label": "checkbox" }}
+              className="stake-to-ohm-checkbox"
             />
           </Box>
           <Box width="100%">
@@ -247,7 +248,7 @@ function Stake() {
                 `Staking ${quantity.toFixed(4)} OHM to ${(quantity / Number(currentIndex)).toFixed(4)} gOHM`}
               {view === 1 &&
                 checked &&
-                `Unstaking ${quantity.toFixed(4)} gOHM to ${(quantity * Number(currentIndex)).toFixed(4)} OHM`}
+                `Unstaking ${(quantity / Number(currentIndex)).toFixed(4)} gOHM to ${quantity.toFixed(4)} OHM`}
               {view === 0 && !checked && "Stake to gOHM instead"}
               {view === 1 && !checked && "Unstake from gOHM instead"}
             </Typography>

--- a/src/views/Stake/stake.scss
+++ b/src/views/Stake/stake.scss
@@ -11,6 +11,12 @@
     line-height: 110% !important;
   }
 
+  .stake-to-ohm-checkbox {
+    svg{
+      font-size: 0.6em;
+    }
+  }
+
   .stake-tab-buttons {
     margin-bottom: 0.25rem;
   }


### PR DESCRIPTION
'staking 0.12 gOMH to 10.5 ohm' text fixed.  highest priority.  
Also default staking/unstaking between ohm/sohm
checkbox smaller