### PR TITLE
Improve/tighten `eslint` configuration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-# folders
-build/
-node_modules/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,5 +37,7 @@ module.exports = {
     "unused-imports/no-unused-imports": "error",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
+    "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/ban-ts-ignore": "off",
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/eslint-recommended",
   ],
+  plugins: ["simple-import-sort"],
   rules: {
     "prettier/prettier": ["error"],
     "import/prefer-default-export": "off",
@@ -32,5 +33,6 @@ module.exports = {
     "no-nested-ternary": "off",
     "no-restricted-syntax": "off",
     "no-plusplus": "off",
+    "simple-import-sort/imports": "error",
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,4 +40,5 @@ module.exports = {
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/ban-ts-ignore": "off",
   },
+  ignorePatterns: ["build", "node_modules"],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,8 +10,13 @@ module.exports = {
       jsx: true,
     },
   },
-  extends: ["plugin:prettier/recommended", "prettier/react", "prettier/@typescript-eslint"],
-  plugins: ["prettier"],
+  extends: [
+    "react-app",
+    "plugin:prettier/recommended",
+    "plugin:react-hooks/recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+  ],
   rules: {
     "prettier/prettier": ["error"],
     "import/prefer-default-export": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/eslint-recommended",
   ],
-  plugins: ["simple-import-sort"],
+  plugins: ["simple-import-sort", "unused-imports"],
   rules: {
     "prettier/prettier": ["error"],
     "import/prefer-default-export": "off",
@@ -34,5 +34,6 @@ module.exports = {
     "no-restricted-syntax": "off",
     "no-plusplus": "off",
     "simple-import-sort/imports": "error",
+    "unused-imports/no-unused-imports": "error",
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,5 +35,7 @@ module.exports = {
     "no-plusplus": "off",
     "simple-import-sort/imports": "error",
     "unused-imports/no-unused-imports": "error",
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,7 @@ module.exports = {
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/ban-ts-ignore": "off",
+    "no-undef": "error",
   },
   ignorePatterns: ["build", "node_modules"],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,4 +42,8 @@ module.exports = {
     "no-undef": "error",
   },
   ignorePatterns: ["build", "node_modules"],
+  globals: {
+    React: true,
+    JSX: true,
+  },
 };

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "eject": "react-scripts eject",
     "start": "react-scripts start",
     "test": "react-scripts test",
-    "lint": "eslint --config ./.eslintrc.js --ignore-path ./.eslintignore ./src/",
+    "lint": "eslint --config ./.eslintrc.js ./src/",
     "lint:fix": "prettier --write ./src/ & yarn lint --fix",
     "surge": "surge ./build",
     "ship": "yarn surge",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,9 @@
     "gulp-debug": "^4.0.0",
     "gulp-less": "^5.0.0",
     "gulp-postcss": "^9.0.0",
+    "husky": "^7.0.4",
     "less-plugin-npm-import": "^2.1.0",
+    "lint-staged": "^12.1.3",
     "prettier": "^2.0.5",
     "surge": "^0.21.5",
     "type-graphql": "^1.1.1",
@@ -149,7 +151,8 @@
     "lingui:fetch": "git submodule update --init --remote src/locales/translations",
     "typechain:build": "yarn run typechain --target ethers-v5 --out-dir src/typechain src/abi/*.json src/abi/**/*.json",
     "preinstall": "[ ! -e src/locales/translations/.git ] && yarn lingui:fetch || exit 0",
-    "postinstall": "yarn typechain:build && yarn lingui:compile"
+    "postinstall": "yarn typechain:build && yarn lingui:compile",
+    "prepare": "husky install"
   },
   "resolutions": {
     "**/immer": "9.0.6",
@@ -160,5 +163,8 @@
     "**/node-fetch": "2.6.1",
     "**/nth-check": "2.0.1",
     "**/ansi-regex": "5.0.1"
+  },
+  "lint-staged": {
+    "*.{jsx,js,tsx,ts}": "eslint --quiet --config ./.eslintrc.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -165,6 +165,6 @@
     "**/ansi-regex": "5.0.1"
   },
   "lint-staged": {
-    "*.{jsx,js,tsx,ts}": "eslint --quiet --config ./.eslintrc.js"
+    "*.{jsx,js,tsx,ts}": "eslint --quiet --fix --config ./.eslintrc.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "start": "react-scripts start",
     "test": "react-scripts test",
     "lint": "eslint --config ./.eslintrc.js --ignore-path ./.eslintignore ./src/",
+    "lint:fix": "prettier --write ./src/ & yarn lint --fix",
     "surge": "surge ./build",
     "ship": "yarn surge",
     "theme": "npx gulp less",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "eject": "react-scripts eject",
     "start": "react-scripts start",
     "test": "react-scripts test",
-    "lint": "eslint --config ./.eslintrc.js ./src/",
+    "lint": "eslint --config ./.eslintrc.js ./src/ --ext .jsx,.js,.tsx,.ts",
     "lint:fix": "prettier --write ./src/ & yarn lint --fix",
     "surge": "surge ./build",
     "ship": "yarn surge",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "gulp": "^4.0.2",
     "gulp-csso": "^4.0.1",
     "gulp-debug": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -124,9 +124,6 @@
     "type-graphql": "^1.1.1",
     "typechain": "^6.0.2"
   },
-  "eslintConfig": {
-    "extends": "react-app"
-  },
   "scripts": {
     "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "eject": "react-scripts eject",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "gulp": "^4.0.2",
     "gulp-csso": "^4.0.1",
     "gulp-debug": "^4.0.0",

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,5 +1,6 @@
-import React from "react";
 import { render } from "@testing-library/react";
+import React from "react";
+
 import App from "./App";
 
 // eslint-disable-next-line no-undef

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,57 +1,54 @@
-import { ThemeProvider } from "@material-ui/core/styles";
-import { useEffect, useState, useCallback } from "react";
-import { Route, Redirect, Switch, useLocation } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "react-query";
-import { useDispatch, useSelector } from "react-redux";
+import "./style.scss";
+
 import { useMediaQuery } from "@material-ui/core";
-import { makeStyles } from "@material-ui/core/styles";
 import CssBaseline from "@material-ui/core/CssBaseline";
-import useTheme from "./hooks/useTheme";
-import useBonds, { IAllBondData } from "./hooks/Bonds";
-import { useAddress, useWeb3Context } from "./hooks/web3Context";
-import useSegmentAnalytics from "./hooks/useSegmentAnalytics";
-import { segmentUA } from "./helpers/userAnalyticHelpers";
-import { shouldTriggerSafetyCheck } from "./helpers";
+import { ThemeProvider } from "@material-ui/core/styles";
+import { makeStyles } from "@material-ui/core/styles";
+import { useCallback, useEffect, useState } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { useDispatch } from "react-redux";
+import { Redirect, Route, Switch, useLocation } from "react-router-dom";
+import MigrationModal from "src/components/Migration/MigrationModal";
+import projectData from "src/views/Give/projects.json";
 
-import { calcBondDetails } from "./slices/BondSlice";
-import { loadAppDetails } from "./slices/AppSlice";
-import { loadAccountDetails, calculateUserBondDetails, getMigrationAllowances } from "./slices/AccountSlice";
-import { getZapTokenBalances } from "./slices/ZapSlice";
-import { info } from "./slices/MessagesSlice";
-
-import {
-  Stake,
-  ChooseBond,
-  Bond,
-  TreasuryDashboard,
-  PoolTogether,
-  Zap,
-  Wrap,
-  V1Stake,
-  CausesDashboard,
-  DepositYield,
-  RedeemYield,
-} from "./views";
+import Announcement from "./components/Announcement/Announcement";
+import CallToAction from "./components/CallToAction/CallToAction";
+import Messages from "./components/Messages/Messages";
+import NavDrawer from "./components/Sidebar/NavDrawer.jsx";
 import Sidebar from "./components/Sidebar/Sidebar.jsx";
 import TopBar from "./components/TopBar/TopBar.jsx";
-import CallToAction from "./components/CallToAction/CallToAction";
-import NavDrawer from "./components/Sidebar/NavDrawer.jsx";
-import Messages from "./components/Messages/Messages";
-import NotFound from "./views/404/NotFound";
-import MigrationModal from "src/components/Migration/MigrationModal";
-import ChangeNetwork from "./views/ChangeNetwork/ChangeNetwork";
-import { dark as darkTheme } from "./themes/dark.js";
-import { light as lightTheme } from "./themes/light.js";
-import { girth as gTheme } from "./themes/girth.js";
-import { v4 as uuidv4 } from "uuid";
-import "./style.scss";
-import { useGoogleAnalytics } from "./hooks/useGoogleAnalytics";
-import { initializeNetwork } from "./slices/NetworkSlice";
+import { shouldTriggerSafetyCheck } from "./helpers";
+import { segmentUA } from "./helpers/userAnalyticHelpers";
 import { useAppSelector } from "./hooks";
-import { Project } from "src/components/GiveProject/project.type";
+import useBonds, { IAllBondData } from "./hooks/Bonds";
+import { useGoogleAnalytics } from "./hooks/useGoogleAnalytics";
+import useSegmentAnalytics from "./hooks/useSegmentAnalytics";
+import useTheme from "./hooks/useTheme";
+import { useAddress, useWeb3Context } from "./hooks/web3Context";
+import { calculateUserBondDetails, getMigrationAllowances, loadAccountDetails } from "./slices/AccountSlice";
+import { loadAppDetails } from "./slices/AppSlice";
+import { calcBondDetails } from "./slices/BondSlice";
+import { info } from "./slices/MessagesSlice";
+import { initializeNetwork } from "./slices/NetworkSlice";
+import { getZapTokenBalances } from "./slices/ZapSlice";
+import { dark as darkTheme } from "./themes/dark.js";
+import { girth as gTheme } from "./themes/girth.js";
+import { light as lightTheme } from "./themes/light.js";
+import {
+  Bond,
+  CausesDashboard,
+  ChooseBond,
+  DepositYield,
+  RedeemYield,
+  Stake,
+  TreasuryDashboard,
+  V1Stake,
+  Wrap,
+  Zap,
+} from "./views";
+import NotFound from "./views/404/NotFound";
+import ChangeNetwork from "./views/ChangeNetwork/ChangeNetwork";
 import ProjectInfo from "./views/Give/ProjectInfo";
-import projectData from "src/views/Give/projects.json";
-import Announcement from "./components/Announcement/Announcement";
 
 // 😬 Sorry for all the console logging
 const DEBUG = false;
@@ -140,7 +137,7 @@ function App() {
     // address lookup on the wrong chain which then throws the error. To properly resolve this,
     // we shouldn't be initializing to networkID=1 in web3Context without first listening for the
     // network. To actually test rinkeby, change setnetworkID equal to 4 before testing.
-    let loadProvider = provider;
+    const loadProvider = provider;
 
     if (whichDetails === "app") {
       loadApp(loadProvider);

--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -1,14 +1,13 @@
 /* eslint-disable global-require */
+import { i18n } from "@lingui/core";
+import { I18nProvider } from "@lingui/react";
 import { FC, useEffect } from "react";
 import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
-import { Web3ContextProvider } from "./hooks/web3Context";
-
-import { i18n } from "@lingui/core";
-import { I18nProvider } from "@lingui/react";
-import { initLocale } from "./locales";
 
 import App from "./App";
+import { Web3ContextProvider } from "./hooks/web3Context";
+import { initLocale } from "./locales";
 import store from "./store";
 
 const Root: FC = () => {

--- a/src/abi/MockSohm.json
+++ b/src/abi/MockSohm.json
@@ -1,468 +1,468 @@
 {
-	"abi": [
-		{
-			"inputs": [
-				{
-					"internalType": "uint256",
-					"name": "initialIndex_",
-					"type": "uint256"
-				},
-				{
-					"internalType": "uint256",
-					"name": "rebasePct_",
-					"type": "uint256"
-				}
-			],
-			"stateMutability": "nonpayable",
-			"type": "constructor"
-		},
-		{
-			"anonymous": false,
-			"inputs": [
-				{
-					"indexed": true,
-					"internalType": "address",
-					"name": "owner",
-					"type": "address"
-				},
-				{
-					"indexed": true,
-					"internalType": "address",
-					"name": "spender",
-					"type": "address"
-				},
-				{
-					"indexed": false,
-					"internalType": "uint256",
-					"name": "value",
-					"type": "uint256"
-				}
-			],
-			"name": "Approval",
-			"type": "event"
-		},
-		{
-			"anonymous": false,
-			"inputs": [
-				{
-					"indexed": true,
-					"internalType": "address",
-					"name": "from",
-					"type": "address"
-				},
-				{
-					"indexed": true,
-					"internalType": "address",
-					"name": "to",
-					"type": "address"
-				},
-				{
-					"indexed": false,
-					"internalType": "uint256",
-					"name": "value",
-					"type": "uint256"
-				}
-			],
-			"name": "Transfer",
-			"type": "event"
-		},
-		{
-			"inputs": [],
-			"name": "DECIMALS",
-			"outputs": [
-				{
-					"internalType": "uint256",
-					"name": "",
-					"type": "uint256"
-				}
-			],
-			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "",
-					"type": "address"
-				}
-			],
-			"name": "_agnosticAmount",
-			"outputs": [
-				{
-					"internalType": "uint256",
-					"name": "",
-					"type": "uint256"
-				}
-			],
-			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "",
-					"type": "address"
-				},
-				{
-					"internalType": "address",
-					"name": "",
-					"type": "address"
-				}
-			],
-			"name": "_allowedValue",
-			"outputs": [
-				{
-					"internalType": "uint256",
-					"name": "",
-					"type": "uint256"
-				}
-			],
-			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"inputs": [],
-			"name": "_index",
-			"outputs": [
-				{
-					"internalType": "uint256",
-					"name": "",
-					"type": "uint256"
-				}
-			],
-			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"inputs": [],
-			"name": "_rebasePct",
-			"outputs": [
-				{
-					"internalType": "uint256",
-					"name": "",
-					"type": "uint256"
-				}
-			],
-			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "owner",
-					"type": "address"
-				},
-				{
-					"internalType": "address",
-					"name": "spender",
-					"type": "address"
-				}
-			],
-			"name": "allowance",
-			"outputs": [
-				{
-					"internalType": "uint256",
-					"name": "",
-					"type": "uint256"
-				}
-			],
-			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "spender_",
-					"type": "address"
-				},
-				{
-					"internalType": "uint256",
-					"name": "value_",
-					"type": "uint256"
-				}
-			],
-			"name": "approve",
-			"outputs": [
-				{
-					"internalType": "bool",
-					"name": "",
-					"type": "bool"
-				}
-			],
-			"stateMutability": "nonpayable",
-			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "owner_",
-					"type": "address"
-				}
-			],
-			"name": "balanceOf",
-			"outputs": [
-				{
-					"internalType": "uint256",
-					"name": "",
-					"type": "uint256"
-				}
-			],
-			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"inputs": [],
-			"name": "decimals",
-			"outputs": [
-				{
-					"internalType": "uint8",
-					"name": "",
-					"type": "uint8"
-				}
-			],
-			"stateMutability": "pure",
-			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "spender",
-					"type": "address"
-				},
-				{
-					"internalType": "uint256",
-					"name": "subtractedValue",
-					"type": "uint256"
-				}
-			],
-			"name": "decreaseAllowance",
-			"outputs": [
-				{
-					"internalType": "bool",
-					"name": "",
-					"type": "bool"
-				}
-			],
-			"stateMutability": "nonpayable",
-			"type": "function"
-		},
-		{
-			"inputs": [],
-			"name": "drip",
-			"outputs": [],
-			"stateMutability": "nonpayable",
-			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "spender",
-					"type": "address"
-				},
-				{
-					"internalType": "uint256",
-					"name": "addedValue",
-					"type": "uint256"
-				}
-			],
-			"name": "increaseAllowance",
-			"outputs": [
-				{
-					"internalType": "bool",
-					"name": "",
-					"type": "bool"
-				}
-			],
-			"stateMutability": "nonpayable",
-			"type": "function"
-		},
-		{
-			"inputs": [],
-			"name": "index",
-			"outputs": [
-				{
-					"internalType": "uint256",
-					"name": "",
-					"type": "uint256"
-				}
-			],
-			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "to_",
-					"type": "address"
-				},
-				{
-					"internalType": "uint256",
-					"name": "amount_",
-					"type": "uint256"
-				}
-			],
-			"name": "mint",
-			"outputs": [
-				{
-					"internalType": "uint256",
-					"name": "",
-					"type": "uint256"
-				}
-			],
-			"stateMutability": "nonpayable",
-			"type": "function"
-		},
-		{
-			"inputs": [],
-			"name": "name",
-			"outputs": [
-				{
-					"internalType": "string",
-					"name": "",
-					"type": "string"
-				}
-			],
-			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "",
-					"type": "address"
-				}
-			],
-			"name": "nextBlockCanClaim",
-			"outputs": [
-				{
-					"internalType": "uint256",
-					"name": "",
-					"type": "uint256"
-				}
-			],
-			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"inputs": [],
-			"name": "rebase",
-			"outputs": [],
-			"stateMutability": "nonpayable",
-			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "uint256",
-					"name": "newIndex_",
-					"type": "uint256"
-				}
-			],
-			"name": "setIndex",
-			"outputs": [],
-			"stateMutability": "nonpayable",
-			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "uint256",
-					"name": "newRebasePct_",
-					"type": "uint256"
-				}
-			],
-			"name": "setRebasePct",
-			"outputs": [],
-			"stateMutability": "nonpayable",
-			"type": "function"
-		},
-		{
-			"inputs": [],
-			"name": "symbol",
-			"outputs": [
-				{
-					"internalType": "string",
-					"name": "",
-					"type": "string"
-				}
-			],
-			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"inputs": [],
-			"name": "totalSupply",
-			"outputs": [
-				{
-					"internalType": "uint256",
-					"name": "",
-					"type": "uint256"
-				}
-			],
-			"stateMutability": "view",
-			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "to_",
-					"type": "address"
-				},
-				{
-					"internalType": "uint256",
-					"name": "value_",
-					"type": "uint256"
-				}
-			],
-			"name": "transfer",
-			"outputs": [
-				{
-					"internalType": "bool",
-					"name": "",
-					"type": "bool"
-				}
-			],
-			"stateMutability": "nonpayable",
-			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address",
-					"name": "from_",
-					"type": "address"
-				},
-				{
-					"internalType": "address",
-					"name": "to_",
-					"type": "address"
-				},
-				{
-					"internalType": "uint256",
-					"name": "value_",
-					"type": "uint256"
-				}
-			],
-			"name": "transferFrom",
-			"outputs": [
-				{
-					"internalType": "bool",
-					"name": "",
-					"type": "bool"
-				}
-			],
-			"stateMutability": "nonpayable",
-			"type": "function"
-		}
-	]
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "initialIndex_",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "rebasePct_",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Approval",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "Transfer",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DECIMALS",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "_agnosticAmount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "_allowedValue",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "_index",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "_rebasePct",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        }
+      ],
+      "name": "allowance",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender_",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value_",
+          "type": "uint256"
+        }
+      ],
+      "name": "approve",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "owner_",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+        {
+          "internalType": "uint8",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "subtractedValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "decreaseAllowance",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "drip",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "spender",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "addedValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "increaseAllowance",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "index",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to_",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount_",
+          "type": "uint256"
+        }
+      ],
+      "name": "mint",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "nextBlockCanClaim",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "rebase",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "newIndex_",
+          "type": "uint256"
+        }
+      ],
+      "name": "setIndex",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "newRebasePct_",
+          "type": "uint256"
+        }
+      ],
+      "name": "setRebasePct",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "to_",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value_",
+          "type": "uint256"
+        }
+      ],
+      "name": "transfer",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "from_",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to_",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value_",
+          "type": "uint256"
+        }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
 }

--- a/src/abi/OlympusFaucet.json
+++ b/src/abi/OlympusFaucet.json
@@ -1,43 +1,43 @@
 {
-	"abi": [
-		{
-			"inputs": [],
-			"stateMutability": "nonpayable",
-			"type": "constructor"
-		},
-		{
-			"stateMutability": "payable",
-			"type": "fallback"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "address payable[]",
-					"name": "_users",
-					"type": "address[]"
-				}
-			],
-			"name": "whitelistUsers",
-			"outputs": [],
-			"stateMutability": "nonpayable",
-			"type": "function"
-		},
-		{
-			"inputs": [
-				{
-					"internalType": "uint256",
-					"name": "amount",
-					"type": "uint256"
-				}
-			],
-			"name": "withdraw",
-			"outputs": [],
-			"stateMutability": "nonpayable",
-			"type": "function"
-		},
-		{
-			"stateMutability": "payable",
-			"type": "receive"
-		}
-	]
+  "abi": [
+    {
+      "inputs": [],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "stateMutability": "payable",
+      "type": "fallback"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address payable[]",
+          "name": "_users",
+          "type": "address[]"
+        }
+      ],
+      "name": "whitelistUsers",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "withdraw",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "stateMutability": "payable",
+      "type": "receive"
+    }
+  ]
 }

--- a/src/abi/OlympusGiving.json
+++ b/src/abi/OlympusGiving.json
@@ -1,3 +1,245 @@
 {
-	"abi": [{"inputs":[{"internalType":"address","name":"sOhm_","type":"address"},{"internalType":"address","name":"authority_","type":"address"}],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"donor_","type":"address"},{"indexed":true,"internalType":"uint256","name":"amount_","type":"uint256"}],"name":"AllWithdrawn","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"contract IOlympusAuthority","name":"authority","type":"address"}],"name":"AuthorityUpdated","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"donor_","type":"address"},{"indexed":true,"internalType":"address","name":"recipient_","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount_","type":"uint256"}],"name":"Deposited","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"donor_","type":"address"},{"indexed":true,"internalType":"address","name":"recipient_","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount_","type":"uint256"}],"name":"Donated","type":"event"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"bool","name":"active_","type":"bool"}],"name":"EmergencyShutdown","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"recipient_","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount_","type":"uint256"}],"name":"Redeemed","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"donor_","type":"address"},{"indexed":true,"internalType":"address","name":"recipient_","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount_","type":"uint256"}],"name":"Withdrawn","type":"event"},{"inputs":[],"name":"authority","outputs":[{"internalType":"contract IOlympusAuthority","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"amount_","type":"uint256"},{"internalType":"address","name":"recipient_","type":"address"}],"name":"deposit","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"depositDisabled","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"donor_","type":"address"},{"internalType":"address","name":"recipient_","type":"address"}],"name":"depositsTo","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bool","name":"active_","type":"bool"}],"name":"disableDeposits","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bool","name":"active_","type":"bool"}],"name":"disableRedeems","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bool","name":"active_","type":"bool"}],"name":"disableWithdrawals","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"donor_","type":"address"},{"internalType":"address","name":"recipient_","type":"address"}],"name":"donatedTo","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"},{"internalType":"uint256","name":"","type":"uint256"}],"name":"donationInfo","outputs":[{"internalType":"address","name":"recipient","type":"address"},{"internalType":"uint256","name":"deposit","type":"uint256"},{"internalType":"uint256","name":"agnosticDeposit","type":"uint256"},{"internalType":"uint256","name":"carry","type":"uint256"},{"internalType":"uint256","name":"indexAtLastChange","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bool","name":"active_","type":"bool"}],"name":"emergencyShutdown","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"donor_","type":"address"}],"name":"getAllDeposits","outputs":[{"internalType":"address[]","name":"","type":"address[]"},{"internalType":"uint256[]","name":"","type":"uint256[]"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"","type":"address"}],"name":"recipientInfo","outputs":[{"internalType":"uint256","name":"totalDebt","type":"uint256"},{"internalType":"uint256","name":"carry","type":"uint256"},{"internalType":"uint256","name":"agnosticDebt","type":"uint256"},{"internalType":"uint256","name":"indexAtLastChange","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"redeem","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"redeemDisabled","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"recipient_","type":"address"}],"name":"redeemableBalance","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"sOHM","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"contract IOlympusAuthority","name":"_newAuthority","type":"address"}],"name":"setAuthority","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"donor_","type":"address"}],"name":"totalDeposits","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"donor_","type":"address"}],"name":"totalDonated","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"amount_","type":"uint256"},{"internalType":"address","name":"recipient_","type":"address"}],"name":"withdraw","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"withdrawAll","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"withdrawDisabled","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"}]
+  "abi": [
+    {
+      "inputs": [
+        { "internalType": "address", "name": "sOhm_", "type": "address" },
+        { "internalType": "address", "name": "authority_", "type": "address" }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "donor_", "type": "address" },
+        { "indexed": true, "internalType": "uint256", "name": "amount_", "type": "uint256" }
+      ],
+      "name": "AllWithdrawn",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "contract IOlympusAuthority", "name": "authority", "type": "address" }
+      ],
+      "name": "AuthorityUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "donor_", "type": "address" },
+        { "indexed": true, "internalType": "address", "name": "recipient_", "type": "address" },
+        { "indexed": false, "internalType": "uint256", "name": "amount_", "type": "uint256" }
+      ],
+      "name": "Deposited",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "donor_", "type": "address" },
+        { "indexed": true, "internalType": "address", "name": "recipient_", "type": "address" },
+        { "indexed": false, "internalType": "uint256", "name": "amount_", "type": "uint256" }
+      ],
+      "name": "Donated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [{ "indexed": false, "internalType": "bool", "name": "active_", "type": "bool" }],
+      "name": "EmergencyShutdown",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "recipient_", "type": "address" },
+        { "indexed": false, "internalType": "uint256", "name": "amount_", "type": "uint256" }
+      ],
+      "name": "Redeemed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "donor_", "type": "address" },
+        { "indexed": true, "internalType": "address", "name": "recipient_", "type": "address" },
+        { "indexed": false, "internalType": "uint256", "name": "amount_", "type": "uint256" }
+      ],
+      "name": "Withdrawn",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "authority",
+      "outputs": [{ "internalType": "contract IOlympusAuthority", "name": "", "type": "address" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "amount_", "type": "uint256" },
+        { "internalType": "address", "name": "recipient_", "type": "address" }
+      ],
+      "name": "deposit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "depositDisabled",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "donor_", "type": "address" },
+        { "internalType": "address", "name": "recipient_", "type": "address" }
+      ],
+      "name": "depositsTo",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "bool", "name": "active_", "type": "bool" }],
+      "name": "disableDeposits",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "bool", "name": "active_", "type": "bool" }],
+      "name": "disableRedeems",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "bool", "name": "active_", "type": "bool" }],
+      "name": "disableWithdrawals",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "donor_", "type": "address" },
+        { "internalType": "address", "name": "recipient_", "type": "address" }
+      ],
+      "name": "donatedTo",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "address", "name": "", "type": "address" },
+        { "internalType": "uint256", "name": "", "type": "uint256" }
+      ],
+      "name": "donationInfo",
+      "outputs": [
+        { "internalType": "address", "name": "recipient", "type": "address" },
+        { "internalType": "uint256", "name": "deposit", "type": "uint256" },
+        { "internalType": "uint256", "name": "agnosticDeposit", "type": "uint256" },
+        { "internalType": "uint256", "name": "carry", "type": "uint256" },
+        { "internalType": "uint256", "name": "indexAtLastChange", "type": "uint256" }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "bool", "name": "active_", "type": "bool" }],
+      "name": "emergencyShutdown",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "donor_", "type": "address" }],
+      "name": "getAllDeposits",
+      "outputs": [
+        { "internalType": "address[]", "name": "", "type": "address[]" },
+        { "internalType": "uint256[]", "name": "", "type": "uint256[]" }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "name": "recipientInfo",
+      "outputs": [
+        { "internalType": "uint256", "name": "totalDebt", "type": "uint256" },
+        { "internalType": "uint256", "name": "carry", "type": "uint256" },
+        { "internalType": "uint256", "name": "agnosticDebt", "type": "uint256" },
+        { "internalType": "uint256", "name": "indexAtLastChange", "type": "uint256" }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    { "inputs": [], "name": "redeem", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+    {
+      "inputs": [],
+      "name": "redeemDisabled",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "recipient_", "type": "address" }],
+      "name": "redeemableBalance",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "sOHM",
+      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "contract IOlympusAuthority", "name": "_newAuthority", "type": "address" }],
+      "name": "setAuthority",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "donor_", "type": "address" }],
+      "name": "totalDeposits",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{ "internalType": "address", "name": "donor_", "type": "address" }],
+      "name": "totalDonated",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        { "internalType": "uint256", "name": "amount_", "type": "uint256" },
+        { "internalType": "address", "name": "recipient_", "type": "address" }
+      ],
+      "name": "withdraw",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    { "inputs": [], "name": "withdrawAll", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+    {
+      "inputs": [],
+      "name": "withdrawDisabled",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
 }

--- a/src/abi/OlympusMockGiving.json
+++ b/src/abi/OlympusMockGiving.json
@@ -1,321 +1,275 @@
 {
   "abi": [
     {
-      "inputs":[
-        {"internalType":"address","name":"sOhm_","type":"address"}
-      ],
-      "stateMutability":"nonpayable",
-      "type":"constructor"
+      "inputs": [{ "internalType": "address", "name": "sOhm_", "type": "address" }],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
     },
     {
-      "anonymous":false,
-      "inputs":[
-        {"indexed":false,"internalType":"address","name":"donor_","type":"address"},
-        {"indexed":false,"internalType":"uint256","name":"amount_","type":"uint256"}
+      "anonymous": false,
+      "inputs": [
+        { "indexed": false, "internalType": "address", "name": "donor_", "type": "address" },
+        { "indexed": false, "internalType": "uint256", "name": "amount_", "type": "uint256" }
       ],
-      "name":"AllWithdrawn",
-      "type":"event"
+      "name": "AllWithdrawn",
+      "type": "event"
     },
     {
-      "anonymous":false,
-      "inputs":[
-        {"indexed":false,"internalType":"address","name":"donor_","type":"address"},
-        {"indexed":false,"internalType":"address","name":"recipient_","type":"address"},
-        {"indexed":false,"internalType":"uint256","name":"amount_","type":"uint256"}
+      "anonymous": false,
+      "inputs": [
+        { "indexed": false, "internalType": "address", "name": "donor_", "type": "address" },
+        { "indexed": false, "internalType": "address", "name": "recipient_", "type": "address" },
+        { "indexed": false, "internalType": "uint256", "name": "amount_", "type": "uint256" }
       ],
-      "name":"Deposited",
-      "type":"event"
+      "name": "Deposited",
+      "type": "event"
     },
     {
-      "anonymous":false,
-      "inputs":[
-        {"indexed":false,"internalType":"bool","name":"active_","type":"bool"}
-      ],
-      "name":"EmergencyShutdown",
-      "type":"event"
+      "anonymous": false,
+      "inputs": [{ "indexed": false, "internalType": "bool", "name": "active_", "type": "bool" }],
+      "name": "EmergencyShutdown",
+      "type": "event"
     },
     {
-      "anonymous":false,
-      "inputs":[
-        {"indexed":true,"internalType":"address","name":"previousOwner","type":"address"},
-        {"indexed":true,"internalType":"address","name":"newOwner","type":"address"}
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+        { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
       ],
-      "name":"OwnershipPulled",
-      "type":"event"
+      "name": "OwnershipPulled",
+      "type": "event"
     },
     {
-      "anonymous":false,
-      "inputs":[
-        {"indexed":true,"internalType":"address","name":"previousOwner","type":"address"},
-        {"indexed":true,"internalType":"address","name":"newOwner","type":"address"}
+      "anonymous": false,
+      "inputs": [
+        { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+        { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
       ],
-      "name":"OwnershipPushed",
-      "type":"event"
+      "name": "OwnershipPushed",
+      "type": "event"
     },
     {
-      "anonymous":false,
-      "inputs":[
-        {"indexed":false,"internalType":"address","name":"recipient_","type":"address"},
-        {"indexed":false,"internalType":"uint256","name":"amount_","type":"uint256"}
+      "anonymous": false,
+      "inputs": [
+        { "indexed": false, "internalType": "address", "name": "recipient_", "type": "address" },
+        { "indexed": false, "internalType": "uint256", "name": "amount_", "type": "uint256" }
       ],
-      "name":"Redeemed",
-      "type":"event"
+      "name": "Redeemed",
+      "type": "event"
     },
     {
-      "anonymous":false,
-      "inputs":[
-        {"indexed":false,"internalType":"address","name":"donor_","type":"address"},
-        {"indexed":false,"internalType":"address","name":"recipient_","type":"address"},
-        {"indexed":false,"internalType":"uint256","name":"amount_","type":"uint256"}
+      "anonymous": false,
+      "inputs": [
+        { "indexed": false, "internalType": "address", "name": "donor_", "type": "address" },
+        { "indexed": false, "internalType": "address", "name": "recipient_", "type": "address" },
+        { "indexed": false, "internalType": "uint256", "name": "amount_", "type": "uint256" }
       ],
-      "name":"Withdrawn",
-      "type":"event"
+      "name": "Withdrawn",
+      "type": "event"
     },
     {
-      "inputs":[],
-      "name":"DECIMALS",
-      "outputs":[
-        {"internalType":"uint256","name":"","type":"uint256"}
-      ],
-      "stateMutability":"view",
-      "type":"function"
+      "inputs": [],
+      "name": "DECIMALS",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-      "inputs":[
-        {"internalType":"uint256","name":"amount_","type":"uint256"},
-        {"internalType":"address","name":"recipient_","type":"address"}
+      "inputs": [
+        { "internalType": "uint256", "name": "amount_", "type": "uint256" },
+        { "internalType": "address", "name": "recipient_", "type": "address" }
       ],
-      "name":"deposit",
-      "outputs":[],
-      "stateMutability":"nonpayable",
-      "type":"function"
+      "name": "deposit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-      "inputs":[],
-      "name":"depositDisabled",
-      "outputs":[
-        {"internalType":"bool","name":"","type":"bool"}
-      ],
-      "stateMutability":"view",
-      "type":"function"
+      "inputs": [],
+      "name": "depositDisabled",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-      "inputs":[
-        {"internalType":"address","name":"donor_","type":"address"},
-        {"internalType":"address","name":"recipient_","type":"address"}
+      "inputs": [
+        { "internalType": "address", "name": "donor_", "type": "address" },
+        { "internalType": "address", "name": "recipient_", "type": "address" }
       ],
-      "name":"depositsTo",
-      "outputs":[
-        {"internalType":"uint256","name":"","type":"uint256"}
-      ],
-      "stateMutability":"view",
-      "type":"function"
+      "name": "depositsTo",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-      "inputs":[
-        {"internalType":"bool","name":"active_","type":"bool"}
-      ],
-      "name":"disableDeposits",
-      "outputs":[],
-      "stateMutability":"nonpayable",
-      "type":"function"
+      "inputs": [{ "internalType": "bool", "name": "active_", "type": "bool" }],
+      "name": "disableDeposits",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-      "inputs":[
-        {"internalType":"bool","name":"active_","type":"bool"}
-      ],
-      "name":"disableRedeems",
-      "outputs":[],
-      "stateMutability":"nonpayable",
-      "type":"function"
+      "inputs": [{ "internalType": "bool", "name": "active_", "type": "bool" }],
+      "name": "disableRedeems",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-      "inputs":[
-        {"internalType":"bool","name":"active_","type":"bool"}
-      ],
-      "name":"disableWithdrawals",
-      "outputs":[],
-      "stateMutability":"nonpayable",
-      "type":"function"
+      "inputs": [{ "internalType": "bool", "name": "active_", "type": "bool" }],
+      "name": "disableWithdrawals",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-      "inputs":[
-        {"internalType":"address","name":"donor_","type":"address"},
-        {"internalType":"address","name":"recipient_","type":"address"}
+      "inputs": [
+        { "internalType": "address", "name": "donor_", "type": "address" },
+        { "internalType": "address", "name": "recipient_", "type": "address" }
       ],
-      "name":"donatedTo",
-      "outputs":[
-        {"internalType":"uint256","name":"","type":"uint256"}
-      ],
-      "stateMutability":"view",
-      "type":"function"
+      "name": "donatedTo",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-      "inputs":[
-        {"internalType":"address","name":"","type":"address"},
-        {"internalType":"uint256","name":"","type":"uint256"}
+      "inputs": [
+        { "internalType": "address", "name": "", "type": "address" },
+        { "internalType": "uint256", "name": "", "type": "uint256" }
       ],
-      "name":"donationInfo",
-      "outputs":[
-        {"internalType":"address","name":"recipient","type":"address"},
-        {"internalType":"uint256","name":"deposit","type":"uint256"},
-        {"internalType":"uint256","name":"agnosticDeposit","type":"uint256"},
-        {"internalType":"uint256","name":"carry","type":"uint256"},
-        {"internalType":"uint256","name":"indexAtLastChange","type":"uint256"}
+      "name": "donationInfo",
+      "outputs": [
+        { "internalType": "address", "name": "recipient", "type": "address" },
+        { "internalType": "uint256", "name": "deposit", "type": "uint256" },
+        { "internalType": "uint256", "name": "agnosticDeposit", "type": "uint256" },
+        { "internalType": "uint256", "name": "carry", "type": "uint256" },
+        { "internalType": "uint256", "name": "indexAtLastChange", "type": "uint256" }
       ],
-      "stateMutability":"view",
-      "type":"function"
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-      "inputs":[
-        {"internalType":"bool","name":"active_","type":"bool"}
-      ],
-      "name":"emergencyShutdown",
-      "outputs":[],
-      "stateMutability":"nonpayable",
-      "type":"function"
+      "inputs": [{ "internalType": "bool", "name": "active_", "type": "bool" }],
+      "name": "emergencyShutdown",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-      "inputs":[
-        {"internalType":"address","name":"donor_","type":"address"}
+      "inputs": [{ "internalType": "address", "name": "donor_", "type": "address" }],
+      "name": "getAllDeposits",
+      "outputs": [
+        { "internalType": "address[]", "name": "", "type": "address[]" },
+        { "internalType": "uint256[]", "name": "", "type": "uint256[]" }
       ],
-      "name":"getAllDeposits",
-      "outputs":[
-        {"internalType":"address[]","name":"","type":"address[]"},
-        {"internalType":"uint256[]","name":"","type":"uint256[]"}
-      ],
-      "stateMutability":"view",
-      "type":"function"
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-      "inputs":[],
-      "name":"owner",
-      "outputs":[
-        {"internalType":"address","name":"","type":"address"}
-      ],
-      "stateMutability":"view",
-      "type":"function"
+      "inputs": [],
+      "name": "owner",
+      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-      "inputs":[],
-      "name":"pullManagement",
-      "outputs":[],
-      "stateMutability":"nonpayable",
-      "type":"function"
+      "inputs": [],
+      "name": "pullManagement",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-      "inputs":[
-        {"internalType":"address","name":"newOwner_","type":"address"}
-      ],
-      "name":"pushManagement",
-      "outputs":[],
-      "stateMutability":"nonpayable",
-      "type":"function"
+      "inputs": [{ "internalType": "address", "name": "newOwner_", "type": "address" }],
+      "name": "pushManagement",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-      "inputs":[
-        {"internalType":"address","name":"","type":"address"}
+      "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "name": "recipientInfo",
+      "outputs": [
+        { "internalType": "uint256", "name": "totalDebt", "type": "uint256" },
+        { "internalType": "uint256", "name": "carry", "type": "uint256" },
+        { "internalType": "uint256", "name": "agnosticDebt", "type": "uint256" },
+        { "internalType": "uint256", "name": "indexAtLastChange", "type": "uint256" }
       ],
-      "name":"recipientInfo",
-      "outputs":[
-        {"internalType":"uint256","name":"totalDebt","type":"uint256"},
-        {"internalType":"uint256","name":"carry","type":"uint256"},
-        {"internalType":"uint256","name":"agnosticDebt","type":"uint256"},
-        {"internalType":"uint256","name":"indexAtLastChange","type":"uint256"}
-      ],
-      "stateMutability":"view",
-      "type":"function"
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-      "inputs":[],
-      "name":"redeem",
-      "outputs":[],
-      "stateMutability":"nonpayable",
-      "type":"function"
+      "inputs": [],
+      "name": "redeem",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-      "inputs":[],
-      "name":"redeemDisabled",
-      "outputs":[
-        {"internalType":"bool","name":"","type":"bool"}
-      ],
-      "stateMutability":"view",
-      "type":"function"
+      "inputs": [],
+      "name": "redeemDisabled",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-      "inputs":[
-        {"internalType":"address","name":"recipient_","type":"address"}
-      ],
-      "name":"redeemableBalance",
-      "outputs":[
-        {"internalType":"uint256","name":"","type":"uint256"}
-      ],
-      "stateMutability":"view",
-      "type":"function"
+      "inputs": [{ "internalType": "address", "name": "recipient_", "type": "address" }],
+      "name": "redeemableBalance",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-      "inputs":[],
-      "name":"renounceManagement",
-      "outputs":[],
-      "stateMutability":"nonpayable",
-      "type":"function"
+      "inputs": [],
+      "name": "renounceManagement",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-      "inputs":[],
-      "name":"sOHM",
-      "outputs":[
-        {"internalType":"address","name":"","type":"address"}
-      ],
-      "stateMutability":"view",
-      "type":"function"
+      "inputs": [],
+      "name": "sOHM",
+      "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-      "inputs":[
-        {"internalType":"address","name":"donor_","type":"address"}
-      ],
-      "name":"totalDeposits",
-      "outputs":[
-        {"internalType":"uint256","name":"","type":"uint256"}
-      ],
-      "stateMutability":"view",
-      "type":"function"
+      "inputs": [{ "internalType": "address", "name": "donor_", "type": "address" }],
+      "name": "totalDeposits",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-      "inputs":[
-        {"internalType":"address","name":"donor_","type":"address"}
-      ],
-      "name":"totalDonated",
-      "outputs":[
-        {"internalType":"uint256","name":"","type":"uint256"}
-      ],
-      "stateMutability":"view",
-      "type":"function"
+      "inputs": [{ "internalType": "address", "name": "donor_", "type": "address" }],
+      "name": "totalDonated",
+      "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
-      "inputs":[
-        {"internalType":"uint256","name":"amount_","type":"uint256"},
-        {"internalType":"address","name":"recipient_","type":"address"}
+      "inputs": [
+        { "internalType": "uint256", "name": "amount_", "type": "uint256" },
+        { "internalType": "address", "name": "recipient_", "type": "address" }
       ],
-      "name":"withdraw",
-      "outputs":[],
-      "stateMutability":"nonpayable",
-      "type":"function"
+      "name": "withdraw",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-      "inputs":[],
-      "name":"withdrawAll",
-      "outputs":[],
-      "stateMutability":"nonpayable",
-      "type":"function"
+      "inputs": [],
+      "name": "withdrawAll",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
     },
     {
-      "inputs":[],
-      "name":"withdrawDisabled",
-      "outputs":[
-        {"internalType":"bool","name":"","type":"bool"}
-      ],
-      "stateMutability":"view",
-      "type":"function"
+      "inputs": [],
+      "name": "withdrawDisabled",
+      "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+      "stateMutability": "view",
+      "type": "function"
     }
   ]
 }

--- a/src/components/Announcement/Announcement.jsx
+++ b/src/components/Announcement/Announcement.jsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
-import { useSelector } from "react-redux";
-import { Box, IconButton, Paper, SvgIcon, Typography } from "@material-ui/core";
-import { NETWORKS, NEWEST_NETWORK_ID } from "src/constants";
-import Pill from "../Pill/Pill";
-import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
 import "./Announcement.scss";
+
+import { Box, IconButton, Paper, SvgIcon, Typography } from "@material-ui/core";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
+import { useState } from "react";
+
+import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
+import Pill from "../Pill/Pill";
 
 function Announcement() {
   const [newNetworkVisible, setNewNetworkVisible] = useState(true);

--- a/src/components/CallToAction/CallToAction.jsx
+++ b/src/components/CallToAction/CallToAction.jsx
@@ -1,8 +1,9 @@
-import { useSelector } from "react-redux";
-import { Box, Typography, Button, SvgIcon } from "@material-ui/core";
-import { t, Trans } from "@lingui/macro";
-import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
 import "./calltoaction.scss";
+
+import { t, Trans } from "@lingui/macro";
+import { Box, Button, SvgIcon, Typography } from "@material-ui/core";
+
+import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
 
 export const LearnMoreButton = () => {
   return (

--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -1,8 +1,9 @@
-import CustomTooltip from "./CustomTooltip";
-import InfoTooltip from "../InfoTooltip/InfoTooltip";
-import ExpandedChart from "./ExpandedChart";
+import "./chart.scss";
+
+import { Box, CircularProgress, SvgIcon, Typography } from "@material-ui/core";
+import { Skeleton } from "@material-ui/lab";
+import { format } from "date-fns";
 import { useEffect, useState } from "react";
-import { ReactComponent as Fullscreen } from "../../assets/icons/fullscreen.svg";
 import {
   Area,
   AreaChart,
@@ -16,11 +17,12 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { Box, CircularProgress, SvgIcon, Typography } from "@material-ui/core";
-import { Skeleton } from "@material-ui/lab";
+
+import { ReactComponent as Fullscreen } from "../../assets/icons/fullscreen.svg";
 import { trim } from "../../helpers";
-import { format } from "date-fns";
-import "./chart.scss";
+import InfoTooltip from "../InfoTooltip/InfoTooltip";
+import CustomTooltip from "./CustomTooltip";
+import ExpandedChart from "./ExpandedChart";
 
 const formatCurrency = c => {
   return new Intl.NumberFormat("en-US", {

--- a/src/components/Chart/CustomTooltip.jsx
+++ b/src/components/Chart/CustomTooltip.jsx
@@ -1,5 +1,6 @@
-import { Box, Paper, Typography } from "@material-ui/core";
 import "./customtooltip.scss";
+
+import { Box, Paper, Typography } from "@material-ui/core";
 
 const renderDate = (index, payload, item) => {
   return index === payload.length - 1 ? (

--- a/src/components/Chart/ExpandedChart.jsx
+++ b/src/components/Chart/ExpandedChart.jsx
@@ -1,7 +1,8 @@
-import InfoTooltip from "../InfoTooltip/InfoTooltip";
 import { Backdrop, Box, Fade, Modal, Paper, SvgIcon, Typography, useMediaQuery } from "@material-ui/core";
-import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
 import { ResponsiveContainer } from "recharts";
+
+import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
+import InfoTooltip from "../InfoTooltip/InfoTooltip";
 
 function ExpandedChart({
   open,

--- a/src/components/ConnectButton.jsx
+++ b/src/components/ConnectButton.jsx
@@ -1,6 +1,6 @@
+import { Trans } from "@lingui/macro";
 import { Button } from "@material-ui/core";
 import { useWeb3Context } from "src/hooks/web3Context";
-import { Trans } from "@lingui/macro";
 
 const ConnectButton = () => {
   const { connect } = useWeb3Context();

--- a/src/components/EducationCard.tsx
+++ b/src/components/EducationCard.tsx
@@ -1,13 +1,12 @@
-import { Box, Button, Container, Grid, Icon, Paper, SvgIcon, Typography } from "@material-ui/core";
-import { ReactComponent as sOhmTokenImg } from "../assets/tokens/token_sOHM.svg";
-import { ReactComponent as yieldImg } from "../assets/icons/yield.svg";
-import { ReactComponent as vaultLockImg } from "../assets/icons/vault-lock.svg";
-import { ReactComponent as arrowRightImg } from "../assets/icons/arrow-right.svg";
-import { shorten } from "src/helpers";
-import InfoTooltip from "src/components/InfoTooltip/InfoTooltip";
 import { t, Trans } from "@lingui/macro";
+import { Box, SvgIcon, Typography } from "@material-ui/core";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
 import { Skeleton } from "@material-ui/lab";
+
+import { ReactComponent as arrowRightImg } from "../assets/icons/arrow-right.svg";
+import { ReactComponent as vaultLockImg } from "../assets/icons/vault-lock.svg";
+import { ReactComponent as yieldImg } from "../assets/icons/yield.svg";
+import { ReactComponent as sOhmTokenImg } from "../assets/tokens/token_sOHM.svg";
 
 const viewBox = "0 0 100 100";
 // The sOHM SVG is 100x100px, whereas the others are 50x50px

--- a/src/components/GiveProject/ProjectCard.tsx
+++ b/src/components/GiveProject/ProjectCard.tsx
@@ -1,47 +1,48 @@
+import { t, Trans } from "@lingui/macro";
 import {
-  Button,
-  Typography,
-  Grid,
-  Paper,
-  Tooltip,
-  Link,
-  LinearProgress,
-  useMediaQuery,
-  Container,
   Box,
+  Button,
+  Container,
+  Grid,
+  LinearProgress,
+  Link,
+  Paper,
   SvgIcon,
+  Tooltip,
+  Typography,
+  useMediaQuery,
 } from "@material-ui/core";
-import Countdown from "react-countdown";
-import { ReactComponent as ClockIcon } from "../../assets/icons/clock.svg";
-import { ReactComponent as CheckIcon } from "../../assets/icons/check-circle.svg";
-import { ReactComponent as ArrowRight } from "../../assets/icons/arrow-right.svg";
-import { ReactComponent as DonorsIcon } from "../../assets/icons/donors.svg";
-import { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
 import { useTheme } from "@material-ui/core/styles";
-import { useAppDispatch } from "src/hooks";
-import { getDonorNumbers, getRedemptionBalancesAsync } from "src/helpers/GiveRedemptionBalanceHelper";
-import { useWeb3Context } from "src/hooks/web3Context";
 import { Skeleton } from "@material-ui/lab";
 import { BigNumber } from "bignumber.js";
-import { RecipientModal } from "src/views/Give/RecipientModal";
-import { SubmitCallback, CancelCallback } from "src/views/Give/Interfaces";
-import { changeGive, changeMockGive, ACTION_GIVE, isSupportedChain } from "src/slices/GiveThunk";
-import { error } from "../../slices/MessagesSlice";
-import { Project } from "./project.type";
-import { countDecimals, roundToDecimal, toInteger } from "./utils";
-import { ReactComponent as WebsiteIcon } from "../../assets/icons/website.svg";
-import { ReactComponent as DonatedIcon } from "../../assets/icons/donated.svg";
-import { ReactComponent as GoalIcon } from "../../assets/icons/goal.svg";
 import MarkdownIt from "markdown-it";
-import { t, Trans } from "@lingui/macro";
-import { useAppSelector } from "src/hooks";
-import { IAccountSlice } from "src/slices/AccountSlice";
-import { IPendingTxn } from "src/slices/PendingTxnsSlice";
-import { IAppData } from "src/slices/AppSlice";
+import { useEffect, useState } from "react";
+import Countdown from "react-countdown";
+import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
 import { EnvHelper } from "src/helpers/Environment";
+import { getDonorNumbers, getRedemptionBalancesAsync } from "src/helpers/GiveRedemptionBalanceHelper";
+import { useAppDispatch } from "src/hooks";
+import { useAppSelector } from "src/hooks";
+import { useWeb3Context } from "src/hooks/web3Context";
+import { IAccountSlice } from "src/slices/AccountSlice";
+import { IAppData } from "src/slices/AppSlice";
+import { ACTION_GIVE, changeGive, changeMockGive, isSupportedChain } from "src/slices/GiveThunk";
+import { IPendingTxn } from "src/slices/PendingTxnsSlice";
+import { CancelCallback, SubmitCallback } from "src/views/Give/Interfaces";
+import { RecipientModal } from "src/views/Give/RecipientModal";
+
+import { ReactComponent as ArrowRight } from "../../assets/icons/arrow-right.svg";
+import { ReactComponent as CheckIcon } from "../../assets/icons/check-circle.svg";
+import { ReactComponent as ClockIcon } from "../../assets/icons/clock.svg";
+import { ReactComponent as DonatedIcon } from "../../assets/icons/donated.svg";
+import { ReactComponent as DonorsIcon } from "../../assets/icons/donors.svg";
+import { ReactComponent as GoalIcon } from "../../assets/icons/goal.svg";
+import { ReactComponent as WebsiteIcon } from "../../assets/icons/website.svg";
+import { error } from "../../slices/MessagesSlice";
 import { GiveHeader } from "./GiveHeader";
+import { Project } from "./project.type";
+import { countDecimals, roundToDecimal, toInteger } from "./utils";
 
 type CountdownProps = {
   total: number;
@@ -110,7 +111,7 @@ export default function ProjectCard({ project, mode }: ProjectDetailsProps) {
   const svgFillColour: string = theme.palette.type === "light" ? "black" : "white";
 
   useEffect(() => {
-    let items = document.getElementsByClassName("project-container");
+    const items = document.getElementsByClassName("project-container");
     if (items.length > 0) {
       items[0].scrollIntoView();
     }

--- a/src/components/GiveProject/utils.ts
+++ b/src/components/GiveProject/utils.ts
@@ -1,5 +1,5 @@
 export const countDecimals = (value: string): number => {
-  let number = Number(value);
+  const number = Number(value);
   if (Math.floor(number) !== number) {
     return value.split(".")[1].length || 0;
   }

--- a/src/components/InfoTooltip/InfoTooltip.jsx
+++ b/src/components/InfoTooltip/InfoTooltip.jsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
-import { ReactComponent as Info } from "../../assets/icons/info.svg";
-import { Box, Paper, Popper, SvgIcon, Typography } from "@material-ui/core";
 import "./infotooltip.scss";
+
+import { Box, Paper, Popper, SvgIcon, Typography } from "@material-ui/core";
+import { useState } from "react";
+
+import { ReactComponent as Info } from "../../assets/icons/info.svg";
 
 function InfoTooltip({ message, children }) {
   const [anchorEl, setAnchorEl] = useState(null);

--- a/src/components/InfoTooltip/InfoTooltipMulti.jsx
+++ b/src/components/InfoTooltip/InfoTooltipMulti.jsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
-import { ReactComponent as Info } from "../../assets/icons/info.svg";
-import { SvgIcon, Paper, Typography, Box, Popper } from "@material-ui/core";
 import "./infotooltip.scss";
+
+import { Box, Paper, Popper, SvgIcon, Typography } from "@material-ui/core";
+import { useState } from "react";
+
+import { ReactComponent as Info } from "../../assets/icons/info.svg";
 
 /**
  * InfoTooltipMulti allows passing an ARRAY of message strings w each Array Element on a new line

--- a/src/components/Loading/LoadingSplash.jsx
+++ b/src/components/Loading/LoadingSplash.jsx
@@ -1,6 +1,8 @@
-import { Backdrop, Container, SvgIcon } from "@material-ui/core";
-import { ReactComponent as OlympusIcon } from "../../assets/Olympus Logo.svg";
 import "./loading.scss";
+
+import { Backdrop, Container, SvgIcon } from "@material-ui/core";
+
+import { ReactComponent as OlympusIcon } from "../../assets/Olympus Logo.svg";
 
 function LoadingSplash() {
   return (

--- a/src/components/Messages/Messages.jsx
+++ b/src/components/Messages/Messages.jsx
@@ -1,11 +1,13 @@
-import { useState, useEffect } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { close, handle_obsolete } from "../../slices/MessagesSlice";
-import store from "../../store";
-import { LinearProgress, Snackbar, makeStyles } from "@material-ui/core";
+import "./ConsoleInterceptor.js";
+
+import { LinearProgress, makeStyles, Snackbar } from "@material-ui/core";
 import Alert from "@material-ui/lab/Alert";
 import AlertTitle from "@material-ui/lab/AlertTitle";
-import "./ConsoleInterceptor.js";
+import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+
+import { close, handle_obsolete } from "../../slices/MessagesSlice";
+import store from "../../store";
 
 const useStyles = makeStyles({
   root: {
@@ -78,7 +80,6 @@ function Messages() {
       </div>
     </div>
   );
-  return res;
 }
 // Invoke repetedly obsolete messages deletion (should be in slice file but I cannot find a way to access the store from there)
 window.setInterval(() => {

--- a/src/components/Metric/Metric.tsx
+++ b/src/components/Metric/Metric.tsx
@@ -1,8 +1,8 @@
-import { Typography, TypographyTypeMap, Box } from "@material-ui/core";
+import "./Metric.scss";
+
+import { Box, Typography, TypographyTypeMap } from "@material-ui/core";
 import { Skeleton, SkeletonTypeMap } from "@material-ui/lab";
 import InfoTooltip from "src/components/InfoTooltip/InfoTooltip";
-
-import "./Metric.scss";
 
 interface MetricProps {
   className?: string;

--- a/src/components/Metric/MetricCollection.tsx
+++ b/src/components/Metric/MetricCollection.tsx
@@ -1,5 +1,6 @@
+import { Box, Grid, GridSize } from "@material-ui/core";
 import { Children } from "react";
-import { Grid, Box, GridSize } from "@material-ui/core";
+
 import Metric from "./Metric";
 
 /**

--- a/src/components/Migration/MigrationModal.tsx
+++ b/src/components/Migration/MigrationModal.tsx
@@ -1,36 +1,35 @@
+import "./migration-modal.scss";
+
+import { t, Trans } from "@lingui/macro";
 import {
   Backdrop,
   Box,
   Button,
-  ButtonBase,
   Fade,
   Modal,
+  Paper,
   SvgIcon,
   Table,
+  TableBody,
   TableCell,
   TableHead,
   TableRow,
-  TableBody,
   Typography,
-  Paper,
 } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { trim } from "src/helpers";
+import { useWeb3Context } from "src/hooks";
+import { useAppSelector } from "src/hooks";
+import { info } from "src/slices/MessagesSlice";
+import { changeMigrationApproval, migrateAll } from "src/slices/MigrateThunk";
+import { isPendingTxn, txnButtonText } from "src/slices/PendingTxnsSlice";
 
 // import ButtonUnstyled from "@mui/core/ButtonUnstyled";
 import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
-import { makeStyles } from "@material-ui/core/styles";
-import { useDispatch } from "react-redux";
-import { BigNumber } from "ethers";
-import { changeMigrationApproval, migrateAll } from "src/slices/MigrateThunk";
-import { useWeb3Context } from "src/hooks";
-import { useEffect, useMemo } from "react";
-import { isPendingTxn, txnButtonText } from "src/slices/PendingTxnsSlice";
-import { info } from "src/slices/MessagesSlice";
 import InfoTooltip from "../InfoTooltip/InfoTooltip";
-import "./migration-modal.scss";
-import { useAppSelector } from "src/hooks";
-import { trim } from "src/helpers";
-import { t, Trans } from "@lingui/macro";
 const formatCurrency = (c: number) => {
   return new Intl.NumberFormat("en-US", {
     style: "currency",
@@ -83,7 +82,7 @@ function MigrationModal({ open, handleClose }: { open: boolean; handleClose: any
   });
 
   let rows = [];
-  let isMigrationComplete = useAppSelector(state => state.account.isMigrationComplete);
+  const isMigrationComplete = useAppSelector(state => state.account.isMigrationComplete);
 
   const onSeekApproval = (token: string) => {
     dispatch(

--- a/src/components/RebaseTimer/RebaseTimer.jsx
+++ b/src/components/RebaseTimer/RebaseTimer.jsx
@@ -1,12 +1,14 @@
-import { useSelector, useDispatch } from "react-redux";
-import { getRebaseBlock, secondsUntilBlock, prettifySeconds } from "../../helpers";
-import { Box, Typography } from "@material-ui/core";
 import "./rebasetimer.scss";
+
+import { Trans } from "@lingui/macro";
+import { Box, Typography } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 import { useEffect, useMemo, useState } from "react";
-import { loadAppDetails } from "../../slices/AppSlice";
+import { useDispatch, useSelector } from "react-redux";
+
+import { getRebaseBlock, prettifySeconds, secondsUntilBlock } from "../../helpers";
 import { useWeb3Context } from "../../hooks/web3Context";
-import { Trans } from "@lingui/macro";
+import { loadAppDetails } from "../../slices/AppSlice";
 
 function RebaseTimer() {
   const dispatch = useDispatch();

--- a/src/components/Sidebar/NavContent.jsx
+++ b/src/components/Sidebar/NavContent.jsx
@@ -1,40 +1,41 @@
-import { useCallback, useState } from "react";
-import { NavLink, useLocation } from "react-router-dom";
-import Social from "./Social";
-import externalUrls from "./externalUrls";
-import { ReactComponent as StakeIcon } from "../../assets/icons/stake.svg";
-import { ReactComponent as BondIcon } from "../../assets/icons/bond.svg";
-import { ReactComponent as DashboardIcon } from "../../assets/icons/dashboard.svg";
-import { ReactComponent as OlympusIcon } from "../../assets/icons/olympus-nav-header.svg";
-import { ReactComponent as PoolTogetherIcon } from "../../assets/icons/33-together.svg";
-import { ReactComponent as GiveIcon } from "../../assets/icons/give.svg";
-import { ReactComponent as ZapIcon } from "../../assets/icons/zap.svg";
-import { ReactComponent as NewIcon } from "../../assets/icons/new-icon.svg";
-import { ReactComponent as WrapIcon } from "../../assets/icons/wrap.svg";
-import { ReactComponent as BridgeIcon } from "../../assets/icons/bridge.svg";
-import { ReactComponent as ArrowUpIcon } from "../../assets/icons/arrow-up.svg";
-import { ReactComponent as ProIcon } from "../../assets/Olympus Logo.svg";
+import "./sidebar.scss";
+
 import { Trans } from "@lingui/macro";
-import { trim, shorten } from "../../helpers";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Divider,
+  Link,
+  Paper,
+  SvgIcon,
+  Typography,
+} from "@material-ui/core";
+import { ExpandMore } from "@material-ui/icons";
+import { Skeleton } from "@material-ui/lab";
+import { useCallback, useState } from "react";
+import { useSelector } from "react-redux";
+import { NavLink, useLocation } from "react-router-dom";
+import { EnvHelper } from "src/helpers/Environment";
 import { useAddress } from "src/hooks/web3Context";
+
+import { ReactComponent as ArrowUpIcon } from "../../assets/icons/arrow-up.svg";
+import { ReactComponent as BondIcon } from "../../assets/icons/bond.svg";
+import { ReactComponent as BridgeIcon } from "../../assets/icons/bridge.svg";
+import { ReactComponent as DashboardIcon } from "../../assets/icons/dashboard.svg";
+import { ReactComponent as GiveIcon } from "../../assets/icons/give.svg";
+import { ReactComponent as NewIcon } from "../../assets/icons/new-icon.svg";
+import { ReactComponent as OlympusIcon } from "../../assets/icons/olympus-nav-header.svg";
+import { ReactComponent as StakeIcon } from "../../assets/icons/stake.svg";
+import { ReactComponent as WrapIcon } from "../../assets/icons/wrap.svg";
+import { ReactComponent as ZapIcon } from "../../assets/icons/zap.svg";
+import { ReactComponent as ProIcon } from "../../assets/Olympus Logo.svg";
+import { shorten, trim } from "../../helpers";
 import useBonds from "../../hooks/Bonds";
 import useENS from "../../hooks/useENS";
-import {
-  Paper,
-  Link,
-  Box,
-  Typography,
-  SvgIcon,
-  Divider,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-} from "@material-ui/core";
-import { Skeleton } from "@material-ui/lab";
-import "./sidebar.scss";
-import { useSelector } from "react-redux";
-import { EnvHelper } from "src/helpers/Environment";
-import { ExpandMore } from "@material-ui/icons";
+import externalUrls from "./externalUrls";
+import Social from "./Social";
 
 function NavContent() {
   const [isActive] = useState();

--- a/src/components/Sidebar/NavDrawer.jsx
+++ b/src/components/Sidebar/NavDrawer.jsx
@@ -1,5 +1,6 @@
-import { makeStyles } from "@material-ui/core/styles";
 import { SwipeableDrawer } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+
 import NavContent from "./NavContent.jsx";
 
 const drawerWidth = 280;

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -1,6 +1,8 @@
-import { Drawer } from "@material-ui/core";
-import NavContent from "./NavContent.jsx";
 import "./sidebar.scss";
+
+import { Drawer } from "@material-ui/core";
+
+import NavContent from "./NavContent.jsx";
 
 function Sidebar() {
   return (

--- a/src/components/Sidebar/Social.jsx
+++ b/src/components/Sidebar/Social.jsx
@@ -1,8 +1,9 @@
-import { SvgIcon, Link } from "@material-ui/core";
+import { Link, SvgIcon } from "@material-ui/core";
+
+import { ReactComponent as Discord } from "../../assets/icons/discord.svg";
 import { ReactComponent as GitHub } from "../../assets/icons/github.svg";
 import { ReactComponent as Medium } from "../../assets/icons/medium.svg";
 import { ReactComponent as Twitter } from "../../assets/icons/twitter.svg";
-import { ReactComponent as Discord } from "../../assets/icons/discord.svg";
 
 export default function Social() {
   return (

--- a/src/components/Sidebar/externalUrls.jsx
+++ b/src/components/Sidebar/externalUrls.jsx
@@ -1,9 +1,9 @@
+import { Trans } from "@lingui/macro";
+import { SvgIcon } from "@material-ui/core";
+
+import { ReactComponent as DocsIcon } from "../../assets/icons/docs.svg";
 import { ReactComponent as ForumIcon } from "../../assets/icons/forum.svg";
 import { ReactComponent as GovIcon } from "../../assets/icons/governance.svg";
-import { ReactComponent as DocsIcon } from "../../assets/icons/docs.svg";
-import { ReactComponent as BridgeIcon } from "../../assets/icons/bridge.svg";
-import { SvgIcon } from "@material-ui/core";
-import { Trans } from "@lingui/macro";
 
 const externalUrls = [
   {

--- a/src/components/Sidebar/sidebar.scss
+++ b/src/components/Sidebar/sidebar.scss
@@ -125,7 +125,6 @@
   padding-left: 33px;
   margin-top: 8px;
 
-
   .discounts-accordion {
     backdrop-filter: none;
     background-color: inherit;

--- a/src/components/TopBar/LocaleSwitch.tsx
+++ b/src/components/TopBar/LocaleSwitch.tsx
@@ -1,13 +1,13 @@
-import { t } from "@lingui/macro";
+import "./localesmenu.scss";
+
 import { i18n } from "@lingui/core";
+import { t } from "@lingui/macro";
+import { Box, Button, Fade, Paper, Popper, Typography } from "@material-ui/core";
 import { ReferenceObject } from "popper.js";
-import { useState, MouseEvent } from "react";
-import { Popper, Button, Paper, Typography, Box, Fade } from "@material-ui/core";
+import { MouseEvent, useState } from "react";
 
 import FlagIcon from "../../helpers/flagicon.js";
 import { locales, selectLocale } from "../../locales";
-
-import "./localesmenu.scss";
 
 function getLocaleFlag(locale: string) {
   return locales[locale].flag;

--- a/src/components/TopBar/NetworkMenu.jsx
+++ b/src/components/TopBar/NetworkMenu.jsx
@@ -1,9 +1,11 @@
-import { Button, Typography } from "@material-ui/core";
-import { NavLink } from "react-router-dom";
-import React, { useEffect, useState } from "react";
 import "./networkmenu.scss";
+
+import { Button, Typography } from "@material-ui/core";
 import Grid from "@material-ui/core/Grid";
+import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
+import { NavLink } from "react-router-dom";
+
 import { NETWORKS } from "../../constants";
 
 function NetworkMenu() {

--- a/src/components/TopBar/ThemeSwitch.jsx
+++ b/src/components/TopBar/ThemeSwitch.jsx
@@ -1,8 +1,9 @@
-import ToggleButton from "@material-ui/lab/ToggleButton";
-import SvgIcon from "@material-ui/core/SvgIcon";
-import { ReactComponent as SunIcon } from "../../assets/icons/sun.svg";
-import { ReactComponent as MoonIcon } from "../../assets/icons/moon.svg";
 import { t } from "@lingui/macro";
+import SvgIcon from "@material-ui/core/SvgIcon";
+import ToggleButton from "@material-ui/lab/ToggleButton";
+
+import { ReactComponent as MoonIcon } from "../../assets/icons/moon.svg";
+import { ReactComponent as SunIcon } from "../../assets/icons/sun.svg";
 
 function ThemeSwitcher({ theme, toggleTheme }) {
   return (

--- a/src/components/TopBar/TopBar.jsx
+++ b/src/components/TopBar/TopBar.jsx
@@ -1,11 +1,13 @@
-import { AppBar, Toolbar, Box, Button, SvgIcon } from "@material-ui/core";
+import "./topbar.scss";
+
+import { AppBar, Box, Button, SvgIcon, Toolbar } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
+
 import { ReactComponent as MenuIcon } from "../../assets/icons/hamburger.svg";
+import LocaleSwitcher from "./LocaleSwitch.tsx";
 // import OhmMenu from "./OhmMenu.jsx";
 import ThemeSwitcher from "./ThemeSwitch.jsx";
-import LocaleSwitcher from "./LocaleSwitch.tsx";
-import "./topbar.scss";
 import Wallet from "./Wallet";
 
 const useStyles = makeStyles(theme => ({

--- a/src/components/TopBar/Wallet/InitialWalletView.tsx
+++ b/src/components/TopBar/Wallet/InitialWalletView.tsx
@@ -1,35 +1,31 @@
-import { Component, ReactElement, useState } from "react";
+import { Trans } from "@lingui/macro";
 import {
-  useTheme,
-  useMediaQuery,
-  withStyles,
-  SvgIcon,
-  Button,
-  Typography,
   Box,
+  Button,
   Divider,
   IconButton,
   Paper,
+  SvgIcon,
+  Typography,
+  useMediaQuery,
+  useTheme,
+  withStyles,
 } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
-import { ReactComponent as CloseIcon } from "src/assets/icons/x.svg";
-import { ReactComponent as ArrowUpIcon } from "src/assets/icons/arrow-up.svg";
-import { ReactComponent as wethTokenImg } from "src/assets/tokens/wETH.svg";
-import { ReactComponent as fraxTokenImg } from "src/assets/tokens/FRAX.svg";
-import { ReactComponent as daiTokenImg } from "src/assets/tokens/DAI.svg";
-import { ReactComponent as wsOhmTokenImg } from "src/assets/tokens/token_wsOHM.svg";
+import { Component, ReactElement, useState } from "react";
 import { ReactComponent as arrowDown } from "src/assets/icons/arrow-down.svg";
-import { addresses, TOKEN_DECIMALS } from "src/constants";
+import { ReactComponent as ArrowUpIcon } from "src/assets/icons/arrow-up.svg";
+import { ReactComponent as CloseIcon } from "src/assets/icons/x.svg";
+import { ReactComponent as daiTokenImg } from "src/assets/tokens/DAI.svg";
+import { ReactComponent as fraxTokenImg } from "src/assets/tokens/FRAX.svg";
+import { ReactComponent as wsOhmTokenImg } from "src/assets/tokens/token_wsOHM.svg";
+import { ReactComponent as wethTokenImg } from "src/assets/tokens/wETH.svg";
 import { formatCurrency } from "src/helpers";
+import { ohm_dai, ohm_frax } from "src/helpers/AllBonds";
 import { useAppSelector, useWeb3Context } from "src/hooks";
 import useCurrentTheme from "src/hooks/useTheme";
 
-import { ohm_frax, ohm_dai } from "src/helpers/AllBonds";
-
-import { IToken, Token, Tokens, useWallet } from "./Token";
-import { NetworkID } from "src/lib/Bond";
-import { BigNumber } from "ethers";
-import { t, Trans } from "@lingui/macro";
+import { IToken, Tokens, useWallet } from "./Token";
 
 const Borrow = ({
   Icon1,

--- a/src/components/TopBar/Wallet/Token.tsx
+++ b/src/components/TopBar/Wallet/Token.tsx
@@ -1,37 +1,32 @@
-import { useState } from "react";
+import { t } from "@lingui/macro";
 import {
-  SvgIcon,
-  Button,
-  Typography,
-  Box,
   Accordion as MuiAccordion,
-  AccordionSummary as MuiAccordionSummary,
   AccordionDetails,
-  withStyles,
+  AccordionSummary as MuiAccordionSummary,
+  Box,
+  Button,
+  SvgIcon,
+  Typography,
   useTheme,
+  withStyles,
 } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
-
-import { useAppSelector } from "src/hooks";
-import { useWeb3Context } from "src/hooks/web3Context";
-import { addresses, NETWORKS } from "src/constants";
-import { formatCurrency } from "src/helpers";
-import { RootState } from "src/store";
-import { NetworkID } from "src/lib/Bond";
-
+import { useState } from "react";
+import { useQuery } from "react-query";
 import { ReactComponent as MoreIcon } from "src/assets/icons/more.svg";
+import GOhmImg from "src/assets/tokens/gohm.png";
+import Token33tImg from "src/assets/tokens/token_33T.svg";
 import OhmImg from "src/assets/tokens/token_OHM.svg";
 import SOhmImg from "src/assets/tokens/token_sOHM.svg";
 import WsOhmImg from "src/assets/tokens/token_wsOHM.svg";
-import Token33tImg from "src/assets/tokens/token_33T.svg";
-import GOhmImg from "src/assets/tokens/gohm.png";
-
+import { addresses, NETWORKS } from "src/constants";
+import { formatCurrency } from "src/helpers";
 import { segmentUA } from "src/helpers/userAnalyticHelpers";
-import { t } from "@lingui/macro";
-
-import { useQuery } from "react-query";
+import { useAppSelector } from "src/hooks";
+import { useWeb3Context } from "src/hooks/web3Context";
+import { NetworkID } from "src/lib/Bond";
 import { fetchCrossChainBalances } from "src/lib/fetchBalances";
-import { BigNumber } from "ethers";
+import { RootState } from "src/store";
 
 const Accordion = withStyles({
   root: {
@@ -106,7 +101,7 @@ const addTokenToWallet = async (token: IToken, userAddress: string) => {
 
 interface TokenProps extends IToken {
   expanded: boolean;
-  onChangeExpanded: (event: React.ChangeEvent<{}>, isExpanded: boolean) => void;
+  onChangeExpanded: (event: React.ChangeEvent<any>, isExpanded: boolean) => void;
   onAddTokenToWallet: () => void;
   tDecimals: number;
 }

--- a/src/components/TopBar/Wallet/index.tsx
+++ b/src/components/TopBar/Wallet/index.tsx
@@ -1,10 +1,10 @@
+import { t } from "@lingui/macro";
+import { Button, SvgIcon, SwipeableDrawer, Typography, useTheme, withStyles } from "@material-ui/core";
 import { useState } from "react";
-
 import { ReactComponent as WalletIcon } from "src/assets/icons/wallet.svg";
 import { useWeb3Context } from "src/hooks/web3Context";
+
 import InitialWalletView from "./InitialWalletView";
-import { SwipeableDrawer, SvgIcon, Button, Typography, useTheme, withStyles } from "@material-ui/core";
-import { t } from "@lingui/macro";
 
 const WalletButton = ({ openWallet }: { openWallet: () => void }) => {
   const { connect, connected } = useWeb3Context();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,8 @@
-import { NodeHelper } from "./helpers/NodeHelper";
-import { EnvHelper } from "./helpers/Environment";
-import ethereum from "./assets/tokens/wETH.svg";
 import arbitrum from "./assets/arbitrum.png";
 import avalanche from "./assets/tokens/AVAX.svg";
+import ethereum from "./assets/tokens/wETH.svg";
+import { EnvHelper } from "./helpers/Environment";
+import { NodeHelper } from "./helpers/NodeHelper";
 
 export const THE_GRAPH_URL = "https://api.thegraph.com/subgraphs/name/drondin/olympus-protocol-metrics";
 export const EPOCH_INTERVAL = 2200;

--- a/src/graph/poolTogether.schema.graphql
+++ b/src/graph/poolTogether.schema.graphql
@@ -2,7 +2,7 @@
 # source: https://github.com/pooltogether/pooltogether-subgraph-v3/blob/master/schema.graphql
 
 scalar Bytes
-scalar BigInt 
+scalar BigInt
 
 enum PrizePoolState {
   Opened
@@ -16,7 +16,6 @@ enum PrizePoolType {
   Stake
   YieldSource
 }
-
 
 # ID: `${comptroller.address}`
 type Comptroller @entity {
@@ -67,25 +66,21 @@ type PrizePool @entity {
 
   currentPrizeId: BigInt!
   currentState: PrizePoolState!
-  
+
   prizes: [Prize!]! @derivedFrom(field: "prizePool")
   tokenCreditRates: [CreditRate!]! @derivedFrom(field: "prizePool")
   tokenCreditBalances: [CreditBalance!]! @derivedFrom(field: "prizePool")
-
 
   prizePoolAccounts: [PrizePoolAccount!]! @derivedFrom(field: "prizePool")
 
   controlledTokens: [ControlledToken!]! @derivedFrom(field: "controller") # controlled tokens may not exist until transfer is called
 }
 
-
-
 # ID: `${compoundPrizePool.address}`
 type CompoundPrizePool @entity {
   id: ID!
   cToken: Bytes
 }
-
 
 # ID: `${stakePrizePool.address}`
 type StakePrizePool @entity {
@@ -148,7 +143,6 @@ type Prize @entity {
   numberOfExternalAwardedErc20Winners: BigInt
 
   totalTicketSupply: BigInt # cache of num tickets sold when this prize was awarded
-
   awardedControlledTokens: [AwardedControlledToken!]! @derivedFrom(field: "prize")
   awardedExternalErc20Tokens: [AwardedExternalErc20Token!]! @derivedFrom(field: "prize")
   awardedExternalErc721Nfts: [AwardedExternalErc721Nft!]! @derivedFrom(field: "prize")
@@ -163,18 +157,17 @@ type AwardedControlledToken @entity {
   prize: Prize!
 }
 
-
 # ID: `${prize.id}-${token.address} -${winnerAddress} -{Prize::winnerIndex}`
 # dynamically generated type, not mapped to a specific contract
 type AwardedExternalErc20Token @entity {
   id: ID!
 
   address: Bytes!
-  
+
   name: String
   symbol: String
   decimals: BigInt
-  
+
   balanceAwarded: BigInt
   prize: Prize!
   winner: Bytes
@@ -188,11 +181,9 @@ type AwardedExternalErc721Nft @entity {
   address: Bytes!
   tokenIds: [BigInt!]
   prize: Prize
-  
+
   winner: Bytes
 }
-
-
 
 # ID: `${controlledToken.address}`
 type ControlledToken @entity {
@@ -202,13 +193,13 @@ type ControlledToken @entity {
   symbol: String!
   decimals: BigInt
 
-  controller: PrizePool 
+  controller: PrizePool
 
   totalSupply: BigInt!
 
   numberOfHolders: BigInt!
 
-  balances: [ControlledTokenBalance!]! @derivedFrom(field:"controlledToken")
+  balances: [ControlledTokenBalance!]! @derivedFrom(field: "controlledToken")
 }
 
 type ControlledTokenBalance @entity {
@@ -227,7 +218,7 @@ type SingleRandomWinnerExternalErc20Award @entity {
   name: String
   symbol: String
   decimals: BigInt
-  
+
   prizeStrategy: SingleRandomWinnerPrizeStrategy
 }
 
@@ -240,11 +231,10 @@ type SingleRandomWinnerExternalErc721Award @entity {
   prizeStrategy: SingleRandomWinnerPrizeStrategy
 }
 
-# join table 
-type PrizePoolAccount @entity{
+# join table
+type PrizePoolAccount @entity {
   id: ID! #composite prizerpool id - accountid
-
-  prizePool: PrizePool! 
+  prizePool: PrizePool!
   account: Account!
 }
 
@@ -255,8 +245,6 @@ type Account @entity {
   prizePoolAccounts: [PrizePoolAccount!]! @derivedFrom(field: "account")
   controlledTokenBalances: [ControlledTokenBalance!] @derivedFrom(field: "account")
 }
-
-
 
 # ID: `${prizePool.address}-${controlledToken.address}`
 # dynamically generated type, not mapped to a specific contract
@@ -319,7 +307,6 @@ type BalanceDrip @entity {
   deactivated: Boolean!
 }
 
-
 # ID: `${volumeDripId}-${player.address}`
 # dynamically generated type, not mapped to a specific contract
 type VolumeDripPlayer @entity {
@@ -371,31 +358,30 @@ type VolumeDrip @entity {
 type MultipleWinnersPrizeStrategy @entity {
   id: ID!
   owner: Bytes
-  
+
   numberOfWinners: BigInt
-  splitExternalERC20Awards: Boolean 
+  splitExternalERC20Awards: Boolean
 
-
-  tokenListener: Bytes 
-  prizePool: PrizePool 
+  tokenListener: Bytes
+  prizePool: PrizePool
   rng: Bytes
-  
-  ticket: ControlledToken  
+
+  ticket: ControlledToken
   sponsorship: ControlledToken
-  
-  prizePeriodSeconds: BigInt! 
-  prizePeriodStartedAt: BigInt! 
-  prizePeriodEndAt: BigInt! 
+
+  prizePeriodSeconds: BigInt!
+  prizePeriodStartedAt: BigInt!
+  prizePeriodEndAt: BigInt!
 
   prizeSplits: [PrizeSplit!] @derivedFrom(field: "prizeStrategy")
   blockListedAddresses: [Bytes!]
-  
-  externalErc20Awards: [MultipleWinnersExternalErc20Award!]! @derivedFrom(field: "prizeStrategy") 
+
+  externalErc20Awards: [MultipleWinnersExternalErc20Award!]! @derivedFrom(field: "prizeStrategy")
   externalErc721Awards: [MultipleWinnersExternalErc721Award!]! @derivedFrom(field: "prizeStrategy")
 }
 
 # ID: prizeStrategy.address-index
-type PrizeSplit @entity{
+type PrizeSplit @entity {
   id: ID!
   percentage: BigInt!
   target: Bytes!
@@ -412,7 +398,7 @@ type MultipleWinnersExternalErc20Award @entity {
   name: String
   symbol: String
   decimals: BigInt
-  
+
   balanceAwarded: BigInt
   prizeStrategy: MultipleWinnersPrizeStrategy
 }

--- a/src/helpers/33Together.ts
+++ b/src/helpers/33Together.ts
@@ -1,6 +1,7 @@
 import { BigNumber, ethers } from "ethers";
-import { addresses } from "../constants";
 import { trim } from "src/helpers";
+
+import { addresses } from "../constants";
 
 /**
  * Calculates user's odds of winning based on their pool balance
@@ -84,5 +85,5 @@ export const poolTogetherUILinks = (networkId: number): Array<string> => {
  * @param odds current odds as number or a string representing 0 odds
  * @param precision the amount of decimal places to display, defaults to 4
  */
-export const trimOdds = (odds: number | string, precision: number = 4) =>
+export const trimOdds = (odds: number | string, precision = 4) =>
   typeof odds === "string" ? odds : trim(odds, precision);

--- a/src/helpers/AllBonds.ts
+++ b/src/helpers/AllBonds.ts
@@ -1,36 +1,31 @@
-import { StableBond, LPBond, NetworkID, CustomBond, BondType } from "src/lib/Bond";
-import { addresses } from "src/constants";
-
+import { BigNumberish } from "ethers";
+import { abi as CvxBondContract } from "src/abi/bonds/CvxContract.json";
+import { abi as DaiBondContract } from "src/abi/bonds/DaiContract.json";
+import { abi as EthBondContract } from "src/abi/bonds/EthContract.json";
+import { abi as FraxBondContract } from "src/abi/bonds/FraxContract.json";
+import { abi as LusdBondContract } from "src/abi/bonds/LusdContract.json";
+import { abi as BondOhmDaiContract } from "src/abi/bonds/OhmDaiContract.json";
+import { abi as BondOhmEthContract } from "src/abi/bonds/OhmEthContract.json";
+import { abi as FraxOhmBondContract } from "src/abi/bonds/OhmFraxContract.json";
+import { abi as BondOhmLusdContract } from "src/abi/bonds/OhmLusdContract.json";
+import { abi as ierc20Abi } from "src/abi/IERC20.json";
+import { abi as ReserveOhmDaiContract } from "src/abi/reserves/OhmDai.json";
+import { abi as ReserveOhmEthContract } from "src/abi/reserves/OhmEth.json";
+import { abi as ReserveOhmFraxContract } from "src/abi/reserves/OhmFrax.json";
+import { abi as ReserveOhmLusdContract } from "src/abi/reserves/OhmLusd.json";
+import { ReactComponent as CvxImg } from "src/assets/tokens/CVX.svg";
 import { ReactComponent as DaiImg } from "src/assets/tokens/DAI.svg";
-import { ReactComponent as OhmDaiImg } from "src/assets/tokens/OHM-DAI.svg";
 import { ReactComponent as FraxImg } from "src/assets/tokens/FRAX.svg";
+import { ReactComponent as LusdImg } from "src/assets/tokens/LUSD.svg";
+import { ReactComponent as OhmDaiImg } from "src/assets/tokens/OHM-DAI.svg";
 import { ReactComponent as OhmFraxImg } from "src/assets/tokens/OHM-FRAX.svg";
 import { ReactComponent as OhmLusdImg } from "src/assets/tokens/OHM-LUSD.svg";
 import { ReactComponent as OhmEthImg } from "src/assets/tokens/OHM-WETH.svg";
 import { ReactComponent as wETHImg } from "src/assets/tokens/wETH.svg";
-import { ReactComponent as LusdImg } from "src/assets/tokens/LUSD.svg";
-import { ReactComponent as CvxImg } from "src/assets/tokens/CVX.svg";
-
-import { abi as FraxOhmBondContract } from "src/abi/bonds/OhmFraxContract.json";
-import { abi as BondOhmDaiContract } from "src/abi/bonds/OhmDaiContract.json";
-import { abi as BondOhmLusdContract } from "src/abi/bonds/OhmLusdContract.json";
-import { abi as BondOhmEthContract } from "src/abi/bonds/OhmEthContract.json";
-
-import { abi as DaiBondContract } from "src/abi/bonds/DaiContract.json";
-import { abi as ReserveOhmLusdContract } from "src/abi/reserves/OhmLusd.json";
-import { abi as ReserveOhmDaiContract } from "src/abi/reserves/OhmDai.json";
-import { abi as ReserveOhmFraxContract } from "src/abi/reserves/OhmFrax.json";
-import { abi as ReserveOhmEthContract } from "src/abi/reserves/OhmEth.json";
-
-import { abi as FraxBondContract } from "src/abi/bonds/FraxContract.json";
-import { abi as LusdBondContract } from "src/abi/bonds/LusdContract.json";
-import { abi as EthBondContract } from "src/abi/bonds/EthContract.json";
-import { abi as CvxBondContract } from "src/abi/bonds/CvxContract.json";
-
-import { abi as ierc20Abi } from "src/abi/IERC20.json";
-import { getBondCalculator } from "src/helpers/BondCalculator";
-import { BigNumberish } from "ethers";
+import { addresses } from "src/constants";
 import { getTokenPrice } from "src/helpers";
+import { getBondCalculator } from "src/helpers/BondCalculator";
+import { BondType, CustomBond, LPBond, NetworkID, StableBond } from "src/lib/Bond";
 
 // TODO(zx): Further modularize by splitting up reserveAssets into vendor token definitions
 //   and include that in the definition of a bond
@@ -319,7 +314,7 @@ export const cvx = new CustomBond({
     },
   },
   customTreasuryBalanceFunc: async function (this: CustomBond, networkID, provider) {
-    let cvxPrice: number = await getTokenPrice("convex-finance");
+    const cvxPrice: number = await getTokenPrice("convex-finance");
     const token = this.getContractForReserve(networkID, provider);
     let cvxAmount: BigNumberish = await token.balanceOf(addresses[networkID].TREASURY_ADDRESS);
     cvxAmount = Number(cvxAmount.toString()) / Math.pow(10, 18);
@@ -376,7 +371,7 @@ export const cvx_expired = new CustomBond({
     },
   },
   customTreasuryBalanceFunc: async function (this: CustomBond, networkID, provider) {
-    let cvxPrice: number = await getTokenPrice("convex-finance");
+    const cvxPrice: number = await getTokenPrice("convex-finance");
     const token = this.getContractForReserve(networkID, provider);
     let cvxAmount: BigNumberish = await token.balanceOf(addresses[networkID].TREASURY_ADDRESS);
     cvxAmount = Number(cvxAmount.toString()) / Math.pow(10, 18);
@@ -686,7 +681,7 @@ export const ohm_weth = new CustomBond({
       const tokenAmount = await token.balanceOf(addresses[networkID].TREASURY_V2);
       const valuation = await bondCalculator.valuation(tokenAddress || "", tokenAmount);
       const markdown = await bondCalculator.markdown(tokenAddress || "");
-      let tokenUSD =
+      const tokenUSD =
         (Number(valuation.toString()) / Math.pow(10, 9)) * (Number(markdown.toString()) / Math.pow(10, 18));
       return tokenUSD * Number(ethPrice.toString());
     } else {
@@ -697,7 +692,7 @@ export const ohm_weth = new CustomBond({
       const tokenAmount = await token.balanceOf(addresses[networkID].TREASURY_ADDRESS);
       const valuation = await bondCalculator.valuation(tokenAddress || "", tokenAmount);
       const markdown = await bondCalculator.markdown(tokenAddress || "");
-      let tokenUSD =
+      const tokenUSD =
         (Number(valuation.toString()) / Math.pow(10, 9)) * (Number(markdown.toString()) / Math.pow(10, 18));
       return tokenUSD;
     }
@@ -763,7 +758,7 @@ export const ohm_wethOld = new CustomBond({
       const tokenAmount = await token.balanceOf(addresses[networkID].TREASURY_ADDRESS);
       const valuation = await bondCalculator.valuation(tokenAddress || "", tokenAmount);
       const markdown = await bondCalculator.markdown(tokenAddress || "");
-      let tokenUSD =
+      const tokenUSD =
         (Number(valuation.toString()) / Math.pow(10, 9)) * (Number(markdown.toString()) / Math.pow(10, 18));
       return tokenUSD * Number(ethPrice.toString());
     } else {
@@ -774,7 +769,7 @@ export const ohm_wethOld = new CustomBond({
       const tokenAmount = await token.balanceOf(addresses[networkID].TREASURY_ADDRESS);
       const valuation = await bondCalculator.valuation(tokenAddress || "", tokenAmount);
       const markdown = await bondCalculator.markdown(tokenAddress || "");
-      let tokenUSD =
+      const tokenUSD =
         (Number(valuation.toString()) / Math.pow(10, 9)) * (Number(markdown.toString()) / Math.pow(10, 18));
       return tokenUSD;
     }

--- a/src/helpers/BondCalculator.ts
+++ b/src/helpers/BondCalculator.ts
@@ -1,8 +1,9 @@
 import { StaticJsonRpcProvider } from "@ethersproject/providers";
-import { NetworkID } from "src/lib/Bond";
-import { abi as BondCalcContractABI } from "src/abi/BondCalcContract.json";
 import { ethers } from "ethers";
+import { abi as BondCalcContractABI } from "src/abi/BondCalcContract.json";
 import { addresses } from "src/constants";
+import { NetworkID } from "src/lib/Bond";
+
 import { BondCalcContract } from "../typechain";
 
 export const getBondCalculator = (networkID: NetworkID, provider: StaticJsonRpcProvider, v2Bond: boolean) => {

--- a/src/helpers/Environment.ts
+++ b/src/helpers/Environment.ts
@@ -1,5 +1,3 @@
-import { NetworkID } from "src/lib/Bond";
-
 /**
  * Access `process.env` in an environment helper
  * Usage: `EnvHelper.env`
@@ -191,7 +189,7 @@ export class EnvHelper {
 
   static getZapperAPIKey() {
     // EnvHelper.env.REACT_APP_ZAPPER_API
-    let apiKey = EnvHelper.env.REACT_APP_ZAPPER_API;
+    const apiKey = EnvHelper.env.REACT_APP_ZAPPER_API;
     if (!apiKey) {
       console.warn("zaps won't work without REACT_APP_ZAPPER_API key");
     }
@@ -200,7 +198,7 @@ export class EnvHelper {
 
   static getZapperPoolAddress() {
     // EnvHelper.env.REACT_APP_ZAPPER_POOL
-    let zapPool = EnvHelper.env.REACT_APP_ZAPPER_POOL;
+    const zapPool = EnvHelper.env.REACT_APP_ZAPPER_POOL;
     if (!zapPool) {
       console.warn("zaps won't work without REACT_APP_ZAPPER_POOL address");
     }

--- a/src/helpers/GiveRedemptionBalanceHelper.ts
+++ b/src/helpers/GiveRedemptionBalanceHelper.ts
@@ -1,8 +1,8 @@
-import { ethers, BigNumber } from "ethers";
-import { addresses } from "../constants";
+import { BigNumber, ethers } from "ethers";
+
 import { abi as OlympusGiving } from "../abi/OlympusGiving.json";
-import { createAsyncThunk } from "@reduxjs/toolkit";
-import { IBaseAddressAsyncThunk, ICalcUserBondDetailsAsyncThunk } from "../slices/interfaces";
+import { addresses } from "../constants";
+import { IBaseAddressAsyncThunk } from "../slices/interfaces";
 
 interface IUserRecipientInfo {
   totalDebt: string;
@@ -17,7 +17,7 @@ interface IDonorAddresses {
 
 export const getRedemptionBalancesAsync = async ({ address, networkID, provider }: IBaseAddressAsyncThunk) => {
   let redeemableBalance = 0;
-  let recipientInfo: IUserRecipientInfo = {
+  const recipientInfo: IUserRecipientInfo = {
     totalDebt: "",
     carry: "",
     agnosticDebt: "",
@@ -29,7 +29,7 @@ export const getRedemptionBalancesAsync = async ({ address, networkID, provider 
     redeemableBalance = await givingContract.redeemableBalance(address);
 
     try {
-      let recipientInfoData = await givingContract.recipientInfo(address);
+      const recipientInfoData = await givingContract.recipientInfo(address);
       recipientInfo.totalDebt = ethers.utils.formatUnits(recipientInfoData.totalDebt.toNumber(), "gwei");
       recipientInfo.carry = ethers.utils.formatUnits(recipientInfoData.carry.toNumber(), "gwei");
       recipientInfo.agnosticDebt = ethers.utils.formatUnits(recipientInfoData.agnosticDebt.toNumber(), "gwei");
@@ -54,7 +54,7 @@ export const getRedemptionBalancesAsync = async ({ address, networkID, provider 
 
 export const getMockRedemptionBalancesAsync = async ({ address, networkID, provider }: IBaseAddressAsyncThunk) => {
   let redeemableBalance = 0;
-  let recipientInfo: IUserRecipientInfo = {
+  const recipientInfo: IUserRecipientInfo = {
     totalDebt: "",
     carry: "",
     agnosticDebt: "",
@@ -70,7 +70,7 @@ export const getMockRedemptionBalancesAsync = async ({ address, networkID, provi
     redeemableBalance = await givingContract.redeemableBalance(address);
 
     try {
-      let recipientInfoData = await givingContract.recipientInfo(address);
+      const recipientInfoData = await givingContract.recipientInfo(address);
       recipientInfo.totalDebt = ethers.utils.formatUnits(recipientInfoData.totalDebt.toNumber(), "gwei");
       recipientInfo.carry = ethers.utils.formatUnits(recipientInfoData.carry.toNumber(), "gwei");
       recipientInfo.agnosticDebt = ethers.utils.formatUnits(recipientInfoData.agnosticDebt.toNumber(), "gwei");
@@ -113,8 +113,8 @@ export const getDonorNumbers = async ({ address, networkID, provider }: IBaseAdd
   // using the filter, get all events
   const events = await provider.getLogs(filter);
 
-  let donorAddresses: IDonorAddresses = {};
-  let donationsToAddress = [];
+  const donorAddresses: IDonorAddresses = {};
+  const donationsToAddress = [];
   for (let i = 0; i < events.length; i++) {
     const event = events[i];
 

--- a/src/helpers/NodeHelper.ts
+++ b/src/helpers/NodeHelper.ts
@@ -1,7 +1,8 @@
-import { minutesAgo } from "./index";
-import { EnvHelper } from "./Environment";
-import { ethers } from "ethers";
 import { StaticJsonRpcProvider } from "@ethersproject/providers";
+import { ethers } from "ethers";
+
+import { EnvHelper } from "./Environment";
+import { minutesAgo } from "./index";
 
 interface ICurrentStats {
   failedConnectionCount: number;
@@ -67,7 +68,7 @@ export class NodeHelper {
   static _removeNodeFromProviders(providerKey: string, providerUrl: string, networkId: number) {
     // get Object of current removed Nodes
     // key = providerUrl, value = removedAt Timestamp
-    let currentRemovedNodesObj = NodeHelper.currentRemovedNodes;
+    const currentRemovedNodesObj = NodeHelper.currentRemovedNodes;
     if (Object.keys(currentRemovedNodesObj).includes(providerUrl)) {
       // already on the removed nodes list
     } else {
@@ -132,7 +133,7 @@ export class NodeHelper {
    */
   static getNodesUris = (networkId: number) => {
     let allURIs = EnvHelper.getAPIUris(networkId);
-    let invalidNodes = NodeHelper.currentRemovedNodesURIs;
+    const invalidNodes = NodeHelper.currentRemovedNodesURIs;
     // filter invalidNodes out of allURIs
     // this allows duplicates in allURIs, removes both if invalid, & allows both if valid
     allURIs = allURIs.filter(item => !invalidNodes.includes(item));
@@ -171,7 +172,7 @@ export class NodeHelper {
   static checkAllNodesStatus = async (networkId: number) => {
     return await Promise.all(
       NodeHelper.getNodesUris(networkId).map(async URI => {
-        let workingUrl = await NodeHelper.checkNodeStatus(URI, networkId);
+        const workingUrl = await NodeHelper.checkNodeStatus(URI, networkId);
         return workingUrl;
       }),
     );
@@ -215,7 +216,7 @@ export class NodeHelper {
   }) => {
     let liveURL: boolean | string;
     try {
-      let resp = await fetch(url, {
+      const resp = await fetch(url, {
         method: "POST",
         mode: "cors",
         headers: {
@@ -227,7 +228,7 @@ export class NodeHelper {
         throw Error("failed node connection");
       } else {
         // response came back but is it healthy?
-        let jsonResponse = await resp.json();
+        const jsonResponse = await resp.json();
         if (NodeHelper.validityCheck({ nodeMethod, resultVal: jsonResponse.result })) {
           liveURL = url;
         } else {

--- a/src/helpers/QueryParameterHelper.ts
+++ b/src/helpers/QueryParameterHelper.ts
@@ -1,6 +1,6 @@
 export function getParameterByName(name: string, url: string) {
   name = name.replace(/[\[\]]/g, "\\$&");
-  var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+  const regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
     results = regex.exec(url);
   if (!results) return null;
   if (!results[2]) return "";

--- a/src/helpers/index.tsx
+++ b/src/helpers/index.tsx
@@ -1,21 +1,19 @@
-import { EPOCH_INTERVAL, BLOCK_RATE_SECONDS, addresses } from "../constants";
-import { BigNumber, ethers } from "ethers";
-import axios from "axios";
-import { abi as PairContractABI } from "../abi/PairContract.json";
-import { abi as RedeemHelperABI } from "../abi/RedeemHelper.json";
-
-import { SvgIcon } from "@material-ui/core";
-import { ReactComponent as OhmImg } from "../assets/tokens/token_OHM.svg";
-import { ReactComponent as SOhmImg } from "../assets/tokens/token_sOHM.svg";
-
-import { ohm_dai, ohm_weth, ohm_daiOld } from "./AllBonds";
 import { JsonRpcSigner, StaticJsonRpcProvider } from "@ethersproject/providers";
+import { SvgIcon } from "@material-ui/core";
+import axios from "axios";
+import { BigNumber, ethers } from "ethers";
 import { IBaseAsyncThunk } from "src/slices/interfaces";
-import { PairContract, RedeemHelper } from "../typechain";
 import { GOHM__factory } from "src/typechain/factories/GOHM__factory";
 
+import { abi as PairContractABI } from "../abi/PairContract.json";
+import { abi as RedeemHelperABI } from "../abi/RedeemHelper.json";
+import { ReactComponent as OhmImg } from "../assets/tokens/token_OHM.svg";
+import { ReactComponent as SOhmImg } from "../assets/tokens/token_sOHM.svg";
+import { addresses, BLOCK_RATE_SECONDS, EPOCH_INTERVAL } from "../constants";
 import { EnvHelper } from "../helpers/Environment";
 import { NodeHelper } from "../helpers/NodeHelper";
+import { PairContract, RedeemHelper } from "../typechain";
+import { ohm_dai, ohm_daiOld, ohm_weth } from "./AllBonds";
 
 /**
  * gets marketPrice from Ohm-DAI v2
@@ -226,30 +224,30 @@ export const minutesAgo = (x: number) => {
  * ... Math.trunc which accomplishes the same result as parseInt.
  */
 export const subtractDates = (dateA: Date, dateB: Date) => {
-  let msA: number = dateA.getTime();
-  let msB: number = dateB.getTime();
+  const msA: number = dateA.getTime();
+  const msB: number = dateB.getTime();
 
   let diff: number = msA - msB;
 
-  let days: number = 0;
+  let days = 0;
   if (diff >= 86400000) {
     days = Math.trunc(diff / 86400000);
     diff -= days * 86400000;
   }
 
-  let hours: number = 0;
+  let hours = 0;
   if (days || diff >= 3600000) {
     hours = Math.trunc(diff / 3600000);
     diff -= hours * 3600000;
   }
 
-  let minutes: number = 0;
+  let minutes = 0;
   if (hours || diff >= 60000) {
     minutes = Math.trunc(diff / 60000);
     diff -= minutes * 60000;
   }
 
-  let seconds: number = 0;
+  let seconds = 0;
   if (minutes || diff >= 1000) {
     seconds = Math.trunc(diff / 1000);
   }

--- a/src/helpers/userAnalyticHelpers.js
+++ b/src/helpers/userAnalyticHelpers.js
@@ -1,5 +1,3 @@
-import { EnvHelper } from "./Environment";
-
 // Pushing data to segment analytics
 export function segmentUA(data) {
   const analytics = (window.analytics = window.analytics);

--- a/src/hooks/Bonds.ts
+++ b/src/hooks/Bonds.ts
@@ -1,8 +1,8 @@
-import { useSelector } from "react-redux";
 import { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
 import allBonds, { allExpiredBonds } from "src/helpers/AllBonds";
-import { IUserBondDetails } from "src/slices/AccountSlice";
 import { Bond } from "src/lib/Bond";
+import { IUserBondDetails } from "src/slices/AccountSlice";
 import { IBondDetails } from "src/slices/BondSlice";
 
 interface IBondingStateView {
@@ -12,7 +12,7 @@ interface IBondingStateView {
     };
   };
   bonding: {
-    loading: Boolean;
+    loading: boolean;
     [key: string]: any;
   };
 }
@@ -31,8 +31,7 @@ function useBonds(networkId: number) {
   const [expiredBonds, setExpiredBonds] = useState<Bond[] | IAllBondData[]>(initialExpiredArray);
 
   useEffect(() => {
-    let bondDetails: IAllBondData[];
-    bondDetails = allBonds
+    const bondDetails: IAllBondData[] = allBonds
       .flatMap(bond => {
         if (bondState[bond.name] && bondState[bond.name].bondDiscount) {
           return Object.assign(bond, bondState[bond.name]); // Keeps the object type
@@ -56,8 +55,7 @@ function useBonds(networkId: number) {
     // setBonds(bondDetails);
 
     // TODO (appleseed-expiredBonds): there may be a smarter way to refactor this
-    let expiredDetails: IAllBondData[];
-    expiredDetails = allExpiredBonds
+    const expiredDetails: IAllBondData[] = allExpiredBonds
       .flatMap(bond => {
         if (bondState[bond.name] && bondState[bond.name].bondDiscount) {
           return Object.assign(bond, bondState[bond.name]); // Keeps the object type

--- a/src/hooks/useENS.ts
+++ b/src/hooks/useENS.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 import { useEffect, useState } from "react";
+
 import { useWeb3Context } from "./web3Context";
 
 const useENS = (address: string) => {
@@ -10,7 +11,7 @@ const useENS = (address: string) => {
     const resolveENS = async () => {
       if (ethers.utils.isAddress(address)) {
         try {
-          let ensName = await provider.lookupAddress(address);
+          const ensName = await provider.lookupAddress(address);
           setENSName(ensName);
         } catch (e) {
           console.log("e", e);

--- a/src/hooks/useGoogleAnalytics.ts
+++ b/src/hooks/useGoogleAnalytics.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
 import ReactGA from "react-ga";
+import { useLocation } from "react-router-dom";
+
 import { EnvHelper } from "../helpers/Environment";
 
 const GA_API_KEY = EnvHelper.getGaKey();

--- a/src/hooks/usePathForNetwork.ts
+++ b/src/hooks/usePathForNetwork.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect } from "react";
 import { History } from "history";
+import { useEffect } from "react";
 import { VIEWS_FOR_NETWORK } from "src/constants";
 
 /**

--- a/src/hooks/useSegmentAnalytics.js
+++ b/src/hooks/useSegmentAnalytics.js
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
-import { EnvHelper } from "../helpers/Environment";
 import { useLocation } from "react-router-dom";
 import { useWeb3Context } from "src/hooks/web3Context";
 import { v4 as uuidv4 } from "uuid";
+
+import { EnvHelper } from "../helpers/Environment";
 import { getParameterByName } from "../helpers/QueryParameterHelper";
 
 const SEGMENT_API_KEY = EnvHelper.getSegmentKey();

--- a/src/hooks/web3Context.tsx
+++ b/src/hooks/web3Context.tsx
@@ -1,11 +1,10 @@
-import React, { ReactElement, useCallback, useContext, useEffect, useMemo, useState } from "react";
-import Web3Modal from "web3modal";
-import { JsonRpcProvider, StaticJsonRpcProvider, Web3Provider } from "@ethersproject/providers";
-import WalletConnectProvider from "@walletconnect/web3-provider";
+import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
 import { IFrameEthereumProvider } from "@ledgerhq/iframe-provider";
-import { EnvHelper } from "../helpers/Environment";
-import store from "../store";
+import WalletConnectProvider from "@walletconnect/web3-provider";
+import React, { ReactElement, useCallback, useContext, useMemo, useState } from "react";
 import { NodeHelper } from "src/helpers/NodeHelper";
+import Web3Modal from "web3modal";
+
 import { NETWORKS } from "../constants";
 
 /**
@@ -26,7 +25,7 @@ type onChainProvider = {
   connected: boolean;
   provider: JsonRpcProvider;
   web3Modal: Web3Modal;
-  chainChanged: Boolean;
+  chainChanged: boolean;
   onChainChangeComplete: () => void;
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@
 
 // import React from "react";
 import ReactDOM from "react-dom";
+
 import Root from "./Root";
 
 // const subgraphUri = "http://localhost:8000/subgraphs/name/scaffold-eth/your-contract";

--- a/src/lib/Bond.ts
+++ b/src/lib/Bond.ts
@@ -1,12 +1,11 @@
 import { JsonRpcSigner, StaticJsonRpcProvider } from "@ethersproject/providers";
-import { ethers, BigNumber } from "ethers";
-
+import { BigNumber, ethers } from "ethers";
+import React from "react";
 import { abi as ierc20Abi } from "src/abi/IERC20.json";
+import { addresses } from "src/constants";
 import { getTokenPrice } from "src/helpers";
 import { getBondCalculator } from "src/helpers/BondCalculator";
 import { EthContract, PairContract } from "src/typechain";
-import { addresses } from "src/constants";
-import React from "react";
 
 export enum NetworkID {
   Mainnet = 1,
@@ -80,7 +79,7 @@ export abstract class Bond {
   readonly v2Bond: boolean;
 
   // The following two fields will differ on how they are set depending on bond type
-  abstract isLP: Boolean;
+  abstract isLP: boolean;
   abstract reserveContract: ethers.ContractInterface; // Token ABI
   abstract displayUnits: string;
 
@@ -179,14 +178,15 @@ export class LPBond extends Bond {
     const tokenAmount = tokenAmountV1.add(tokenAmountV2);
     const valuation = await bondCalculator.valuation(tokenAddress || "", tokenAmount);
     const markdown = await bondCalculator.markdown(tokenAddress || "");
-    let tokenUSD = (Number(valuation.toString()) / Math.pow(10, 9)) * (Number(markdown.toString()) / Math.pow(10, 18));
+    const tokenUSD =
+      (Number(valuation.toString()) / Math.pow(10, 9)) * (Number(markdown.toString()) / Math.pow(10, 18));
     return Number(tokenUSD.toString());
   }
 }
 
 // Generic BondClass we should be using everywhere
 // Assumes the token being deposited follows the standard ERC20 spec
-export interface StableBondOpts extends BondOpts {}
+export type StableBondOpts = BondOpts;
 export class StableBond extends Bond {
   readonly isLP = false;
   readonly reserveContract: ethers.ContractInterface;
@@ -200,8 +200,8 @@ export class StableBond extends Bond {
   }
 
   async getTreasuryBalance(networkID: NetworkID, provider: StaticJsonRpcProvider) {
-    let token = this.getContractForReserve(networkID, provider);
-    let tokenAmountV1 = await token.balanceOf(addresses[networkID].TREASURY_ADDRESS);
+    const token = this.getContractForReserve(networkID, provider);
+    const tokenAmountV1 = await token.balanceOf(addresses[networkID].TREASURY_ADDRESS);
     let tokenAmountV2 = BigNumber.from("0");
     try {
       tokenAmountV2 = await token.balanceOf(addresses[networkID].TREASURY_V2);
@@ -226,7 +226,7 @@ export interface CustomBondOpts extends BondOpts {
   ) => Promise<number>;
 }
 export class CustomBond extends Bond {
-  readonly isLP: Boolean;
+  readonly isLP: boolean;
   getTreasuryBalance(networkID: NetworkID, provider: StaticJsonRpcProvider): Promise<number> {
     throw new Error("Method not implemented.");
   }

--- a/src/lib/apolloClient.ts
+++ b/src/lib/apolloClient.ts
@@ -1,4 +1,5 @@
-import { ApolloClient, InMemoryCache, gql } from "@apollo/client";
+import { ApolloClient, gql, InMemoryCache } from "@apollo/client";
+
 import { THE_GRAPH_URL } from "../constants";
 
 const client = () =>

--- a/src/lib/fetchBalances.ts
+++ b/src/lib/fetchBalances.ts
@@ -1,5 +1,4 @@
 import { ethers } from "ethers";
-
 import { addresses } from "src/constants";
 import { EnvHelper } from "src/helpers/Environment";
 import { NetworkID } from "src/lib/Bond";

--- a/src/lib/ohmToast.js
+++ b/src/lib/ohmToast.js
@@ -1,7 +1,8 @@
-import Snackbar from "@material-ui/core/Snackbar";
-import MuiAlert from "@material-ui/lab/Alert";
 import Slide from "@material-ui/core/Slide";
+import Snackbar from "@material-ui/core/Snackbar";
 import { makeStyles } from "@material-ui/core/styles";
+import MuiAlert from "@material-ui/lab/Alert";
+import { useState } from "react";
 
 function Alert(props) {
   return <MuiAlert elevation={6} variant="outlined" {...props} />;

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,5 +1,5 @@
 import { i18n } from "@lingui/core";
-import { en, fr, ko, tr, zh, ar, es, vi } from "make-plural/plurals";
+import { ar, en, es, fr, ko, tr, vi, zh } from "make-plural/plurals";
 
 // Declare locales
 interface ILocale {
@@ -26,11 +26,11 @@ translations_style_dom.type = "text/css";
 document.getElementsByTagName("head")[0].appendChild(translations_style_dom);
 
 // Load locale data
-for (var [key, locale] of Object.entries(locales)) {
+for (const [key, locale] of Object.entries(locales)) {
   i18n.loadLocaleData(key, { plurals: locale.plurals });
 }
 
-async function fetchLocale(locale: string = "en") {
+async function fetchLocale(locale = "en") {
   const { messages } = await import(
     /* webpackChunkName: "[request]" */ `../locales/translations/olympus-frontend/${locale}/messages`
   );
@@ -43,7 +43,7 @@ export function selectLocale(locale: string) {
   return fetchLocale(locale);
 }
 export function initLocale() {
-  var locale = window.localStorage.getItem("locale") as string;
+  let locale = window.localStorage.getItem("locale") as string;
   if (!Object.keys(locales).includes(locale)) locale = "en";
   fetchLocale(locale);
 }

--- a/src/slices/AppSlice.ts
+++ b/src/slices/AppSlice.ts
@@ -1,13 +1,14 @@
+import { createAsyncThunk, createSelector, createSlice } from "@reduxjs/toolkit";
 import { ethers } from "ethers";
-import { addresses } from "../constants";
-import { abi as sOHMv2 } from "../abi/sOhmv2.json";
-import { setAll, getTokenPrice, getMarketPrice } from "../helpers";
 import { NodeHelper } from "src/helpers/NodeHelper";
-import apollo from "../lib/apolloClient";
-import { createSlice, createSelector, createAsyncThunk } from "@reduxjs/toolkit";
 import { RootState } from "src/store";
+
+import { abi as sOHMv2 } from "../abi/sOhmv2.json";
+import { addresses } from "../constants";
+import { getMarketPrice, getTokenPrice, setAll } from "../helpers";
+import apollo from "../lib/apolloClient";
+import { OlympusStaking__factory, OlympusStakingv2__factory, SOhmv2 } from "../typechain";
 import { IBaseAsyncThunk } from "./interfaces";
-import { OlympusStakingv2__factory, OlympusStaking__factory, SOhmv2 } from "../typechain";
 
 interface IProtocolMetrics {
   readonly timestamp: string;

--- a/src/slices/GiveThunk.ts
+++ b/src/slices/GiveThunk.ts
@@ -1,23 +1,22 @@
+import { t } from "@lingui/macro";
+import { createAsyncThunk } from "@reduxjs/toolkit";
 import { ethers } from "ethers";
-import { addresses } from "../constants";
+
 import { abi as ierc20Abi } from "../abi/IERC20.json";
+import { abi as MockSohm } from "../abi/MockSohm.json";
 import { abi as OlympusGiving } from "../abi/OlympusGiving.json";
 import { abi as OlympusMockGiving } from "../abi/OlympusMockGiving.json";
-import { abi as MockSohm } from "../abi/MockSohm.json";
-import { clearPendingTxn, fetchPendingTxns, getGivingTypeText, isPendingTxn, IPendingTxn } from "./PendingTxnsSlice";
-import { createAsyncThunk } from "@reduxjs/toolkit";
-import { fetchAccountSuccess, getBalances, getDonationBalances, getMockDonationBalances } from "./AccountSlice";
+import { addresses } from "../constants";
+import { segmentUA } from "../helpers/userAnalyticHelpers";
 import { error } from "../slices/MessagesSlice";
+import { fetchAccountSuccess, getBalances, getDonationBalances, getMockDonationBalances } from "./AccountSlice";
 import {
   IActionValueRecipientAsyncThunk,
+  IBaseAddressAsyncThunk,
   IChangeApprovalAsyncThunk,
   IJsonRPCError,
-  IBaseAddressAsyncThunk,
 } from "./interfaces";
-import { segmentUA } from "../helpers/userAnalyticHelpers";
-import { t } from "@lingui/macro";
-import { useLocation } from "react-router-dom";
-import { EnvHelper } from "src/helpers/Environment";
+import { clearPendingTxn, fetchPendingTxns, getGivingTypeText, IPendingTxn, isPendingTxn } from "./PendingTxnsSlice";
 
 interface IUAData {
   address: string;
@@ -82,7 +81,7 @@ export const changeApproval = createAsyncThunk(
       }
     }
 
-    let giveAllowance = await sohmContract.allowance(address, addresses[networkID].GIVING_ADDRESS);
+    const giveAllowance = await sohmContract.allowance(address, addresses[networkID].GIVING_ADDRESS);
 
     return dispatch(
       fetchAccountSuccess({
@@ -133,7 +132,7 @@ export const changeMockApproval = createAsyncThunk(
       The pseudo-sOHM contract used on testnet does not have a functional allowance
       mapping. Instead approval calls write allowaces to a mapping title _allowedValue
     */
-    let giveAllowance = await sohmContract._allowedValue(address, addresses[networkID].MOCK_GIVING_ADDRESS);
+    const giveAllowance = await sohmContract._allowedValue(address, addresses[networkID].MOCK_GIVING_ADDRESS);
 
     return dispatch(
       fetchAccountSuccess({
@@ -157,7 +156,7 @@ export const changeGive = createAsyncThunk(
     const giving = new ethers.Contract(addresses[networkID].GIVING_ADDRESS as string, OlympusGiving, signer);
     let giveTx;
 
-    let uaData: IUAData = {
+    const uaData: IUAData = {
       address: address,
       value: value,
       recipient: recipient,
@@ -178,7 +177,7 @@ export const changeGive = createAsyncThunk(
         if (parseFloat(value) > 0) {
           giveTx = await giving.deposit(ethers.utils.parseUnits(value, "gwei"), recipient);
         } else if (parseFloat(value) < 0) {
-          let reductionAmount = (-1 * parseFloat(value)).toString();
+          const reductionAmount = (-1 * parseFloat(value)).toString();
           giveTx = await giving.withdraw(ethers.utils.parseUnits(reductionAmount, "gwei"), recipient);
         }
       } else if (action === ACTION_GIVE_WITHDRAW) {
@@ -224,7 +223,7 @@ export const changeMockGive = createAsyncThunk(
     const giving = new ethers.Contract(addresses[networkID].MOCK_GIVING_ADDRESS as string, OlympusMockGiving, signer);
     let giveTx;
 
-    let uaData: IUAData = {
+    const uaData: IUAData = {
       address: address,
       value: value,
       recipient: recipient,
@@ -245,7 +244,7 @@ export const changeMockGive = createAsyncThunk(
         if (parseFloat(value) > 0) {
           giveTx = await giving.deposit(ethers.utils.parseUnits(value, "gwei"), recipient);
         } else if (parseFloat(value) < 0) {
-          let reductionAmount = (-1 * parseFloat(value)).toString();
+          const reductionAmount = (-1 * parseFloat(value)).toString();
           giveTx = await giving.withdraw(ethers.utils.parseUnits(reductionAmount, "gwei"), recipient);
         }
       } else if (action === ACTION_GIVE_WITHDRAW) {
@@ -293,7 +292,7 @@ export const getTestTokens = createAsyncThunk(
 
     const signer = provider.getSigner();
     const mockSohmContract = new ethers.Contract(addresses[networkID].MOCK_SOHM as string, MockSohm, signer);
-    let pendingTxnType = "drip";
+    const pendingTxnType = "drip";
     let getTx;
     try {
       getTx = await mockSohmContract.drip();

--- a/src/slices/MessagesSlice.ts
+++ b/src/slices/MessagesSlice.ts
@@ -16,7 +16,7 @@ interface MessagesState {
 }
 // Adds a message to the store
 const createMessage = function (state: MessagesState, severity: string, title: string, text: string) {
-  let message: Message = {
+  const message: Message = {
     id: nb_messages++,
     severity,
     title,
@@ -50,7 +50,7 @@ const messagesSlice = createSlice({
     },
     // Finds and removes obsolete messages
     handle_obsolete(state) {
-      let activeMessages = state.items.filter(message => {
+      const activeMessages = state.items.filter(message => {
         return Date.now() - message.created < MESSAGES_MAX_DISPLAY_DURATION;
       });
       if (state.items.length != activeMessages.length) {

--- a/src/slices/MigrateThunk.ts
+++ b/src/slices/MigrateThunk.ts
@@ -1,7 +1,12 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { BigNumber, ethers } from "ethers";
 import { addresses } from "src/constants";
+import { NetworkID } from "src/lib/Bond";
 import { CrossChainMigrator__factory, IERC20, IERC20__factory } from "src/typechain";
+import { OlympusTokenMigrator__factory } from "src/typechain";
+
+import { error, info } from "../slices/MessagesSlice";
+import { fetchAccountSuccess, getBalances, getMigrationAllowances } from "./AccountSlice";
 import {
   IActionValueAsyncThunk,
   IBaseAddressAsyncThunk,
@@ -9,11 +14,7 @@ import {
   IJsonRPCError,
   IValueAsyncThunk,
 } from "./interfaces";
-import { fetchAccountSuccess, getBalances, getMigrationAllowances, loadAccountDetails } from "./AccountSlice";
-import { error, info } from "../slices/MessagesSlice";
 import { clearPendingTxn, fetchPendingTxns } from "./PendingTxnsSlice";
-import { OlympusTokenMigrator__factory } from "src/typechain";
-import { NetworkID } from "src/lib/Bond";
 
 enum TokenType {
   UNSTAKED,
@@ -92,7 +93,7 @@ export const changeMigrationApproval = createAsyncThunk(
 );
 
 interface IMigrationWithType extends IActionValueAsyncThunk {
-  type: String;
+  type: string;
 }
 
 export const bridgeBack = createAsyncThunk(

--- a/src/slices/NetworkSlice.ts
+++ b/src/slices/NetworkSlice.ts
@@ -1,11 +1,12 @@
-import { createAsyncThunk, createSelector, createSlice } from "@reduxjs/toolkit";
 import { JsonRpcProvider, StaticJsonRpcProvider } from "@ethersproject/providers";
-import { error } from "./MessagesSlice";
+import { createAsyncThunk, createSelector, createSlice } from "@reduxjs/toolkit";
+
+import { NETWORKS } from "../constants";
 import { setAll } from "../helpers";
 import { EnvHelper } from "../helpers/Environment";
 import { NodeHelper } from "../helpers/NodeHelper";
-import { NETWORKS } from "../constants";
 import { RootState } from "../store";
+import { error } from "./MessagesSlice";
 
 interface IGetCurrentNetwork {
   provider: StaticJsonRpcProvider | JsonRpcProvider;
@@ -17,7 +18,7 @@ export const initializeNetwork = createAsyncThunk(
     try {
       let networkName: string;
       let uri: string;
-      let supported: boolean = true;
+      let supported = true;
       const id: number = await provider.getNetwork().then(network => network.chainId);
 
       switch (id) {

--- a/src/slices/PendingTxnsSlice.ts
+++ b/src/slices/PendingTxnsSlice.ts
@@ -1,5 +1,6 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { t } from "@lingui/macro";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
 import { ACTION_GIVE, ACTION_GIVE_EDIT } from "./GiveThunk";
 
 export interface IPendingTxn {

--- a/src/slices/PoolThunk.ts
+++ b/src/slices/PoolThunk.ts
@@ -1,25 +1,26 @@
-import { ethers, BigNumber } from "ethers";
-import { addresses } from "../constants";
-import { abi as ierc20Abi } from "../abi/IERC20.json";
-import { abi as PrizePool } from "../abi/33-together/PrizePoolAbi2.json";
-import { abi as AwardPool } from "../abi/33-together/AwardAbi2.json";
 import { createAsyncThunk, createSelector, createSlice } from "@reduxjs/toolkit";
-import { clearPendingTxn, fetchPendingTxns } from "./PendingTxnsSlice";
-import { fetchAccountSuccess, getBalances } from "./AccountSlice";
-import { getCreditMaturationDaysAndLimitPercentage } from "../helpers/33Together";
-import { setAll } from "../helpers";
-import { error, info } from "./MessagesSlice";
+import { BigNumber, ethers } from "ethers";
 import { RootState } from "src/store";
+import { AwardAbi2, PrizePoolAbi, PrizePoolAbi2, SOHM } from "src/typechain";
+
+import { abi as AwardPool } from "../abi/33-together/AwardAbi2.json";
+import { abi as PrizePool } from "../abi/33-together/PrizePoolAbi2.json";
+import { abi as ierc20Abi } from "../abi/IERC20.json";
+import { addresses } from "../constants";
+import { setAll } from "../helpers";
+import { getCreditMaturationDaysAndLimitPercentage } from "../helpers/33Together";
+import { segmentUA } from "../helpers/userAnalyticHelpers";
+import { fetchAccountSuccess, getBalances } from "./AccountSlice";
 import {
-  IValueAsyncThunk,
+  IActionAsyncThunk,
+  IActionValueAsyncThunk,
   IBaseAsyncThunk,
   IChangeApprovalAsyncThunk,
-  IActionValueAsyncThunk,
-  IActionAsyncThunk,
   IJsonRPCError,
+  IValueAsyncThunk,
 } from "./interfaces";
-import { AwardAbi2, PrizePoolAbi, PrizePoolAbi2, SOHM } from "src/typechain";
-import { segmentUA } from "../helpers/userAnalyticHelpers";
+import { error, info } from "./MessagesSlice";
+import { clearPendingTxn, fetchPendingTxns } from "./PendingTxnsSlice";
 
 export const getPoolValues = createAsyncThunk(
   "pool/getPoolValues",
@@ -145,7 +146,7 @@ export const poolDeposit = createAsyncThunk(
       signer,
     ) as PrizePoolAbi;
     let poolTx;
-    let uaData = {
+    const uaData = {
       address: address,
       value: value,
       type: "33t Deposit",
@@ -242,7 +243,7 @@ export const poolWithdraw = createAsyncThunk(
     ) as PrizePoolAbi2;
 
     let poolTx;
-    let uaData = {
+    const uaData = {
       address: address,
       value: value,
       type: "Withdraw",

--- a/src/slices/RedeemThunk.ts
+++ b/src/slices/RedeemThunk.ts
@@ -1,14 +1,14 @@
-import { ethers } from "ethers";
-import { addresses } from "../constants";
-import { abi as ierc20Abi } from "../abi/IERC20.json";
-import { abi as OlympusGiving } from "../abi/OlympusGiving.json";
-import { clearPendingTxn, fetchPendingTxns } from "./PendingTxnsSlice";
-import { createAsyncThunk } from "@reduxjs/toolkit";
-import { fetchAccountSuccess, getBalances, getRedemptionBalances, getMockRedemptionBalances } from "./AccountSlice";
-import { error } from "../slices/MessagesSlice";
-import { IBaseAddressAsyncThunk, IJsonRPCError } from "./interfaces";
-import { segmentUA } from "../helpers/userAnalyticHelpers";
 import { t } from "@lingui/macro";
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { ethers } from "ethers";
+
+import { abi as OlympusGiving } from "../abi/OlympusGiving.json";
+import { addresses } from "../constants";
+import { segmentUA } from "../helpers/userAnalyticHelpers";
+import { error } from "../slices/MessagesSlice";
+import { getBalances, getMockRedemptionBalances, getRedemptionBalances } from "./AccountSlice";
+import { IBaseAddressAsyncThunk, IJsonRPCError } from "./interfaces";
+import { clearPendingTxn, fetchPendingTxns } from "./PendingTxnsSlice";
 
 interface IUAData {
   address: string;
@@ -31,7 +31,7 @@ export const redeemBalance = createAsyncThunk(
     const redeemableBalance = await giving.redeemableBalance(address);
     let redeemTx;
 
-    let uaData: IUAData = {
+    const uaData: IUAData = {
       address: address,
       value: redeemableBalance,
       approved: true,
@@ -85,7 +85,7 @@ export const redeemMockBalance = createAsyncThunk(
     const redeemableBalance = await giving.redeemableBalance(address);
     let redeemTx;
 
-    let uaData: IUAData = {
+    const uaData: IUAData = {
       address: address,
       value: redeemableBalance,
       approved: true,

--- a/src/slices/StakeThunk.ts
+++ b/src/slices/StakeThunk.ts
@@ -1,20 +1,16 @@
-import { ethers, BigNumber } from "ethers";
-import { addresses } from "../constants";
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import { BigNumber, ethers } from "ethers";
+import ReactGA from "react-ga";
+import { IERC20, OlympusStaking__factory, OlympusStakingv2__factory, StakingHelper } from "src/typechain";
+
 import { abi as ierc20ABI } from "../abi/IERC20.json";
 import { abi as StakingHelperABI } from "../abi/StakingHelper.json";
-import { clearPendingTxn, fetchPendingTxns, getStakingTypeText } from "./PendingTxnsSlice";
-import { createAsyncThunk } from "@reduxjs/toolkit";
-import { fetchAccountSuccess, getBalances } from "./AccountSlice";
-import { error, info } from "../slices/MessagesSlice";
-import {
-  IActionValueAsyncThunk,
-  IChangeApprovalAsyncThunk,
-  IChangeApprovalWithVersionAsyncThunk,
-  IJsonRPCError,
-} from "./interfaces";
+import { addresses } from "../constants";
 import { segmentUA } from "../helpers/userAnalyticHelpers";
-import { IERC20, OlympusStakingv2__factory, OlympusStaking__factory, StakingHelper } from "src/typechain";
-import ReactGA from "react-ga";
+import { error, info } from "../slices/MessagesSlice";
+import { fetchAccountSuccess, getBalances } from "./AccountSlice";
+import { IActionValueAsyncThunk, IChangeApprovalWithVersionAsyncThunk, IJsonRPCError } from "./interfaces";
+import { clearPendingTxn, fetchPendingTxns, getStakingTypeText } from "./PendingTxnsSlice";
 
 interface IUAData {
   address: string;
@@ -33,7 +29,7 @@ function alreadyApprovedToken(
   version2: boolean,
 ) {
   // set defaults
-  let bigZero = BigNumber.from("0");
+  const bigZero = BigNumber.from("0");
   let applicableAllowance = bigZero;
   // determine which allowance to check
   if (token === "ohm" && version2) {
@@ -167,7 +163,7 @@ export const changeStake = createAsyncThunk(
     const stakingV2 = OlympusStakingv2__factory.connect(addresses[networkID].STAKING_V2, signer);
 
     let stakeTx;
-    let uaData: IUAData = {
+    const uaData: IUAData = {
       address: address,
       value: value,
       approved: true,
@@ -176,7 +172,7 @@ export const changeStake = createAsyncThunk(
     };
     try {
       if (version2) {
-        let rebasing = true; // when true stake into sOHM
+        const rebasing = true; // when true stake into sOHM
         if (action === "stake") {
           uaData.type = "stake";
           // 3rd arg is rebase

--- a/src/slices/WrapThunk.ts
+++ b/src/slices/WrapThunk.ts
@@ -1,14 +1,14 @@
-import { ethers, BigNumber } from "ethers";
-import { addresses } from "../constants";
-import { abi as ierc20ABI } from "../abi/IERC20.json";
-import { abi as v2sOHM } from "../abi/v2sOhmNew.json";
-import { clearPendingTxn, fetchPendingTxns, getWrappingTypeText } from "./PendingTxnsSlice";
 import { createAsyncThunk } from "@reduxjs/toolkit";
-import { fetchAccountSuccess, getBalances } from "./AccountSlice";
-import { error, info } from "../slices/MessagesSlice";
-import { IActionValueAsyncThunk, IChangeApprovalAsyncThunk, IJsonRPCError } from "./interfaces";
-import { segmentUA } from "../helpers/userAnalyticHelpers";
+import { ethers } from "ethers";
 import { IERC20, OlympusStakingv2__factory } from "src/typechain";
+
+import { abi as ierc20ABI } from "../abi/IERC20.json";
+import { addresses } from "../constants";
+import { segmentUA } from "../helpers/userAnalyticHelpers";
+import { error, info } from "../slices/MessagesSlice";
+import { fetchAccountSuccess, getBalances } from "./AccountSlice";
+import { IActionValueAsyncThunk, IChangeApprovalAsyncThunk, IJsonRPCError } from "./interfaces";
+import { clearPendingTxn, fetchPendingTxns, getWrappingTypeText } from "./PendingTxnsSlice";
 
 interface IUAData {
   address: string;
@@ -91,7 +91,7 @@ export const changeWrapV2 = createAsyncThunk(
     const stakingContract = OlympusStakingv2__factory.connect(addresses[networkID].STAKING_V2, signer);
 
     let wrapTx;
-    let uaData: IUAData = {
+    const uaData: IUAData = {
       address: address,
       value: value,
       approved: true,

--- a/src/slices/ZapSlice.ts
+++ b/src/slices/ZapSlice.ts
@@ -1,11 +1,12 @@
 import { createAsyncThunk, createSelector, createSlice } from "@reduxjs/toolkit";
+import { ethers } from "ethers";
 import { setAll } from "src/helpers";
 import { ZapHelper } from "src/helpers/ZapHelper";
+
+import { segmentUA } from "../helpers/userAnalyticHelpers";
 import { getBalances } from "./AccountSlice";
 import { IActionValueAsyncThunk, IBaseAddressAsyncThunk, IZapAsyncThunk } from "./interfaces";
 import { error, info } from "./MessagesSlice";
-import { segmentUA } from "../helpers/userAnalyticHelpers";
-import { ethers } from "ethers";
 interface IUAData {
   address: string;
   value: string;
@@ -49,7 +50,7 @@ export const changeZapTokenAllowance = createAsyncThunk(
       const tx = await signer.sendTransaction(transactionData);
       await tx.wait();
 
-      let uaData: IUAData = {
+      const uaData: IUAData = {
         address: address,
         value: value,
         approved: true,
@@ -60,7 +61,7 @@ export const changeZapTokenAllowance = createAsyncThunk(
       return Object.fromEntries([[action, true]]);
     } catch (e: unknown) {
       const rpcError = e as any;
-      let uaData: IUAData = {
+      const uaData: IUAData = {
         address: address,
         value: value,
         approved: false,
@@ -116,7 +117,7 @@ export const executeZap = createAsyncThunk(
       const tx = await signer.sendTransaction(transactionData);
       await tx.wait();
 
-      let uaData: IUADataZap = {
+      const uaData: IUADataZap = {
         address: address,
         value: sellAmount.toString(),
         token: tokenAddress,
@@ -127,7 +128,7 @@ export const executeZap = createAsyncThunk(
       segmentUA(uaData);
       dispatch(info("Successful Zap!"));
     } catch (e: unknown) {
-      let uaData: IUADataZap = {
+      const uaData: IUADataZap = {
         address: address,
         value: sellAmount.toString(),
         token: tokenAddress,
@@ -198,7 +199,9 @@ const zapTokenBalancesSlice = createSlice({
         console.error("Handled error");
         console.error(error.message);
       })
-      .addCase(getZapTokenAllowance.pending, state => {})
+      .addCase(getZapTokenAllowance.pending, state => {
+        // Do nothing
+      })
       .addCase(getZapTokenAllowance.fulfilled, (state, action) => {
         if (!action.payload) return;
         setAll(state.allowances, action.payload);

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,11 +1,12 @@
 import { configureStore } from "@reduxjs/toolkit";
+
 import accountReducer from "./slices/AccountSlice";
-import networkReducer from "./slices/NetworkSlice";
-import bondingReducer from "./slices/BondSlice";
 import appReducer from "./slices/AppSlice";
+import bondingReducer from "./slices/BondSlice";
+import messagesReducer from "./slices/MessagesSlice";
+import networkReducer from "./slices/NetworkSlice";
 import pendingTransactionsReducer from "./slices/PendingTxnsSlice";
 import poolDataReducer from "./slices/PoolThunk";
-import messagesReducer from "./slices/MessagesSlice";
 import zapReducer from "./slices/ZapSlice";
 // reducers are named automatically based on the name field in the slice
 // exported in slice files by default as nameOfSlice.reducer

--- a/src/themes/dark.js
+++ b/src/themes/dark.js
@@ -1,4 +1,5 @@
 import { createTheme, responsiveFontSizes } from "@material-ui/core/styles";
+
 import fonts from "./fonts";
 import commonSettings, { handleBackdropFilter } from "./global.js";
 

--- a/src/themes/fonts.js
+++ b/src/themes/fonts.js
@@ -1,9 +1,9 @@
-import SquareWOFF from "../assets/fonts/EuclidSquare-Regular.woff";
 import SquareBoldWOFF from "../assets/fonts/EuclidSquare-Bold.woff";
-import SquareSemiBoldWOFF from "../assets/fonts/EuclidSquare-SemiBold.woff";
 import SquareItalicWOFF from "../assets/fonts/EuclidSquare-Italic.woff";
 import SquareLightWOFF from "../assets/fonts/EuclidSquare-Light.woff";
 import SquareMediumWOFF from "../assets/fonts/EuclidSquare-Medium.woff";
+import SquareWOFF from "../assets/fonts/EuclidSquare-Regular.woff";
+import SquareSemiBoldWOFF from "../assets/fonts/EuclidSquare-SemiBold.woff";
 
 const square = {
   fontFamily: "Square",

--- a/src/themes/girth.js
+++ b/src/themes/girth.js
@@ -1,4 +1,5 @@
 import { createTheme, responsiveFontSizes } from "@material-ui/core/styles";
+
 import fonts from "./fonts";
 import commonSettings, { handleBackdropFilter } from "./global.js";
 

--- a/src/themes/light.js
+++ b/src/themes/light.js
@@ -1,4 +1,5 @@
 import { createTheme, responsiveFontSizes } from "@material-ui/core/styles";
+
 import fonts from "./fonts";
 import commonSettings, { handleBackdropFilter } from "./global.js";
 

--- a/src/typechain/pooltogether.d.ts
+++ b/src/typechain/pooltogether.d.ts
@@ -15,1854 +15,1836 @@ export type Scalars = {
 };
 
 export type Account = {
-  __typename?: 'Account';
+  __typename?: "Account";
   controlledTokenBalances?: Maybe<Array<ControlledTokenBalance>>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   prizePoolAccounts: Array<PrizePoolAccount>;
 };
 
-
 export type AccountControlledTokenBalancesArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<ControlledTokenBalance_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<ControlledTokenBalance_Filter>;
 };
 
-
 export type AccountPrizePoolAccountsArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<PrizePoolAccount_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<PrizePoolAccount_Filter>;
 };
 
 export type Account_Filter = {
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
 };
 
 export enum Account_OrderBy {
-  ControlledTokenBalances = 'controlledTokenBalances',
-  Id = 'id',
-  PrizePoolAccounts = 'prizePoolAccounts'
+  ControlledTokenBalances = "controlledTokenBalances",
+  Id = "id",
+  PrizePoolAccounts = "prizePoolAccounts",
 }
 
 export type AwardedControlledToken = {
-  __typename?: 'AwardedControlledToken';
-  amount: Scalars['BigInt'];
-  id: Scalars['ID'];
+  __typename?: "AwardedControlledToken";
+  amount: Scalars["BigInt"];
+  id: Scalars["ID"];
   prize: Prize;
   token: ControlledToken;
-  winner: Scalars['Bytes'];
+  winner: Scalars["Bytes"];
 };
 
 export type AwardedControlledToken_Filter = {
-  amount?: Maybe<Scalars['BigInt']>;
-  amount_gt?: Maybe<Scalars['BigInt']>;
-  amount_gte?: Maybe<Scalars['BigInt']>;
-  amount_in?: Maybe<Array<Scalars['BigInt']>>;
-  amount_lt?: Maybe<Scalars['BigInt']>;
-  amount_lte?: Maybe<Scalars['BigInt']>;
-  amount_not?: Maybe<Scalars['BigInt']>;
-  amount_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  prize?: Maybe<Scalars['String']>;
-  prize_contains?: Maybe<Scalars['String']>;
-  prize_ends_with?: Maybe<Scalars['String']>;
-  prize_gt?: Maybe<Scalars['String']>;
-  prize_gte?: Maybe<Scalars['String']>;
-  prize_in?: Maybe<Array<Scalars['String']>>;
-  prize_lt?: Maybe<Scalars['String']>;
-  prize_lte?: Maybe<Scalars['String']>;
-  prize_not?: Maybe<Scalars['String']>;
-  prize_not_contains?: Maybe<Scalars['String']>;
-  prize_not_ends_with?: Maybe<Scalars['String']>;
-  prize_not_in?: Maybe<Array<Scalars['String']>>;
-  prize_not_starts_with?: Maybe<Scalars['String']>;
-  prize_starts_with?: Maybe<Scalars['String']>;
-  token?: Maybe<Scalars['String']>;
-  token_contains?: Maybe<Scalars['String']>;
-  token_ends_with?: Maybe<Scalars['String']>;
-  token_gt?: Maybe<Scalars['String']>;
-  token_gte?: Maybe<Scalars['String']>;
-  token_in?: Maybe<Array<Scalars['String']>>;
-  token_lt?: Maybe<Scalars['String']>;
-  token_lte?: Maybe<Scalars['String']>;
-  token_not?: Maybe<Scalars['String']>;
-  token_not_contains?: Maybe<Scalars['String']>;
-  token_not_ends_with?: Maybe<Scalars['String']>;
-  token_not_in?: Maybe<Array<Scalars['String']>>;
-  token_not_starts_with?: Maybe<Scalars['String']>;
-  token_starts_with?: Maybe<Scalars['String']>;
-  winner?: Maybe<Scalars['Bytes']>;
-  winner_contains?: Maybe<Scalars['Bytes']>;
-  winner_in?: Maybe<Array<Scalars['Bytes']>>;
-  winner_not?: Maybe<Scalars['Bytes']>;
-  winner_not_contains?: Maybe<Scalars['Bytes']>;
-  winner_not_in?: Maybe<Array<Scalars['Bytes']>>;
+  amount?: Maybe<Scalars["BigInt"]>;
+  amount_gt?: Maybe<Scalars["BigInt"]>;
+  amount_gte?: Maybe<Scalars["BigInt"]>;
+  amount_in?: Maybe<Array<Scalars["BigInt"]>>;
+  amount_lt?: Maybe<Scalars["BigInt"]>;
+  amount_lte?: Maybe<Scalars["BigInt"]>;
+  amount_not?: Maybe<Scalars["BigInt"]>;
+  amount_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  prize?: Maybe<Scalars["String"]>;
+  prize_contains?: Maybe<Scalars["String"]>;
+  prize_ends_with?: Maybe<Scalars["String"]>;
+  prize_gt?: Maybe<Scalars["String"]>;
+  prize_gte?: Maybe<Scalars["String"]>;
+  prize_in?: Maybe<Array<Scalars["String"]>>;
+  prize_lt?: Maybe<Scalars["String"]>;
+  prize_lte?: Maybe<Scalars["String"]>;
+  prize_not?: Maybe<Scalars["String"]>;
+  prize_not_contains?: Maybe<Scalars["String"]>;
+  prize_not_ends_with?: Maybe<Scalars["String"]>;
+  prize_not_in?: Maybe<Array<Scalars["String"]>>;
+  prize_not_starts_with?: Maybe<Scalars["String"]>;
+  prize_starts_with?: Maybe<Scalars["String"]>;
+  token?: Maybe<Scalars["String"]>;
+  token_contains?: Maybe<Scalars["String"]>;
+  token_ends_with?: Maybe<Scalars["String"]>;
+  token_gt?: Maybe<Scalars["String"]>;
+  token_gte?: Maybe<Scalars["String"]>;
+  token_in?: Maybe<Array<Scalars["String"]>>;
+  token_lt?: Maybe<Scalars["String"]>;
+  token_lte?: Maybe<Scalars["String"]>;
+  token_not?: Maybe<Scalars["String"]>;
+  token_not_contains?: Maybe<Scalars["String"]>;
+  token_not_ends_with?: Maybe<Scalars["String"]>;
+  token_not_in?: Maybe<Array<Scalars["String"]>>;
+  token_not_starts_with?: Maybe<Scalars["String"]>;
+  token_starts_with?: Maybe<Scalars["String"]>;
+  winner?: Maybe<Scalars["Bytes"]>;
+  winner_contains?: Maybe<Scalars["Bytes"]>;
+  winner_in?: Maybe<Array<Scalars["Bytes"]>>;
+  winner_not?: Maybe<Scalars["Bytes"]>;
+  winner_not_contains?: Maybe<Scalars["Bytes"]>;
+  winner_not_in?: Maybe<Array<Scalars["Bytes"]>>;
 };
 
 export enum AwardedControlledToken_OrderBy {
-  Amount = 'amount',
-  Id = 'id',
-  Prize = 'prize',
-  Token = 'token',
-  Winner = 'winner'
+  Amount = "amount",
+  Id = "id",
+  Prize = "prize",
+  Token = "token",
+  Winner = "winner",
 }
 
 export type AwardedExternalErc20Token = {
-  __typename?: 'AwardedExternalErc20Token';
-  address: Scalars['Bytes'];
-  balanceAwarded?: Maybe<Scalars['BigInt']>;
-  decimals?: Maybe<Scalars['BigInt']>;
-  id: Scalars['ID'];
-  name?: Maybe<Scalars['String']>;
+  __typename?: "AwardedExternalErc20Token";
+  address: Scalars["Bytes"];
+  balanceAwarded?: Maybe<Scalars["BigInt"]>;
+  decimals?: Maybe<Scalars["BigInt"]>;
+  id: Scalars["ID"];
+  name?: Maybe<Scalars["String"]>;
   prize: Prize;
-  symbol?: Maybe<Scalars['String']>;
-  winner?: Maybe<Scalars['Bytes']>;
+  symbol?: Maybe<Scalars["String"]>;
+  winner?: Maybe<Scalars["Bytes"]>;
 };
 
 export type AwardedExternalErc20Token_Filter = {
-  address?: Maybe<Scalars['Bytes']>;
-  address_contains?: Maybe<Scalars['Bytes']>;
-  address_in?: Maybe<Array<Scalars['Bytes']>>;
-  address_not?: Maybe<Scalars['Bytes']>;
-  address_not_contains?: Maybe<Scalars['Bytes']>;
-  address_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  balanceAwarded?: Maybe<Scalars['BigInt']>;
-  balanceAwarded_gt?: Maybe<Scalars['BigInt']>;
-  balanceAwarded_gte?: Maybe<Scalars['BigInt']>;
-  balanceAwarded_in?: Maybe<Array<Scalars['BigInt']>>;
-  balanceAwarded_lt?: Maybe<Scalars['BigInt']>;
-  balanceAwarded_lte?: Maybe<Scalars['BigInt']>;
-  balanceAwarded_not?: Maybe<Scalars['BigInt']>;
-  balanceAwarded_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  decimals?: Maybe<Scalars['BigInt']>;
-  decimals_gt?: Maybe<Scalars['BigInt']>;
-  decimals_gte?: Maybe<Scalars['BigInt']>;
-  decimals_in?: Maybe<Array<Scalars['BigInt']>>;
-  decimals_lt?: Maybe<Scalars['BigInt']>;
-  decimals_lte?: Maybe<Scalars['BigInt']>;
-  decimals_not?: Maybe<Scalars['BigInt']>;
-  decimals_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  name?: Maybe<Scalars['String']>;
-  name_contains?: Maybe<Scalars['String']>;
-  name_ends_with?: Maybe<Scalars['String']>;
-  name_gt?: Maybe<Scalars['String']>;
-  name_gte?: Maybe<Scalars['String']>;
-  name_in?: Maybe<Array<Scalars['String']>>;
-  name_lt?: Maybe<Scalars['String']>;
-  name_lte?: Maybe<Scalars['String']>;
-  name_not?: Maybe<Scalars['String']>;
-  name_not_contains?: Maybe<Scalars['String']>;
-  name_not_ends_with?: Maybe<Scalars['String']>;
-  name_not_in?: Maybe<Array<Scalars['String']>>;
-  name_not_starts_with?: Maybe<Scalars['String']>;
-  name_starts_with?: Maybe<Scalars['String']>;
-  prize?: Maybe<Scalars['String']>;
-  prize_contains?: Maybe<Scalars['String']>;
-  prize_ends_with?: Maybe<Scalars['String']>;
-  prize_gt?: Maybe<Scalars['String']>;
-  prize_gte?: Maybe<Scalars['String']>;
-  prize_in?: Maybe<Array<Scalars['String']>>;
-  prize_lt?: Maybe<Scalars['String']>;
-  prize_lte?: Maybe<Scalars['String']>;
-  prize_not?: Maybe<Scalars['String']>;
-  prize_not_contains?: Maybe<Scalars['String']>;
-  prize_not_ends_with?: Maybe<Scalars['String']>;
-  prize_not_in?: Maybe<Array<Scalars['String']>>;
-  prize_not_starts_with?: Maybe<Scalars['String']>;
-  prize_starts_with?: Maybe<Scalars['String']>;
-  symbol?: Maybe<Scalars['String']>;
-  symbol_contains?: Maybe<Scalars['String']>;
-  symbol_ends_with?: Maybe<Scalars['String']>;
-  symbol_gt?: Maybe<Scalars['String']>;
-  symbol_gte?: Maybe<Scalars['String']>;
-  symbol_in?: Maybe<Array<Scalars['String']>>;
-  symbol_lt?: Maybe<Scalars['String']>;
-  symbol_lte?: Maybe<Scalars['String']>;
-  symbol_not?: Maybe<Scalars['String']>;
-  symbol_not_contains?: Maybe<Scalars['String']>;
-  symbol_not_ends_with?: Maybe<Scalars['String']>;
-  symbol_not_in?: Maybe<Array<Scalars['String']>>;
-  symbol_not_starts_with?: Maybe<Scalars['String']>;
-  symbol_starts_with?: Maybe<Scalars['String']>;
-  winner?: Maybe<Scalars['Bytes']>;
-  winner_contains?: Maybe<Scalars['Bytes']>;
-  winner_in?: Maybe<Array<Scalars['Bytes']>>;
-  winner_not?: Maybe<Scalars['Bytes']>;
-  winner_not_contains?: Maybe<Scalars['Bytes']>;
-  winner_not_in?: Maybe<Array<Scalars['Bytes']>>;
+  address?: Maybe<Scalars["Bytes"]>;
+  address_contains?: Maybe<Scalars["Bytes"]>;
+  address_in?: Maybe<Array<Scalars["Bytes"]>>;
+  address_not?: Maybe<Scalars["Bytes"]>;
+  address_not_contains?: Maybe<Scalars["Bytes"]>;
+  address_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  balanceAwarded?: Maybe<Scalars["BigInt"]>;
+  balanceAwarded_gt?: Maybe<Scalars["BigInt"]>;
+  balanceAwarded_gte?: Maybe<Scalars["BigInt"]>;
+  balanceAwarded_in?: Maybe<Array<Scalars["BigInt"]>>;
+  balanceAwarded_lt?: Maybe<Scalars["BigInt"]>;
+  balanceAwarded_lte?: Maybe<Scalars["BigInt"]>;
+  balanceAwarded_not?: Maybe<Scalars["BigInt"]>;
+  balanceAwarded_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  decimals?: Maybe<Scalars["BigInt"]>;
+  decimals_gt?: Maybe<Scalars["BigInt"]>;
+  decimals_gte?: Maybe<Scalars["BigInt"]>;
+  decimals_in?: Maybe<Array<Scalars["BigInt"]>>;
+  decimals_lt?: Maybe<Scalars["BigInt"]>;
+  decimals_lte?: Maybe<Scalars["BigInt"]>;
+  decimals_not?: Maybe<Scalars["BigInt"]>;
+  decimals_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  name?: Maybe<Scalars["String"]>;
+  name_contains?: Maybe<Scalars["String"]>;
+  name_ends_with?: Maybe<Scalars["String"]>;
+  name_gt?: Maybe<Scalars["String"]>;
+  name_gte?: Maybe<Scalars["String"]>;
+  name_in?: Maybe<Array<Scalars["String"]>>;
+  name_lt?: Maybe<Scalars["String"]>;
+  name_lte?: Maybe<Scalars["String"]>;
+  name_not?: Maybe<Scalars["String"]>;
+  name_not_contains?: Maybe<Scalars["String"]>;
+  name_not_ends_with?: Maybe<Scalars["String"]>;
+  name_not_in?: Maybe<Array<Scalars["String"]>>;
+  name_not_starts_with?: Maybe<Scalars["String"]>;
+  name_starts_with?: Maybe<Scalars["String"]>;
+  prize?: Maybe<Scalars["String"]>;
+  prize_contains?: Maybe<Scalars["String"]>;
+  prize_ends_with?: Maybe<Scalars["String"]>;
+  prize_gt?: Maybe<Scalars["String"]>;
+  prize_gte?: Maybe<Scalars["String"]>;
+  prize_in?: Maybe<Array<Scalars["String"]>>;
+  prize_lt?: Maybe<Scalars["String"]>;
+  prize_lte?: Maybe<Scalars["String"]>;
+  prize_not?: Maybe<Scalars["String"]>;
+  prize_not_contains?: Maybe<Scalars["String"]>;
+  prize_not_ends_with?: Maybe<Scalars["String"]>;
+  prize_not_in?: Maybe<Array<Scalars["String"]>>;
+  prize_not_starts_with?: Maybe<Scalars["String"]>;
+  prize_starts_with?: Maybe<Scalars["String"]>;
+  symbol?: Maybe<Scalars["String"]>;
+  symbol_contains?: Maybe<Scalars["String"]>;
+  symbol_ends_with?: Maybe<Scalars["String"]>;
+  symbol_gt?: Maybe<Scalars["String"]>;
+  symbol_gte?: Maybe<Scalars["String"]>;
+  symbol_in?: Maybe<Array<Scalars["String"]>>;
+  symbol_lt?: Maybe<Scalars["String"]>;
+  symbol_lte?: Maybe<Scalars["String"]>;
+  symbol_not?: Maybe<Scalars["String"]>;
+  symbol_not_contains?: Maybe<Scalars["String"]>;
+  symbol_not_ends_with?: Maybe<Scalars["String"]>;
+  symbol_not_in?: Maybe<Array<Scalars["String"]>>;
+  symbol_not_starts_with?: Maybe<Scalars["String"]>;
+  symbol_starts_with?: Maybe<Scalars["String"]>;
+  winner?: Maybe<Scalars["Bytes"]>;
+  winner_contains?: Maybe<Scalars["Bytes"]>;
+  winner_in?: Maybe<Array<Scalars["Bytes"]>>;
+  winner_not?: Maybe<Scalars["Bytes"]>;
+  winner_not_contains?: Maybe<Scalars["Bytes"]>;
+  winner_not_in?: Maybe<Array<Scalars["Bytes"]>>;
 };
 
 export enum AwardedExternalErc20Token_OrderBy {
-  Address = 'address',
-  BalanceAwarded = 'balanceAwarded',
-  Decimals = 'decimals',
-  Id = 'id',
-  Name = 'name',
-  Prize = 'prize',
-  Symbol = 'symbol',
-  Winner = 'winner'
+  Address = "address",
+  BalanceAwarded = "balanceAwarded",
+  Decimals = "decimals",
+  Id = "id",
+  Name = "name",
+  Prize = "prize",
+  Symbol = "symbol",
+  Winner = "winner",
 }
 
 export type AwardedExternalErc721Nft = {
-  __typename?: 'AwardedExternalErc721Nft';
-  address: Scalars['Bytes'];
-  id: Scalars['ID'];
+  __typename?: "AwardedExternalErc721Nft";
+  address: Scalars["Bytes"];
+  id: Scalars["ID"];
   prize?: Maybe<Prize>;
-  tokenIds?: Maybe<Array<Scalars['BigInt']>>;
-  winner?: Maybe<Scalars['Bytes']>;
+  tokenIds?: Maybe<Array<Scalars["BigInt"]>>;
+  winner?: Maybe<Scalars["Bytes"]>;
 };
 
 export type AwardedExternalErc721Nft_Filter = {
-  address?: Maybe<Scalars['Bytes']>;
-  address_contains?: Maybe<Scalars['Bytes']>;
-  address_in?: Maybe<Array<Scalars['Bytes']>>;
-  address_not?: Maybe<Scalars['Bytes']>;
-  address_not_contains?: Maybe<Scalars['Bytes']>;
-  address_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  prize?: Maybe<Scalars['String']>;
-  prize_contains?: Maybe<Scalars['String']>;
-  prize_ends_with?: Maybe<Scalars['String']>;
-  prize_gt?: Maybe<Scalars['String']>;
-  prize_gte?: Maybe<Scalars['String']>;
-  prize_in?: Maybe<Array<Scalars['String']>>;
-  prize_lt?: Maybe<Scalars['String']>;
-  prize_lte?: Maybe<Scalars['String']>;
-  prize_not?: Maybe<Scalars['String']>;
-  prize_not_contains?: Maybe<Scalars['String']>;
-  prize_not_ends_with?: Maybe<Scalars['String']>;
-  prize_not_in?: Maybe<Array<Scalars['String']>>;
-  prize_not_starts_with?: Maybe<Scalars['String']>;
-  prize_starts_with?: Maybe<Scalars['String']>;
-  tokenIds?: Maybe<Array<Scalars['BigInt']>>;
-  tokenIds_contains?: Maybe<Array<Scalars['BigInt']>>;
-  tokenIds_not?: Maybe<Array<Scalars['BigInt']>>;
-  tokenIds_not_contains?: Maybe<Array<Scalars['BigInt']>>;
-  winner?: Maybe<Scalars['Bytes']>;
-  winner_contains?: Maybe<Scalars['Bytes']>;
-  winner_in?: Maybe<Array<Scalars['Bytes']>>;
-  winner_not?: Maybe<Scalars['Bytes']>;
-  winner_not_contains?: Maybe<Scalars['Bytes']>;
-  winner_not_in?: Maybe<Array<Scalars['Bytes']>>;
+  address?: Maybe<Scalars["Bytes"]>;
+  address_contains?: Maybe<Scalars["Bytes"]>;
+  address_in?: Maybe<Array<Scalars["Bytes"]>>;
+  address_not?: Maybe<Scalars["Bytes"]>;
+  address_not_contains?: Maybe<Scalars["Bytes"]>;
+  address_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  prize?: Maybe<Scalars["String"]>;
+  prize_contains?: Maybe<Scalars["String"]>;
+  prize_ends_with?: Maybe<Scalars["String"]>;
+  prize_gt?: Maybe<Scalars["String"]>;
+  prize_gte?: Maybe<Scalars["String"]>;
+  prize_in?: Maybe<Array<Scalars["String"]>>;
+  prize_lt?: Maybe<Scalars["String"]>;
+  prize_lte?: Maybe<Scalars["String"]>;
+  prize_not?: Maybe<Scalars["String"]>;
+  prize_not_contains?: Maybe<Scalars["String"]>;
+  prize_not_ends_with?: Maybe<Scalars["String"]>;
+  prize_not_in?: Maybe<Array<Scalars["String"]>>;
+  prize_not_starts_with?: Maybe<Scalars["String"]>;
+  prize_starts_with?: Maybe<Scalars["String"]>;
+  tokenIds?: Maybe<Array<Scalars["BigInt"]>>;
+  tokenIds_contains?: Maybe<Array<Scalars["BigInt"]>>;
+  tokenIds_not?: Maybe<Array<Scalars["BigInt"]>>;
+  tokenIds_not_contains?: Maybe<Array<Scalars["BigInt"]>>;
+  winner?: Maybe<Scalars["Bytes"]>;
+  winner_contains?: Maybe<Scalars["Bytes"]>;
+  winner_in?: Maybe<Array<Scalars["Bytes"]>>;
+  winner_not?: Maybe<Scalars["Bytes"]>;
+  winner_not_contains?: Maybe<Scalars["Bytes"]>;
+  winner_not_in?: Maybe<Array<Scalars["Bytes"]>>;
 };
 
 export enum AwardedExternalErc721Nft_OrderBy {
-  Address = 'address',
-  Id = 'id',
-  Prize = 'prize',
-  TokenIds = 'tokenIds',
-  Winner = 'winner'
+  Address = "address",
+  Id = "id",
+  Prize = "prize",
+  TokenIds = "tokenIds",
+  Winner = "winner",
 }
 
 export type BalanceDrip = {
-  __typename?: 'BalanceDrip';
+  __typename?: "BalanceDrip";
   comptroller: Comptroller;
-  deactivated: Scalars['Boolean'];
-  dripRatePerSecond?: Maybe<Scalars['BigInt']>;
-  dripToken: Scalars['Bytes'];
-  exchangeRateMantissa?: Maybe<Scalars['BigInt']>;
-  id: Scalars['ID'];
-  measureToken: Scalars['Bytes'];
+  deactivated: Scalars["Boolean"];
+  dripRatePerSecond?: Maybe<Scalars["BigInt"]>;
+  dripToken: Scalars["Bytes"];
+  exchangeRateMantissa?: Maybe<Scalars["BigInt"]>;
+  id: Scalars["ID"];
+  measureToken: Scalars["Bytes"];
   players: Array<BalanceDripPlayer>;
-  sourceAddress: Scalars['Bytes'];
-  timestamp?: Maybe<Scalars['BigInt']>;
+  sourceAddress: Scalars["Bytes"];
+  timestamp?: Maybe<Scalars["BigInt"]>;
 };
 
-
 export type BalanceDripPlayersArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<BalanceDripPlayer_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<BalanceDripPlayer_Filter>;
 };
 
 export type BalanceDripPlayer = {
-  __typename?: 'BalanceDripPlayer';
-  address: Scalars['Bytes'];
+  __typename?: "BalanceDripPlayer";
+  address: Scalars["Bytes"];
   balanceDrip: BalanceDrip;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
 };
 
 export type BalanceDripPlayer_Filter = {
-  address?: Maybe<Scalars['Bytes']>;
-  address_contains?: Maybe<Scalars['Bytes']>;
-  address_in?: Maybe<Array<Scalars['Bytes']>>;
-  address_not?: Maybe<Scalars['Bytes']>;
-  address_not_contains?: Maybe<Scalars['Bytes']>;
-  address_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  balanceDrip?: Maybe<Scalars['String']>;
-  balanceDrip_contains?: Maybe<Scalars['String']>;
-  balanceDrip_ends_with?: Maybe<Scalars['String']>;
-  balanceDrip_gt?: Maybe<Scalars['String']>;
-  balanceDrip_gte?: Maybe<Scalars['String']>;
-  balanceDrip_in?: Maybe<Array<Scalars['String']>>;
-  balanceDrip_lt?: Maybe<Scalars['String']>;
-  balanceDrip_lte?: Maybe<Scalars['String']>;
-  balanceDrip_not?: Maybe<Scalars['String']>;
-  balanceDrip_not_contains?: Maybe<Scalars['String']>;
-  balanceDrip_not_ends_with?: Maybe<Scalars['String']>;
-  balanceDrip_not_in?: Maybe<Array<Scalars['String']>>;
-  balanceDrip_not_starts_with?: Maybe<Scalars['String']>;
-  balanceDrip_starts_with?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
+  address?: Maybe<Scalars["Bytes"]>;
+  address_contains?: Maybe<Scalars["Bytes"]>;
+  address_in?: Maybe<Array<Scalars["Bytes"]>>;
+  address_not?: Maybe<Scalars["Bytes"]>;
+  address_not_contains?: Maybe<Scalars["Bytes"]>;
+  address_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  balanceDrip?: Maybe<Scalars["String"]>;
+  balanceDrip_contains?: Maybe<Scalars["String"]>;
+  balanceDrip_ends_with?: Maybe<Scalars["String"]>;
+  balanceDrip_gt?: Maybe<Scalars["String"]>;
+  balanceDrip_gte?: Maybe<Scalars["String"]>;
+  balanceDrip_in?: Maybe<Array<Scalars["String"]>>;
+  balanceDrip_lt?: Maybe<Scalars["String"]>;
+  balanceDrip_lte?: Maybe<Scalars["String"]>;
+  balanceDrip_not?: Maybe<Scalars["String"]>;
+  balanceDrip_not_contains?: Maybe<Scalars["String"]>;
+  balanceDrip_not_ends_with?: Maybe<Scalars["String"]>;
+  balanceDrip_not_in?: Maybe<Array<Scalars["String"]>>;
+  balanceDrip_not_starts_with?: Maybe<Scalars["String"]>;
+  balanceDrip_starts_with?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
 };
 
 export enum BalanceDripPlayer_OrderBy {
-  Address = 'address',
-  BalanceDrip = 'balanceDrip',
-  Id = 'id'
+  Address = "address",
+  BalanceDrip = "balanceDrip",
+  Id = "id",
 }
 
 export type BalanceDrip_Filter = {
-  comptroller?: Maybe<Scalars['String']>;
-  comptroller_contains?: Maybe<Scalars['String']>;
-  comptroller_ends_with?: Maybe<Scalars['String']>;
-  comptroller_gt?: Maybe<Scalars['String']>;
-  comptroller_gte?: Maybe<Scalars['String']>;
-  comptroller_in?: Maybe<Array<Scalars['String']>>;
-  comptroller_lt?: Maybe<Scalars['String']>;
-  comptroller_lte?: Maybe<Scalars['String']>;
-  comptroller_not?: Maybe<Scalars['String']>;
-  comptroller_not_contains?: Maybe<Scalars['String']>;
-  comptroller_not_ends_with?: Maybe<Scalars['String']>;
-  comptroller_not_in?: Maybe<Array<Scalars['String']>>;
-  comptroller_not_starts_with?: Maybe<Scalars['String']>;
-  comptroller_starts_with?: Maybe<Scalars['String']>;
-  deactivated?: Maybe<Scalars['Boolean']>;
-  deactivated_in?: Maybe<Array<Scalars['Boolean']>>;
-  deactivated_not?: Maybe<Scalars['Boolean']>;
-  deactivated_not_in?: Maybe<Array<Scalars['Boolean']>>;
-  dripRatePerSecond?: Maybe<Scalars['BigInt']>;
-  dripRatePerSecond_gt?: Maybe<Scalars['BigInt']>;
-  dripRatePerSecond_gte?: Maybe<Scalars['BigInt']>;
-  dripRatePerSecond_in?: Maybe<Array<Scalars['BigInt']>>;
-  dripRatePerSecond_lt?: Maybe<Scalars['BigInt']>;
-  dripRatePerSecond_lte?: Maybe<Scalars['BigInt']>;
-  dripRatePerSecond_not?: Maybe<Scalars['BigInt']>;
-  dripRatePerSecond_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  dripToken?: Maybe<Scalars['Bytes']>;
-  dripToken_contains?: Maybe<Scalars['Bytes']>;
-  dripToken_in?: Maybe<Array<Scalars['Bytes']>>;
-  dripToken_not?: Maybe<Scalars['Bytes']>;
-  dripToken_not_contains?: Maybe<Scalars['Bytes']>;
-  dripToken_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  exchangeRateMantissa?: Maybe<Scalars['BigInt']>;
-  exchangeRateMantissa_gt?: Maybe<Scalars['BigInt']>;
-  exchangeRateMantissa_gte?: Maybe<Scalars['BigInt']>;
-  exchangeRateMantissa_in?: Maybe<Array<Scalars['BigInt']>>;
-  exchangeRateMantissa_lt?: Maybe<Scalars['BigInt']>;
-  exchangeRateMantissa_lte?: Maybe<Scalars['BigInt']>;
-  exchangeRateMantissa_not?: Maybe<Scalars['BigInt']>;
-  exchangeRateMantissa_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  measureToken?: Maybe<Scalars['Bytes']>;
-  measureToken_contains?: Maybe<Scalars['Bytes']>;
-  measureToken_in?: Maybe<Array<Scalars['Bytes']>>;
-  measureToken_not?: Maybe<Scalars['Bytes']>;
-  measureToken_not_contains?: Maybe<Scalars['Bytes']>;
-  measureToken_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  sourceAddress?: Maybe<Scalars['Bytes']>;
-  sourceAddress_contains?: Maybe<Scalars['Bytes']>;
-  sourceAddress_in?: Maybe<Array<Scalars['Bytes']>>;
-  sourceAddress_not?: Maybe<Scalars['Bytes']>;
-  sourceAddress_not_contains?: Maybe<Scalars['Bytes']>;
-  sourceAddress_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  timestamp?: Maybe<Scalars['BigInt']>;
-  timestamp_gt?: Maybe<Scalars['BigInt']>;
-  timestamp_gte?: Maybe<Scalars['BigInt']>;
-  timestamp_in?: Maybe<Array<Scalars['BigInt']>>;
-  timestamp_lt?: Maybe<Scalars['BigInt']>;
-  timestamp_lte?: Maybe<Scalars['BigInt']>;
-  timestamp_not?: Maybe<Scalars['BigInt']>;
-  timestamp_not_in?: Maybe<Array<Scalars['BigInt']>>;
+  comptroller?: Maybe<Scalars["String"]>;
+  comptroller_contains?: Maybe<Scalars["String"]>;
+  comptroller_ends_with?: Maybe<Scalars["String"]>;
+  comptroller_gt?: Maybe<Scalars["String"]>;
+  comptroller_gte?: Maybe<Scalars["String"]>;
+  comptroller_in?: Maybe<Array<Scalars["String"]>>;
+  comptroller_lt?: Maybe<Scalars["String"]>;
+  comptroller_lte?: Maybe<Scalars["String"]>;
+  comptroller_not?: Maybe<Scalars["String"]>;
+  comptroller_not_contains?: Maybe<Scalars["String"]>;
+  comptroller_not_ends_with?: Maybe<Scalars["String"]>;
+  comptroller_not_in?: Maybe<Array<Scalars["String"]>>;
+  comptroller_not_starts_with?: Maybe<Scalars["String"]>;
+  comptroller_starts_with?: Maybe<Scalars["String"]>;
+  deactivated?: Maybe<Scalars["Boolean"]>;
+  deactivated_in?: Maybe<Array<Scalars["Boolean"]>>;
+  deactivated_not?: Maybe<Scalars["Boolean"]>;
+  deactivated_not_in?: Maybe<Array<Scalars["Boolean"]>>;
+  dripRatePerSecond?: Maybe<Scalars["BigInt"]>;
+  dripRatePerSecond_gt?: Maybe<Scalars["BigInt"]>;
+  dripRatePerSecond_gte?: Maybe<Scalars["BigInt"]>;
+  dripRatePerSecond_in?: Maybe<Array<Scalars["BigInt"]>>;
+  dripRatePerSecond_lt?: Maybe<Scalars["BigInt"]>;
+  dripRatePerSecond_lte?: Maybe<Scalars["BigInt"]>;
+  dripRatePerSecond_not?: Maybe<Scalars["BigInt"]>;
+  dripRatePerSecond_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  dripToken?: Maybe<Scalars["Bytes"]>;
+  dripToken_contains?: Maybe<Scalars["Bytes"]>;
+  dripToken_in?: Maybe<Array<Scalars["Bytes"]>>;
+  dripToken_not?: Maybe<Scalars["Bytes"]>;
+  dripToken_not_contains?: Maybe<Scalars["Bytes"]>;
+  dripToken_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  exchangeRateMantissa?: Maybe<Scalars["BigInt"]>;
+  exchangeRateMantissa_gt?: Maybe<Scalars["BigInt"]>;
+  exchangeRateMantissa_gte?: Maybe<Scalars["BigInt"]>;
+  exchangeRateMantissa_in?: Maybe<Array<Scalars["BigInt"]>>;
+  exchangeRateMantissa_lt?: Maybe<Scalars["BigInt"]>;
+  exchangeRateMantissa_lte?: Maybe<Scalars["BigInt"]>;
+  exchangeRateMantissa_not?: Maybe<Scalars["BigInt"]>;
+  exchangeRateMantissa_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  measureToken?: Maybe<Scalars["Bytes"]>;
+  measureToken_contains?: Maybe<Scalars["Bytes"]>;
+  measureToken_in?: Maybe<Array<Scalars["Bytes"]>>;
+  measureToken_not?: Maybe<Scalars["Bytes"]>;
+  measureToken_not_contains?: Maybe<Scalars["Bytes"]>;
+  measureToken_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  sourceAddress?: Maybe<Scalars["Bytes"]>;
+  sourceAddress_contains?: Maybe<Scalars["Bytes"]>;
+  sourceAddress_in?: Maybe<Array<Scalars["Bytes"]>>;
+  sourceAddress_not?: Maybe<Scalars["Bytes"]>;
+  sourceAddress_not_contains?: Maybe<Scalars["Bytes"]>;
+  sourceAddress_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  timestamp?: Maybe<Scalars["BigInt"]>;
+  timestamp_gt?: Maybe<Scalars["BigInt"]>;
+  timestamp_gte?: Maybe<Scalars["BigInt"]>;
+  timestamp_in?: Maybe<Array<Scalars["BigInt"]>>;
+  timestamp_lt?: Maybe<Scalars["BigInt"]>;
+  timestamp_lte?: Maybe<Scalars["BigInt"]>;
+  timestamp_not?: Maybe<Scalars["BigInt"]>;
+  timestamp_not_in?: Maybe<Array<Scalars["BigInt"]>>;
 };
 
 export enum BalanceDrip_OrderBy {
-  Comptroller = 'comptroller',
-  Deactivated = 'deactivated',
-  DripRatePerSecond = 'dripRatePerSecond',
-  DripToken = 'dripToken',
-  ExchangeRateMantissa = 'exchangeRateMantissa',
-  Id = 'id',
-  MeasureToken = 'measureToken',
-  Players = 'players',
-  SourceAddress = 'sourceAddress',
-  Timestamp = 'timestamp'
+  Comptroller = "comptroller",
+  Deactivated = "deactivated",
+  DripRatePerSecond = "dripRatePerSecond",
+  DripToken = "dripToken",
+  ExchangeRateMantissa = "exchangeRateMantissa",
+  Id = "id",
+  MeasureToken = "measureToken",
+  Players = "players",
+  SourceAddress = "sourceAddress",
+  Timestamp = "timestamp",
 }
 
 export type Block_Height = {
-  hash?: Maybe<Scalars['Bytes']>;
-  number?: Maybe<Scalars['Int']>;
+  hash?: Maybe<Scalars["Bytes"]>;
+  number?: Maybe<Scalars["Int"]>;
 };
 
 export type CompoundPrizePool = {
-  __typename?: 'CompoundPrizePool';
-  cToken?: Maybe<Scalars['Bytes']>;
-  id: Scalars['ID'];
+  __typename?: "CompoundPrizePool";
+  cToken?: Maybe<Scalars["Bytes"]>;
+  id: Scalars["ID"];
 };
 
 export type CompoundPrizePool_Filter = {
-  cToken?: Maybe<Scalars['Bytes']>;
-  cToken_contains?: Maybe<Scalars['Bytes']>;
-  cToken_in?: Maybe<Array<Scalars['Bytes']>>;
-  cToken_not?: Maybe<Scalars['Bytes']>;
-  cToken_not_contains?: Maybe<Scalars['Bytes']>;
-  cToken_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
+  cToken?: Maybe<Scalars["Bytes"]>;
+  cToken_contains?: Maybe<Scalars["Bytes"]>;
+  cToken_in?: Maybe<Array<Scalars["Bytes"]>>;
+  cToken_not?: Maybe<Scalars["Bytes"]>;
+  cToken_not_contains?: Maybe<Scalars["Bytes"]>;
+  cToken_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
 };
 
 export enum CompoundPrizePool_OrderBy {
-  CToken = 'cToken',
-  Id = 'id'
+  CToken = "cToken",
+  Id = "id",
 }
 
 export type Comptroller = {
-  __typename?: 'Comptroller';
+  __typename?: "Comptroller";
   balanceDrips: Array<BalanceDrip>;
-  id: Scalars['ID'];
-  owner: Scalars['Bytes'];
+  id: Scalars["ID"];
+  owner: Scalars["Bytes"];
   players: Array<DripTokenPlayer>;
   volumeDrips: Array<VolumeDrip>;
 };
 
-
 export type ComptrollerBalanceDripsArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<BalanceDrip_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<BalanceDrip_Filter>;
 };
 
-
 export type ComptrollerPlayersArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<DripTokenPlayer_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<DripTokenPlayer_Filter>;
 };
 
-
 export type ComptrollerVolumeDripsArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<VolumeDrip_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<VolumeDrip_Filter>;
 };
 
 export type Comptroller_Filter = {
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  owner?: Maybe<Scalars['Bytes']>;
-  owner_contains?: Maybe<Scalars['Bytes']>;
-  owner_in?: Maybe<Array<Scalars['Bytes']>>;
-  owner_not?: Maybe<Scalars['Bytes']>;
-  owner_not_contains?: Maybe<Scalars['Bytes']>;
-  owner_not_in?: Maybe<Array<Scalars['Bytes']>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  owner?: Maybe<Scalars["Bytes"]>;
+  owner_contains?: Maybe<Scalars["Bytes"]>;
+  owner_in?: Maybe<Array<Scalars["Bytes"]>>;
+  owner_not?: Maybe<Scalars["Bytes"]>;
+  owner_not_contains?: Maybe<Scalars["Bytes"]>;
+  owner_not_in?: Maybe<Array<Scalars["Bytes"]>>;
 };
 
 export enum Comptroller_OrderBy {
-  BalanceDrips = 'balanceDrips',
-  Id = 'id',
-  Owner = 'owner',
-  Players = 'players',
-  VolumeDrips = 'volumeDrips'
+  BalanceDrips = "balanceDrips",
+  Id = "id",
+  Owner = "owner",
+  Players = "players",
+  VolumeDrips = "volumeDrips",
 }
 
 export type ControlledToken = {
-  __typename?: 'ControlledToken';
+  __typename?: "ControlledToken";
   balances: Array<ControlledTokenBalance>;
   controller?: Maybe<PrizePool>;
-  decimals?: Maybe<Scalars['BigInt']>;
-  id: Scalars['ID'];
-  name: Scalars['String'];
-  numberOfHolders: Scalars['BigInt'];
-  symbol: Scalars['String'];
-  totalSupply: Scalars['BigInt'];
+  decimals?: Maybe<Scalars["BigInt"]>;
+  id: Scalars["ID"];
+  name: Scalars["String"];
+  numberOfHolders: Scalars["BigInt"];
+  symbol: Scalars["String"];
+  totalSupply: Scalars["BigInt"];
 };
 
-
 export type ControlledTokenBalancesArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<ControlledTokenBalance_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<ControlledTokenBalance_Filter>;
 };
 
 export type ControlledTokenBalance = {
-  __typename?: 'ControlledTokenBalance';
+  __typename?: "ControlledTokenBalance";
   account: Account;
-  balance?: Maybe<Scalars['BigInt']>;
+  balance?: Maybe<Scalars["BigInt"]>;
   controlledToken: ControlledToken;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
 };
 
 export type ControlledTokenBalance_Filter = {
-  account?: Maybe<Scalars['String']>;
-  account_contains?: Maybe<Scalars['String']>;
-  account_ends_with?: Maybe<Scalars['String']>;
-  account_gt?: Maybe<Scalars['String']>;
-  account_gte?: Maybe<Scalars['String']>;
-  account_in?: Maybe<Array<Scalars['String']>>;
-  account_lt?: Maybe<Scalars['String']>;
-  account_lte?: Maybe<Scalars['String']>;
-  account_not?: Maybe<Scalars['String']>;
-  account_not_contains?: Maybe<Scalars['String']>;
-  account_not_ends_with?: Maybe<Scalars['String']>;
-  account_not_in?: Maybe<Array<Scalars['String']>>;
-  account_not_starts_with?: Maybe<Scalars['String']>;
-  account_starts_with?: Maybe<Scalars['String']>;
-  balance?: Maybe<Scalars['BigInt']>;
-  balance_gt?: Maybe<Scalars['BigInt']>;
-  balance_gte?: Maybe<Scalars['BigInt']>;
-  balance_in?: Maybe<Array<Scalars['BigInt']>>;
-  balance_lt?: Maybe<Scalars['BigInt']>;
-  balance_lte?: Maybe<Scalars['BigInt']>;
-  balance_not?: Maybe<Scalars['BigInt']>;
-  balance_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  controlledToken?: Maybe<Scalars['String']>;
-  controlledToken_contains?: Maybe<Scalars['String']>;
-  controlledToken_ends_with?: Maybe<Scalars['String']>;
-  controlledToken_gt?: Maybe<Scalars['String']>;
-  controlledToken_gte?: Maybe<Scalars['String']>;
-  controlledToken_in?: Maybe<Array<Scalars['String']>>;
-  controlledToken_lt?: Maybe<Scalars['String']>;
-  controlledToken_lte?: Maybe<Scalars['String']>;
-  controlledToken_not?: Maybe<Scalars['String']>;
-  controlledToken_not_contains?: Maybe<Scalars['String']>;
-  controlledToken_not_ends_with?: Maybe<Scalars['String']>;
-  controlledToken_not_in?: Maybe<Array<Scalars['String']>>;
-  controlledToken_not_starts_with?: Maybe<Scalars['String']>;
-  controlledToken_starts_with?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
+  account?: Maybe<Scalars["String"]>;
+  account_contains?: Maybe<Scalars["String"]>;
+  account_ends_with?: Maybe<Scalars["String"]>;
+  account_gt?: Maybe<Scalars["String"]>;
+  account_gte?: Maybe<Scalars["String"]>;
+  account_in?: Maybe<Array<Scalars["String"]>>;
+  account_lt?: Maybe<Scalars["String"]>;
+  account_lte?: Maybe<Scalars["String"]>;
+  account_not?: Maybe<Scalars["String"]>;
+  account_not_contains?: Maybe<Scalars["String"]>;
+  account_not_ends_with?: Maybe<Scalars["String"]>;
+  account_not_in?: Maybe<Array<Scalars["String"]>>;
+  account_not_starts_with?: Maybe<Scalars["String"]>;
+  account_starts_with?: Maybe<Scalars["String"]>;
+  balance?: Maybe<Scalars["BigInt"]>;
+  balance_gt?: Maybe<Scalars["BigInt"]>;
+  balance_gte?: Maybe<Scalars["BigInt"]>;
+  balance_in?: Maybe<Array<Scalars["BigInt"]>>;
+  balance_lt?: Maybe<Scalars["BigInt"]>;
+  balance_lte?: Maybe<Scalars["BigInt"]>;
+  balance_not?: Maybe<Scalars["BigInt"]>;
+  balance_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  controlledToken?: Maybe<Scalars["String"]>;
+  controlledToken_contains?: Maybe<Scalars["String"]>;
+  controlledToken_ends_with?: Maybe<Scalars["String"]>;
+  controlledToken_gt?: Maybe<Scalars["String"]>;
+  controlledToken_gte?: Maybe<Scalars["String"]>;
+  controlledToken_in?: Maybe<Array<Scalars["String"]>>;
+  controlledToken_lt?: Maybe<Scalars["String"]>;
+  controlledToken_lte?: Maybe<Scalars["String"]>;
+  controlledToken_not?: Maybe<Scalars["String"]>;
+  controlledToken_not_contains?: Maybe<Scalars["String"]>;
+  controlledToken_not_ends_with?: Maybe<Scalars["String"]>;
+  controlledToken_not_in?: Maybe<Array<Scalars["String"]>>;
+  controlledToken_not_starts_with?: Maybe<Scalars["String"]>;
+  controlledToken_starts_with?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
 };
 
 export enum ControlledTokenBalance_OrderBy {
-  Account = 'account',
-  Balance = 'balance',
-  ControlledToken = 'controlledToken',
-  Id = 'id'
+  Account = "account",
+  Balance = "balance",
+  ControlledToken = "controlledToken",
+  Id = "id",
 }
 
 export type ControlledToken_Filter = {
-  controller?: Maybe<Scalars['String']>;
-  controller_contains?: Maybe<Scalars['String']>;
-  controller_ends_with?: Maybe<Scalars['String']>;
-  controller_gt?: Maybe<Scalars['String']>;
-  controller_gte?: Maybe<Scalars['String']>;
-  controller_in?: Maybe<Array<Scalars['String']>>;
-  controller_lt?: Maybe<Scalars['String']>;
-  controller_lte?: Maybe<Scalars['String']>;
-  controller_not?: Maybe<Scalars['String']>;
-  controller_not_contains?: Maybe<Scalars['String']>;
-  controller_not_ends_with?: Maybe<Scalars['String']>;
-  controller_not_in?: Maybe<Array<Scalars['String']>>;
-  controller_not_starts_with?: Maybe<Scalars['String']>;
-  controller_starts_with?: Maybe<Scalars['String']>;
-  decimals?: Maybe<Scalars['BigInt']>;
-  decimals_gt?: Maybe<Scalars['BigInt']>;
-  decimals_gte?: Maybe<Scalars['BigInt']>;
-  decimals_in?: Maybe<Array<Scalars['BigInt']>>;
-  decimals_lt?: Maybe<Scalars['BigInt']>;
-  decimals_lte?: Maybe<Scalars['BigInt']>;
-  decimals_not?: Maybe<Scalars['BigInt']>;
-  decimals_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  name?: Maybe<Scalars['String']>;
-  name_contains?: Maybe<Scalars['String']>;
-  name_ends_with?: Maybe<Scalars['String']>;
-  name_gt?: Maybe<Scalars['String']>;
-  name_gte?: Maybe<Scalars['String']>;
-  name_in?: Maybe<Array<Scalars['String']>>;
-  name_lt?: Maybe<Scalars['String']>;
-  name_lte?: Maybe<Scalars['String']>;
-  name_not?: Maybe<Scalars['String']>;
-  name_not_contains?: Maybe<Scalars['String']>;
-  name_not_ends_with?: Maybe<Scalars['String']>;
-  name_not_in?: Maybe<Array<Scalars['String']>>;
-  name_not_starts_with?: Maybe<Scalars['String']>;
-  name_starts_with?: Maybe<Scalars['String']>;
-  numberOfHolders?: Maybe<Scalars['BigInt']>;
-  numberOfHolders_gt?: Maybe<Scalars['BigInt']>;
-  numberOfHolders_gte?: Maybe<Scalars['BigInt']>;
-  numberOfHolders_in?: Maybe<Array<Scalars['BigInt']>>;
-  numberOfHolders_lt?: Maybe<Scalars['BigInt']>;
-  numberOfHolders_lte?: Maybe<Scalars['BigInt']>;
-  numberOfHolders_not?: Maybe<Scalars['BigInt']>;
-  numberOfHolders_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  symbol?: Maybe<Scalars['String']>;
-  symbol_contains?: Maybe<Scalars['String']>;
-  symbol_ends_with?: Maybe<Scalars['String']>;
-  symbol_gt?: Maybe<Scalars['String']>;
-  symbol_gte?: Maybe<Scalars['String']>;
-  symbol_in?: Maybe<Array<Scalars['String']>>;
-  symbol_lt?: Maybe<Scalars['String']>;
-  symbol_lte?: Maybe<Scalars['String']>;
-  symbol_not?: Maybe<Scalars['String']>;
-  symbol_not_contains?: Maybe<Scalars['String']>;
-  symbol_not_ends_with?: Maybe<Scalars['String']>;
-  symbol_not_in?: Maybe<Array<Scalars['String']>>;
-  symbol_not_starts_with?: Maybe<Scalars['String']>;
-  symbol_starts_with?: Maybe<Scalars['String']>;
-  totalSupply?: Maybe<Scalars['BigInt']>;
-  totalSupply_gt?: Maybe<Scalars['BigInt']>;
-  totalSupply_gte?: Maybe<Scalars['BigInt']>;
-  totalSupply_in?: Maybe<Array<Scalars['BigInt']>>;
-  totalSupply_lt?: Maybe<Scalars['BigInt']>;
-  totalSupply_lte?: Maybe<Scalars['BigInt']>;
-  totalSupply_not?: Maybe<Scalars['BigInt']>;
-  totalSupply_not_in?: Maybe<Array<Scalars['BigInt']>>;
+  controller?: Maybe<Scalars["String"]>;
+  controller_contains?: Maybe<Scalars["String"]>;
+  controller_ends_with?: Maybe<Scalars["String"]>;
+  controller_gt?: Maybe<Scalars["String"]>;
+  controller_gte?: Maybe<Scalars["String"]>;
+  controller_in?: Maybe<Array<Scalars["String"]>>;
+  controller_lt?: Maybe<Scalars["String"]>;
+  controller_lte?: Maybe<Scalars["String"]>;
+  controller_not?: Maybe<Scalars["String"]>;
+  controller_not_contains?: Maybe<Scalars["String"]>;
+  controller_not_ends_with?: Maybe<Scalars["String"]>;
+  controller_not_in?: Maybe<Array<Scalars["String"]>>;
+  controller_not_starts_with?: Maybe<Scalars["String"]>;
+  controller_starts_with?: Maybe<Scalars["String"]>;
+  decimals?: Maybe<Scalars["BigInt"]>;
+  decimals_gt?: Maybe<Scalars["BigInt"]>;
+  decimals_gte?: Maybe<Scalars["BigInt"]>;
+  decimals_in?: Maybe<Array<Scalars["BigInt"]>>;
+  decimals_lt?: Maybe<Scalars["BigInt"]>;
+  decimals_lte?: Maybe<Scalars["BigInt"]>;
+  decimals_not?: Maybe<Scalars["BigInt"]>;
+  decimals_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  name?: Maybe<Scalars["String"]>;
+  name_contains?: Maybe<Scalars["String"]>;
+  name_ends_with?: Maybe<Scalars["String"]>;
+  name_gt?: Maybe<Scalars["String"]>;
+  name_gte?: Maybe<Scalars["String"]>;
+  name_in?: Maybe<Array<Scalars["String"]>>;
+  name_lt?: Maybe<Scalars["String"]>;
+  name_lte?: Maybe<Scalars["String"]>;
+  name_not?: Maybe<Scalars["String"]>;
+  name_not_contains?: Maybe<Scalars["String"]>;
+  name_not_ends_with?: Maybe<Scalars["String"]>;
+  name_not_in?: Maybe<Array<Scalars["String"]>>;
+  name_not_starts_with?: Maybe<Scalars["String"]>;
+  name_starts_with?: Maybe<Scalars["String"]>;
+  numberOfHolders?: Maybe<Scalars["BigInt"]>;
+  numberOfHolders_gt?: Maybe<Scalars["BigInt"]>;
+  numberOfHolders_gte?: Maybe<Scalars["BigInt"]>;
+  numberOfHolders_in?: Maybe<Array<Scalars["BigInt"]>>;
+  numberOfHolders_lt?: Maybe<Scalars["BigInt"]>;
+  numberOfHolders_lte?: Maybe<Scalars["BigInt"]>;
+  numberOfHolders_not?: Maybe<Scalars["BigInt"]>;
+  numberOfHolders_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  symbol?: Maybe<Scalars["String"]>;
+  symbol_contains?: Maybe<Scalars["String"]>;
+  symbol_ends_with?: Maybe<Scalars["String"]>;
+  symbol_gt?: Maybe<Scalars["String"]>;
+  symbol_gte?: Maybe<Scalars["String"]>;
+  symbol_in?: Maybe<Array<Scalars["String"]>>;
+  symbol_lt?: Maybe<Scalars["String"]>;
+  symbol_lte?: Maybe<Scalars["String"]>;
+  symbol_not?: Maybe<Scalars["String"]>;
+  symbol_not_contains?: Maybe<Scalars["String"]>;
+  symbol_not_ends_with?: Maybe<Scalars["String"]>;
+  symbol_not_in?: Maybe<Array<Scalars["String"]>>;
+  symbol_not_starts_with?: Maybe<Scalars["String"]>;
+  symbol_starts_with?: Maybe<Scalars["String"]>;
+  totalSupply?: Maybe<Scalars["BigInt"]>;
+  totalSupply_gt?: Maybe<Scalars["BigInt"]>;
+  totalSupply_gte?: Maybe<Scalars["BigInt"]>;
+  totalSupply_in?: Maybe<Array<Scalars["BigInt"]>>;
+  totalSupply_lt?: Maybe<Scalars["BigInt"]>;
+  totalSupply_lte?: Maybe<Scalars["BigInt"]>;
+  totalSupply_not?: Maybe<Scalars["BigInt"]>;
+  totalSupply_not_in?: Maybe<Array<Scalars["BigInt"]>>;
 };
 
 export enum ControlledToken_OrderBy {
-  Balances = 'balances',
-  Controller = 'controller',
-  Decimals = 'decimals',
-  Id = 'id',
-  Name = 'name',
-  NumberOfHolders = 'numberOfHolders',
-  Symbol = 'symbol',
-  TotalSupply = 'totalSupply'
+  Balances = "balances",
+  Controller = "controller",
+  Decimals = "decimals",
+  Id = "id",
+  Name = "name",
+  NumberOfHolders = "numberOfHolders",
+  Symbol = "symbol",
+  TotalSupply = "totalSupply",
 }
 
 export type CreditBalance = {
-  __typename?: 'CreditBalance';
-  balance?: Maybe<Scalars['BigInt']>;
-  id: Scalars['ID'];
-  initialized?: Maybe<Scalars['Boolean']>;
+  __typename?: "CreditBalance";
+  balance?: Maybe<Scalars["BigInt"]>;
+  id: Scalars["ID"];
+  initialized?: Maybe<Scalars["Boolean"]>;
   prizePool: PrizePool;
-  timestamp?: Maybe<Scalars['BigInt']>;
+  timestamp?: Maybe<Scalars["BigInt"]>;
 };
 
 export type CreditBalance_Filter = {
-  balance?: Maybe<Scalars['BigInt']>;
-  balance_gt?: Maybe<Scalars['BigInt']>;
-  balance_gte?: Maybe<Scalars['BigInt']>;
-  balance_in?: Maybe<Array<Scalars['BigInt']>>;
-  balance_lt?: Maybe<Scalars['BigInt']>;
-  balance_lte?: Maybe<Scalars['BigInt']>;
-  balance_not?: Maybe<Scalars['BigInt']>;
-  balance_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  initialized?: Maybe<Scalars['Boolean']>;
-  initialized_in?: Maybe<Array<Scalars['Boolean']>>;
-  initialized_not?: Maybe<Scalars['Boolean']>;
-  initialized_not_in?: Maybe<Array<Scalars['Boolean']>>;
-  prizePool?: Maybe<Scalars['String']>;
-  prizePool_contains?: Maybe<Scalars['String']>;
-  prizePool_ends_with?: Maybe<Scalars['String']>;
-  prizePool_gt?: Maybe<Scalars['String']>;
-  prizePool_gte?: Maybe<Scalars['String']>;
-  prizePool_in?: Maybe<Array<Scalars['String']>>;
-  prizePool_lt?: Maybe<Scalars['String']>;
-  prizePool_lte?: Maybe<Scalars['String']>;
-  prizePool_not?: Maybe<Scalars['String']>;
-  prizePool_not_contains?: Maybe<Scalars['String']>;
-  prizePool_not_ends_with?: Maybe<Scalars['String']>;
-  prizePool_not_in?: Maybe<Array<Scalars['String']>>;
-  prizePool_not_starts_with?: Maybe<Scalars['String']>;
-  prizePool_starts_with?: Maybe<Scalars['String']>;
-  timestamp?: Maybe<Scalars['BigInt']>;
-  timestamp_gt?: Maybe<Scalars['BigInt']>;
-  timestamp_gte?: Maybe<Scalars['BigInt']>;
-  timestamp_in?: Maybe<Array<Scalars['BigInt']>>;
-  timestamp_lt?: Maybe<Scalars['BigInt']>;
-  timestamp_lte?: Maybe<Scalars['BigInt']>;
-  timestamp_not?: Maybe<Scalars['BigInt']>;
-  timestamp_not_in?: Maybe<Array<Scalars['BigInt']>>;
+  balance?: Maybe<Scalars["BigInt"]>;
+  balance_gt?: Maybe<Scalars["BigInt"]>;
+  balance_gte?: Maybe<Scalars["BigInt"]>;
+  balance_in?: Maybe<Array<Scalars["BigInt"]>>;
+  balance_lt?: Maybe<Scalars["BigInt"]>;
+  balance_lte?: Maybe<Scalars["BigInt"]>;
+  balance_not?: Maybe<Scalars["BigInt"]>;
+  balance_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  initialized?: Maybe<Scalars["Boolean"]>;
+  initialized_in?: Maybe<Array<Scalars["Boolean"]>>;
+  initialized_not?: Maybe<Scalars["Boolean"]>;
+  initialized_not_in?: Maybe<Array<Scalars["Boolean"]>>;
+  prizePool?: Maybe<Scalars["String"]>;
+  prizePool_contains?: Maybe<Scalars["String"]>;
+  prizePool_ends_with?: Maybe<Scalars["String"]>;
+  prizePool_gt?: Maybe<Scalars["String"]>;
+  prizePool_gte?: Maybe<Scalars["String"]>;
+  prizePool_in?: Maybe<Array<Scalars["String"]>>;
+  prizePool_lt?: Maybe<Scalars["String"]>;
+  prizePool_lte?: Maybe<Scalars["String"]>;
+  prizePool_not?: Maybe<Scalars["String"]>;
+  prizePool_not_contains?: Maybe<Scalars["String"]>;
+  prizePool_not_ends_with?: Maybe<Scalars["String"]>;
+  prizePool_not_in?: Maybe<Array<Scalars["String"]>>;
+  prizePool_not_starts_with?: Maybe<Scalars["String"]>;
+  prizePool_starts_with?: Maybe<Scalars["String"]>;
+  timestamp?: Maybe<Scalars["BigInt"]>;
+  timestamp_gt?: Maybe<Scalars["BigInt"]>;
+  timestamp_gte?: Maybe<Scalars["BigInt"]>;
+  timestamp_in?: Maybe<Array<Scalars["BigInt"]>>;
+  timestamp_lt?: Maybe<Scalars["BigInt"]>;
+  timestamp_lte?: Maybe<Scalars["BigInt"]>;
+  timestamp_not?: Maybe<Scalars["BigInt"]>;
+  timestamp_not_in?: Maybe<Array<Scalars["BigInt"]>>;
 };
 
 export enum CreditBalance_OrderBy {
-  Balance = 'balance',
-  Id = 'id',
-  Initialized = 'initialized',
-  PrizePool = 'prizePool',
-  Timestamp = 'timestamp'
+  Balance = "balance",
+  Id = "id",
+  Initialized = "initialized",
+  PrizePool = "prizePool",
+  Timestamp = "timestamp",
 }
 
 export type CreditRate = {
-  __typename?: 'CreditRate';
-  creditLimitMantissa: Scalars['BigInt'];
-  creditRateMantissa: Scalars['BigInt'];
-  id: Scalars['ID'];
+  __typename?: "CreditRate";
+  creditLimitMantissa: Scalars["BigInt"];
+  creditRateMantissa: Scalars["BigInt"];
+  id: Scalars["ID"];
   prizePool: PrizePool;
 };
 
 export type CreditRate_Filter = {
-  creditLimitMantissa?: Maybe<Scalars['BigInt']>;
-  creditLimitMantissa_gt?: Maybe<Scalars['BigInt']>;
-  creditLimitMantissa_gte?: Maybe<Scalars['BigInt']>;
-  creditLimitMantissa_in?: Maybe<Array<Scalars['BigInt']>>;
-  creditLimitMantissa_lt?: Maybe<Scalars['BigInt']>;
-  creditLimitMantissa_lte?: Maybe<Scalars['BigInt']>;
-  creditLimitMantissa_not?: Maybe<Scalars['BigInt']>;
-  creditLimitMantissa_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  creditRateMantissa?: Maybe<Scalars['BigInt']>;
-  creditRateMantissa_gt?: Maybe<Scalars['BigInt']>;
-  creditRateMantissa_gte?: Maybe<Scalars['BigInt']>;
-  creditRateMantissa_in?: Maybe<Array<Scalars['BigInt']>>;
-  creditRateMantissa_lt?: Maybe<Scalars['BigInt']>;
-  creditRateMantissa_lte?: Maybe<Scalars['BigInt']>;
-  creditRateMantissa_not?: Maybe<Scalars['BigInt']>;
-  creditRateMantissa_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  prizePool?: Maybe<Scalars['String']>;
-  prizePool_contains?: Maybe<Scalars['String']>;
-  prizePool_ends_with?: Maybe<Scalars['String']>;
-  prizePool_gt?: Maybe<Scalars['String']>;
-  prizePool_gte?: Maybe<Scalars['String']>;
-  prizePool_in?: Maybe<Array<Scalars['String']>>;
-  prizePool_lt?: Maybe<Scalars['String']>;
-  prizePool_lte?: Maybe<Scalars['String']>;
-  prizePool_not?: Maybe<Scalars['String']>;
-  prizePool_not_contains?: Maybe<Scalars['String']>;
-  prizePool_not_ends_with?: Maybe<Scalars['String']>;
-  prizePool_not_in?: Maybe<Array<Scalars['String']>>;
-  prizePool_not_starts_with?: Maybe<Scalars['String']>;
-  prizePool_starts_with?: Maybe<Scalars['String']>;
+  creditLimitMantissa?: Maybe<Scalars["BigInt"]>;
+  creditLimitMantissa_gt?: Maybe<Scalars["BigInt"]>;
+  creditLimitMantissa_gte?: Maybe<Scalars["BigInt"]>;
+  creditLimitMantissa_in?: Maybe<Array<Scalars["BigInt"]>>;
+  creditLimitMantissa_lt?: Maybe<Scalars["BigInt"]>;
+  creditLimitMantissa_lte?: Maybe<Scalars["BigInt"]>;
+  creditLimitMantissa_not?: Maybe<Scalars["BigInt"]>;
+  creditLimitMantissa_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  creditRateMantissa?: Maybe<Scalars["BigInt"]>;
+  creditRateMantissa_gt?: Maybe<Scalars["BigInt"]>;
+  creditRateMantissa_gte?: Maybe<Scalars["BigInt"]>;
+  creditRateMantissa_in?: Maybe<Array<Scalars["BigInt"]>>;
+  creditRateMantissa_lt?: Maybe<Scalars["BigInt"]>;
+  creditRateMantissa_lte?: Maybe<Scalars["BigInt"]>;
+  creditRateMantissa_not?: Maybe<Scalars["BigInt"]>;
+  creditRateMantissa_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  prizePool?: Maybe<Scalars["String"]>;
+  prizePool_contains?: Maybe<Scalars["String"]>;
+  prizePool_ends_with?: Maybe<Scalars["String"]>;
+  prizePool_gt?: Maybe<Scalars["String"]>;
+  prizePool_gte?: Maybe<Scalars["String"]>;
+  prizePool_in?: Maybe<Array<Scalars["String"]>>;
+  prizePool_lt?: Maybe<Scalars["String"]>;
+  prizePool_lte?: Maybe<Scalars["String"]>;
+  prizePool_not?: Maybe<Scalars["String"]>;
+  prizePool_not_contains?: Maybe<Scalars["String"]>;
+  prizePool_not_ends_with?: Maybe<Scalars["String"]>;
+  prizePool_not_in?: Maybe<Array<Scalars["String"]>>;
+  prizePool_not_starts_with?: Maybe<Scalars["String"]>;
+  prizePool_starts_with?: Maybe<Scalars["String"]>;
 };
 
 export enum CreditRate_OrderBy {
-  CreditLimitMantissa = 'creditLimitMantissa',
-  CreditRateMantissa = 'creditRateMantissa',
-  Id = 'id',
-  PrizePool = 'prizePool'
+  CreditLimitMantissa = "creditLimitMantissa",
+  CreditRateMantissa = "creditRateMantissa",
+  Id = "id",
+  PrizePool = "prizePool",
 }
 
 export type DripTokenPlayer = {
-  __typename?: 'DripTokenPlayer';
-  address: Scalars['Bytes'];
-  balance: Scalars['BigInt'];
+  __typename?: "DripTokenPlayer";
+  address: Scalars["Bytes"];
+  balance: Scalars["BigInt"];
   comptroller: Comptroller;
-  dripToken: Scalars['Bytes'];
-  id: Scalars['ID'];
+  dripToken: Scalars["Bytes"];
+  id: Scalars["ID"];
 };
 
 export type DripTokenPlayer_Filter = {
-  address?: Maybe<Scalars['Bytes']>;
-  address_contains?: Maybe<Scalars['Bytes']>;
-  address_in?: Maybe<Array<Scalars['Bytes']>>;
-  address_not?: Maybe<Scalars['Bytes']>;
-  address_not_contains?: Maybe<Scalars['Bytes']>;
-  address_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  balance?: Maybe<Scalars['BigInt']>;
-  balance_gt?: Maybe<Scalars['BigInt']>;
-  balance_gte?: Maybe<Scalars['BigInt']>;
-  balance_in?: Maybe<Array<Scalars['BigInt']>>;
-  balance_lt?: Maybe<Scalars['BigInt']>;
-  balance_lte?: Maybe<Scalars['BigInt']>;
-  balance_not?: Maybe<Scalars['BigInt']>;
-  balance_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  comptroller?: Maybe<Scalars['String']>;
-  comptroller_contains?: Maybe<Scalars['String']>;
-  comptroller_ends_with?: Maybe<Scalars['String']>;
-  comptroller_gt?: Maybe<Scalars['String']>;
-  comptroller_gte?: Maybe<Scalars['String']>;
-  comptroller_in?: Maybe<Array<Scalars['String']>>;
-  comptroller_lt?: Maybe<Scalars['String']>;
-  comptroller_lte?: Maybe<Scalars['String']>;
-  comptroller_not?: Maybe<Scalars['String']>;
-  comptroller_not_contains?: Maybe<Scalars['String']>;
-  comptroller_not_ends_with?: Maybe<Scalars['String']>;
-  comptroller_not_in?: Maybe<Array<Scalars['String']>>;
-  comptroller_not_starts_with?: Maybe<Scalars['String']>;
-  comptroller_starts_with?: Maybe<Scalars['String']>;
-  dripToken?: Maybe<Scalars['Bytes']>;
-  dripToken_contains?: Maybe<Scalars['Bytes']>;
-  dripToken_in?: Maybe<Array<Scalars['Bytes']>>;
-  dripToken_not?: Maybe<Scalars['Bytes']>;
-  dripToken_not_contains?: Maybe<Scalars['Bytes']>;
-  dripToken_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
+  address?: Maybe<Scalars["Bytes"]>;
+  address_contains?: Maybe<Scalars["Bytes"]>;
+  address_in?: Maybe<Array<Scalars["Bytes"]>>;
+  address_not?: Maybe<Scalars["Bytes"]>;
+  address_not_contains?: Maybe<Scalars["Bytes"]>;
+  address_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  balance?: Maybe<Scalars["BigInt"]>;
+  balance_gt?: Maybe<Scalars["BigInt"]>;
+  balance_gte?: Maybe<Scalars["BigInt"]>;
+  balance_in?: Maybe<Array<Scalars["BigInt"]>>;
+  balance_lt?: Maybe<Scalars["BigInt"]>;
+  balance_lte?: Maybe<Scalars["BigInt"]>;
+  balance_not?: Maybe<Scalars["BigInt"]>;
+  balance_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  comptroller?: Maybe<Scalars["String"]>;
+  comptroller_contains?: Maybe<Scalars["String"]>;
+  comptroller_ends_with?: Maybe<Scalars["String"]>;
+  comptroller_gt?: Maybe<Scalars["String"]>;
+  comptroller_gte?: Maybe<Scalars["String"]>;
+  comptroller_in?: Maybe<Array<Scalars["String"]>>;
+  comptroller_lt?: Maybe<Scalars["String"]>;
+  comptroller_lte?: Maybe<Scalars["String"]>;
+  comptroller_not?: Maybe<Scalars["String"]>;
+  comptroller_not_contains?: Maybe<Scalars["String"]>;
+  comptroller_not_ends_with?: Maybe<Scalars["String"]>;
+  comptroller_not_in?: Maybe<Array<Scalars["String"]>>;
+  comptroller_not_starts_with?: Maybe<Scalars["String"]>;
+  comptroller_starts_with?: Maybe<Scalars["String"]>;
+  dripToken?: Maybe<Scalars["Bytes"]>;
+  dripToken_contains?: Maybe<Scalars["Bytes"]>;
+  dripToken_in?: Maybe<Array<Scalars["Bytes"]>>;
+  dripToken_not?: Maybe<Scalars["Bytes"]>;
+  dripToken_not_contains?: Maybe<Scalars["Bytes"]>;
+  dripToken_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
 };
 
 export enum DripTokenPlayer_OrderBy {
-  Address = 'address',
-  Balance = 'balance',
-  Comptroller = 'comptroller',
-  DripToken = 'dripToken',
-  Id = 'id'
+  Address = "address",
+  Balance = "balance",
+  Comptroller = "comptroller",
+  DripToken = "dripToken",
+  Id = "id",
 }
 
 export type MultipleWinnersExternalErc20Award = {
-  __typename?: 'MultipleWinnersExternalErc20Award';
-  address: Scalars['Bytes'];
-  balanceAwarded?: Maybe<Scalars['BigInt']>;
-  decimals?: Maybe<Scalars['BigInt']>;
-  id: Scalars['ID'];
-  name?: Maybe<Scalars['String']>;
+  __typename?: "MultipleWinnersExternalErc20Award";
+  address: Scalars["Bytes"];
+  balanceAwarded?: Maybe<Scalars["BigInt"]>;
+  decimals?: Maybe<Scalars["BigInt"]>;
+  id: Scalars["ID"];
+  name?: Maybe<Scalars["String"]>;
   prizeStrategy?: Maybe<MultipleWinnersPrizeStrategy>;
-  symbol?: Maybe<Scalars['String']>;
+  symbol?: Maybe<Scalars["String"]>;
 };
 
 export type MultipleWinnersExternalErc20Award_Filter = {
-  address?: Maybe<Scalars['Bytes']>;
-  address_contains?: Maybe<Scalars['Bytes']>;
-  address_in?: Maybe<Array<Scalars['Bytes']>>;
-  address_not?: Maybe<Scalars['Bytes']>;
-  address_not_contains?: Maybe<Scalars['Bytes']>;
-  address_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  balanceAwarded?: Maybe<Scalars['BigInt']>;
-  balanceAwarded_gt?: Maybe<Scalars['BigInt']>;
-  balanceAwarded_gte?: Maybe<Scalars['BigInt']>;
-  balanceAwarded_in?: Maybe<Array<Scalars['BigInt']>>;
-  balanceAwarded_lt?: Maybe<Scalars['BigInt']>;
-  balanceAwarded_lte?: Maybe<Scalars['BigInt']>;
-  balanceAwarded_not?: Maybe<Scalars['BigInt']>;
-  balanceAwarded_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  decimals?: Maybe<Scalars['BigInt']>;
-  decimals_gt?: Maybe<Scalars['BigInt']>;
-  decimals_gte?: Maybe<Scalars['BigInt']>;
-  decimals_in?: Maybe<Array<Scalars['BigInt']>>;
-  decimals_lt?: Maybe<Scalars['BigInt']>;
-  decimals_lte?: Maybe<Scalars['BigInt']>;
-  decimals_not?: Maybe<Scalars['BigInt']>;
-  decimals_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  name?: Maybe<Scalars['String']>;
-  name_contains?: Maybe<Scalars['String']>;
-  name_ends_with?: Maybe<Scalars['String']>;
-  name_gt?: Maybe<Scalars['String']>;
-  name_gte?: Maybe<Scalars['String']>;
-  name_in?: Maybe<Array<Scalars['String']>>;
-  name_lt?: Maybe<Scalars['String']>;
-  name_lte?: Maybe<Scalars['String']>;
-  name_not?: Maybe<Scalars['String']>;
-  name_not_contains?: Maybe<Scalars['String']>;
-  name_not_ends_with?: Maybe<Scalars['String']>;
-  name_not_in?: Maybe<Array<Scalars['String']>>;
-  name_not_starts_with?: Maybe<Scalars['String']>;
-  name_starts_with?: Maybe<Scalars['String']>;
-  prizeStrategy?: Maybe<Scalars['String']>;
-  prizeStrategy_contains?: Maybe<Scalars['String']>;
-  prizeStrategy_ends_with?: Maybe<Scalars['String']>;
-  prizeStrategy_gt?: Maybe<Scalars['String']>;
-  prizeStrategy_gte?: Maybe<Scalars['String']>;
-  prizeStrategy_in?: Maybe<Array<Scalars['String']>>;
-  prizeStrategy_lt?: Maybe<Scalars['String']>;
-  prizeStrategy_lte?: Maybe<Scalars['String']>;
-  prizeStrategy_not?: Maybe<Scalars['String']>;
-  prizeStrategy_not_contains?: Maybe<Scalars['String']>;
-  prizeStrategy_not_ends_with?: Maybe<Scalars['String']>;
-  prizeStrategy_not_in?: Maybe<Array<Scalars['String']>>;
-  prizeStrategy_not_starts_with?: Maybe<Scalars['String']>;
-  prizeStrategy_starts_with?: Maybe<Scalars['String']>;
-  symbol?: Maybe<Scalars['String']>;
-  symbol_contains?: Maybe<Scalars['String']>;
-  symbol_ends_with?: Maybe<Scalars['String']>;
-  symbol_gt?: Maybe<Scalars['String']>;
-  symbol_gte?: Maybe<Scalars['String']>;
-  symbol_in?: Maybe<Array<Scalars['String']>>;
-  symbol_lt?: Maybe<Scalars['String']>;
-  symbol_lte?: Maybe<Scalars['String']>;
-  symbol_not?: Maybe<Scalars['String']>;
-  symbol_not_contains?: Maybe<Scalars['String']>;
-  symbol_not_ends_with?: Maybe<Scalars['String']>;
-  symbol_not_in?: Maybe<Array<Scalars['String']>>;
-  symbol_not_starts_with?: Maybe<Scalars['String']>;
-  symbol_starts_with?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars["Bytes"]>;
+  address_contains?: Maybe<Scalars["Bytes"]>;
+  address_in?: Maybe<Array<Scalars["Bytes"]>>;
+  address_not?: Maybe<Scalars["Bytes"]>;
+  address_not_contains?: Maybe<Scalars["Bytes"]>;
+  address_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  balanceAwarded?: Maybe<Scalars["BigInt"]>;
+  balanceAwarded_gt?: Maybe<Scalars["BigInt"]>;
+  balanceAwarded_gte?: Maybe<Scalars["BigInt"]>;
+  balanceAwarded_in?: Maybe<Array<Scalars["BigInt"]>>;
+  balanceAwarded_lt?: Maybe<Scalars["BigInt"]>;
+  balanceAwarded_lte?: Maybe<Scalars["BigInt"]>;
+  balanceAwarded_not?: Maybe<Scalars["BigInt"]>;
+  balanceAwarded_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  decimals?: Maybe<Scalars["BigInt"]>;
+  decimals_gt?: Maybe<Scalars["BigInt"]>;
+  decimals_gte?: Maybe<Scalars["BigInt"]>;
+  decimals_in?: Maybe<Array<Scalars["BigInt"]>>;
+  decimals_lt?: Maybe<Scalars["BigInt"]>;
+  decimals_lte?: Maybe<Scalars["BigInt"]>;
+  decimals_not?: Maybe<Scalars["BigInt"]>;
+  decimals_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  name?: Maybe<Scalars["String"]>;
+  name_contains?: Maybe<Scalars["String"]>;
+  name_ends_with?: Maybe<Scalars["String"]>;
+  name_gt?: Maybe<Scalars["String"]>;
+  name_gte?: Maybe<Scalars["String"]>;
+  name_in?: Maybe<Array<Scalars["String"]>>;
+  name_lt?: Maybe<Scalars["String"]>;
+  name_lte?: Maybe<Scalars["String"]>;
+  name_not?: Maybe<Scalars["String"]>;
+  name_not_contains?: Maybe<Scalars["String"]>;
+  name_not_ends_with?: Maybe<Scalars["String"]>;
+  name_not_in?: Maybe<Array<Scalars["String"]>>;
+  name_not_starts_with?: Maybe<Scalars["String"]>;
+  name_starts_with?: Maybe<Scalars["String"]>;
+  prizeStrategy?: Maybe<Scalars["String"]>;
+  prizeStrategy_contains?: Maybe<Scalars["String"]>;
+  prizeStrategy_ends_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_gt?: Maybe<Scalars["String"]>;
+  prizeStrategy_gte?: Maybe<Scalars["String"]>;
+  prizeStrategy_in?: Maybe<Array<Scalars["String"]>>;
+  prizeStrategy_lt?: Maybe<Scalars["String"]>;
+  prizeStrategy_lte?: Maybe<Scalars["String"]>;
+  prizeStrategy_not?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_contains?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_ends_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_in?: Maybe<Array<Scalars["String"]>>;
+  prizeStrategy_not_starts_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_starts_with?: Maybe<Scalars["String"]>;
+  symbol?: Maybe<Scalars["String"]>;
+  symbol_contains?: Maybe<Scalars["String"]>;
+  symbol_ends_with?: Maybe<Scalars["String"]>;
+  symbol_gt?: Maybe<Scalars["String"]>;
+  symbol_gte?: Maybe<Scalars["String"]>;
+  symbol_in?: Maybe<Array<Scalars["String"]>>;
+  symbol_lt?: Maybe<Scalars["String"]>;
+  symbol_lte?: Maybe<Scalars["String"]>;
+  symbol_not?: Maybe<Scalars["String"]>;
+  symbol_not_contains?: Maybe<Scalars["String"]>;
+  symbol_not_ends_with?: Maybe<Scalars["String"]>;
+  symbol_not_in?: Maybe<Array<Scalars["String"]>>;
+  symbol_not_starts_with?: Maybe<Scalars["String"]>;
+  symbol_starts_with?: Maybe<Scalars["String"]>;
 };
 
 export enum MultipleWinnersExternalErc20Award_OrderBy {
-  Address = 'address',
-  BalanceAwarded = 'balanceAwarded',
-  Decimals = 'decimals',
-  Id = 'id',
-  Name = 'name',
-  PrizeStrategy = 'prizeStrategy',
-  Symbol = 'symbol'
+  Address = "address",
+  BalanceAwarded = "balanceAwarded",
+  Decimals = "decimals",
+  Id = "id",
+  Name = "name",
+  PrizeStrategy = "prizeStrategy",
+  Symbol = "symbol",
 }
 
 export type MultipleWinnersExternalErc721Award = {
-  __typename?: 'MultipleWinnersExternalErc721Award';
-  address: Scalars['Bytes'];
-  id: Scalars['ID'];
+  __typename?: "MultipleWinnersExternalErc721Award";
+  address: Scalars["Bytes"];
+  id: Scalars["ID"];
   prizeStrategy?: Maybe<MultipleWinnersPrizeStrategy>;
-  tokenIds?: Maybe<Array<Scalars['BigInt']>>;
+  tokenIds?: Maybe<Array<Scalars["BigInt"]>>;
 };
 
 export type MultipleWinnersExternalErc721Award_Filter = {
-  address?: Maybe<Scalars['Bytes']>;
-  address_contains?: Maybe<Scalars['Bytes']>;
-  address_in?: Maybe<Array<Scalars['Bytes']>>;
-  address_not?: Maybe<Scalars['Bytes']>;
-  address_not_contains?: Maybe<Scalars['Bytes']>;
-  address_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  prizeStrategy?: Maybe<Scalars['String']>;
-  prizeStrategy_contains?: Maybe<Scalars['String']>;
-  prizeStrategy_ends_with?: Maybe<Scalars['String']>;
-  prizeStrategy_gt?: Maybe<Scalars['String']>;
-  prizeStrategy_gte?: Maybe<Scalars['String']>;
-  prizeStrategy_in?: Maybe<Array<Scalars['String']>>;
-  prizeStrategy_lt?: Maybe<Scalars['String']>;
-  prizeStrategy_lte?: Maybe<Scalars['String']>;
-  prizeStrategy_not?: Maybe<Scalars['String']>;
-  prizeStrategy_not_contains?: Maybe<Scalars['String']>;
-  prizeStrategy_not_ends_with?: Maybe<Scalars['String']>;
-  prizeStrategy_not_in?: Maybe<Array<Scalars['String']>>;
-  prizeStrategy_not_starts_with?: Maybe<Scalars['String']>;
-  prizeStrategy_starts_with?: Maybe<Scalars['String']>;
-  tokenIds?: Maybe<Array<Scalars['BigInt']>>;
-  tokenIds_contains?: Maybe<Array<Scalars['BigInt']>>;
-  tokenIds_not?: Maybe<Array<Scalars['BigInt']>>;
-  tokenIds_not_contains?: Maybe<Array<Scalars['BigInt']>>;
+  address?: Maybe<Scalars["Bytes"]>;
+  address_contains?: Maybe<Scalars["Bytes"]>;
+  address_in?: Maybe<Array<Scalars["Bytes"]>>;
+  address_not?: Maybe<Scalars["Bytes"]>;
+  address_not_contains?: Maybe<Scalars["Bytes"]>;
+  address_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  prizeStrategy?: Maybe<Scalars["String"]>;
+  prizeStrategy_contains?: Maybe<Scalars["String"]>;
+  prizeStrategy_ends_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_gt?: Maybe<Scalars["String"]>;
+  prizeStrategy_gte?: Maybe<Scalars["String"]>;
+  prizeStrategy_in?: Maybe<Array<Scalars["String"]>>;
+  prizeStrategy_lt?: Maybe<Scalars["String"]>;
+  prizeStrategy_lte?: Maybe<Scalars["String"]>;
+  prizeStrategy_not?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_contains?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_ends_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_in?: Maybe<Array<Scalars["String"]>>;
+  prizeStrategy_not_starts_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_starts_with?: Maybe<Scalars["String"]>;
+  tokenIds?: Maybe<Array<Scalars["BigInt"]>>;
+  tokenIds_contains?: Maybe<Array<Scalars["BigInt"]>>;
+  tokenIds_not?: Maybe<Array<Scalars["BigInt"]>>;
+  tokenIds_not_contains?: Maybe<Array<Scalars["BigInt"]>>;
 };
 
 export enum MultipleWinnersExternalErc721Award_OrderBy {
-  Address = 'address',
-  Id = 'id',
-  PrizeStrategy = 'prizeStrategy',
-  TokenIds = 'tokenIds'
+  Address = "address",
+  Id = "id",
+  PrizeStrategy = "prizeStrategy",
+  TokenIds = "tokenIds",
 }
 
 export type MultipleWinnersPrizeStrategy = {
-  __typename?: 'MultipleWinnersPrizeStrategy';
-  blockListedAddresses?: Maybe<Array<Scalars['Bytes']>>;
+  __typename?: "MultipleWinnersPrizeStrategy";
+  blockListedAddresses?: Maybe<Array<Scalars["Bytes"]>>;
   externalErc20Awards: Array<MultipleWinnersExternalErc20Award>;
   externalErc721Awards: Array<MultipleWinnersExternalErc721Award>;
-  id: Scalars['ID'];
-  numberOfWinners?: Maybe<Scalars['BigInt']>;
-  owner?: Maybe<Scalars['Bytes']>;
-  prizePeriodEndAt: Scalars['BigInt'];
-  prizePeriodSeconds: Scalars['BigInt'];
-  prizePeriodStartedAt: Scalars['BigInt'];
+  id: Scalars["ID"];
+  numberOfWinners?: Maybe<Scalars["BigInt"]>;
+  owner?: Maybe<Scalars["Bytes"]>;
+  prizePeriodEndAt: Scalars["BigInt"];
+  prizePeriodSeconds: Scalars["BigInt"];
+  prizePeriodStartedAt: Scalars["BigInt"];
   prizePool?: Maybe<PrizePool>;
   prizeSplits?: Maybe<Array<PrizeSplit>>;
-  rng?: Maybe<Scalars['Bytes']>;
-  splitExternalERC20Awards?: Maybe<Scalars['Boolean']>;
+  rng?: Maybe<Scalars["Bytes"]>;
+  splitExternalERC20Awards?: Maybe<Scalars["Boolean"]>;
   sponsorship?: Maybe<ControlledToken>;
   ticket?: Maybe<ControlledToken>;
-  tokenListener?: Maybe<Scalars['Bytes']>;
+  tokenListener?: Maybe<Scalars["Bytes"]>;
 };
 
-
 export type MultipleWinnersPrizeStrategyExternalErc20AwardsArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<MultipleWinnersExternalErc20Award_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<MultipleWinnersExternalErc20Award_Filter>;
 };
 
-
 export type MultipleWinnersPrizeStrategyExternalErc721AwardsArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<MultipleWinnersExternalErc721Award_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<MultipleWinnersExternalErc721Award_Filter>;
 };
 
-
 export type MultipleWinnersPrizeStrategyPrizeSplitsArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<PrizeSplit_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<PrizeSplit_Filter>;
 };
 
 export type MultipleWinnersPrizeStrategy_Filter = {
-  blockListedAddresses?: Maybe<Array<Scalars['Bytes']>>;
-  blockListedAddresses_contains?: Maybe<Array<Scalars['Bytes']>>;
-  blockListedAddresses_not?: Maybe<Array<Scalars['Bytes']>>;
-  blockListedAddresses_not_contains?: Maybe<Array<Scalars['Bytes']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  numberOfWinners?: Maybe<Scalars['BigInt']>;
-  numberOfWinners_gt?: Maybe<Scalars['BigInt']>;
-  numberOfWinners_gte?: Maybe<Scalars['BigInt']>;
-  numberOfWinners_in?: Maybe<Array<Scalars['BigInt']>>;
-  numberOfWinners_lt?: Maybe<Scalars['BigInt']>;
-  numberOfWinners_lte?: Maybe<Scalars['BigInt']>;
-  numberOfWinners_not?: Maybe<Scalars['BigInt']>;
-  numberOfWinners_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  owner?: Maybe<Scalars['Bytes']>;
-  owner_contains?: Maybe<Scalars['Bytes']>;
-  owner_in?: Maybe<Array<Scalars['Bytes']>>;
-  owner_not?: Maybe<Scalars['Bytes']>;
-  owner_not_contains?: Maybe<Scalars['Bytes']>;
-  owner_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  prizePeriodEndAt?: Maybe<Scalars['BigInt']>;
-  prizePeriodEndAt_gt?: Maybe<Scalars['BigInt']>;
-  prizePeriodEndAt_gte?: Maybe<Scalars['BigInt']>;
-  prizePeriodEndAt_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizePeriodEndAt_lt?: Maybe<Scalars['BigInt']>;
-  prizePeriodEndAt_lte?: Maybe<Scalars['BigInt']>;
-  prizePeriodEndAt_not?: Maybe<Scalars['BigInt']>;
-  prizePeriodEndAt_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizePeriodSeconds?: Maybe<Scalars['BigInt']>;
-  prizePeriodSeconds_gt?: Maybe<Scalars['BigInt']>;
-  prizePeriodSeconds_gte?: Maybe<Scalars['BigInt']>;
-  prizePeriodSeconds_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizePeriodSeconds_lt?: Maybe<Scalars['BigInt']>;
-  prizePeriodSeconds_lte?: Maybe<Scalars['BigInt']>;
-  prizePeriodSeconds_not?: Maybe<Scalars['BigInt']>;
-  prizePeriodSeconds_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizePeriodStartedAt?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedAt_gt?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedAt_gte?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedAt_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizePeriodStartedAt_lt?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedAt_lte?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedAt_not?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedAt_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizePool?: Maybe<Scalars['String']>;
-  prizePool_contains?: Maybe<Scalars['String']>;
-  prizePool_ends_with?: Maybe<Scalars['String']>;
-  prizePool_gt?: Maybe<Scalars['String']>;
-  prizePool_gte?: Maybe<Scalars['String']>;
-  prizePool_in?: Maybe<Array<Scalars['String']>>;
-  prizePool_lt?: Maybe<Scalars['String']>;
-  prizePool_lte?: Maybe<Scalars['String']>;
-  prizePool_not?: Maybe<Scalars['String']>;
-  prizePool_not_contains?: Maybe<Scalars['String']>;
-  prizePool_not_ends_with?: Maybe<Scalars['String']>;
-  prizePool_not_in?: Maybe<Array<Scalars['String']>>;
-  prizePool_not_starts_with?: Maybe<Scalars['String']>;
-  prizePool_starts_with?: Maybe<Scalars['String']>;
-  rng?: Maybe<Scalars['Bytes']>;
-  rng_contains?: Maybe<Scalars['Bytes']>;
-  rng_in?: Maybe<Array<Scalars['Bytes']>>;
-  rng_not?: Maybe<Scalars['Bytes']>;
-  rng_not_contains?: Maybe<Scalars['Bytes']>;
-  rng_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  splitExternalERC20Awards?: Maybe<Scalars['Boolean']>;
-  splitExternalERC20Awards_in?: Maybe<Array<Scalars['Boolean']>>;
-  splitExternalERC20Awards_not?: Maybe<Scalars['Boolean']>;
-  splitExternalERC20Awards_not_in?: Maybe<Array<Scalars['Boolean']>>;
-  sponsorship?: Maybe<Scalars['String']>;
-  sponsorship_contains?: Maybe<Scalars['String']>;
-  sponsorship_ends_with?: Maybe<Scalars['String']>;
-  sponsorship_gt?: Maybe<Scalars['String']>;
-  sponsorship_gte?: Maybe<Scalars['String']>;
-  sponsorship_in?: Maybe<Array<Scalars['String']>>;
-  sponsorship_lt?: Maybe<Scalars['String']>;
-  sponsorship_lte?: Maybe<Scalars['String']>;
-  sponsorship_not?: Maybe<Scalars['String']>;
-  sponsorship_not_contains?: Maybe<Scalars['String']>;
-  sponsorship_not_ends_with?: Maybe<Scalars['String']>;
-  sponsorship_not_in?: Maybe<Array<Scalars['String']>>;
-  sponsorship_not_starts_with?: Maybe<Scalars['String']>;
-  sponsorship_starts_with?: Maybe<Scalars['String']>;
-  ticket?: Maybe<Scalars['String']>;
-  ticket_contains?: Maybe<Scalars['String']>;
-  ticket_ends_with?: Maybe<Scalars['String']>;
-  ticket_gt?: Maybe<Scalars['String']>;
-  ticket_gte?: Maybe<Scalars['String']>;
-  ticket_in?: Maybe<Array<Scalars['String']>>;
-  ticket_lt?: Maybe<Scalars['String']>;
-  ticket_lte?: Maybe<Scalars['String']>;
-  ticket_not?: Maybe<Scalars['String']>;
-  ticket_not_contains?: Maybe<Scalars['String']>;
-  ticket_not_ends_with?: Maybe<Scalars['String']>;
-  ticket_not_in?: Maybe<Array<Scalars['String']>>;
-  ticket_not_starts_with?: Maybe<Scalars['String']>;
-  ticket_starts_with?: Maybe<Scalars['String']>;
-  tokenListener?: Maybe<Scalars['Bytes']>;
-  tokenListener_contains?: Maybe<Scalars['Bytes']>;
-  tokenListener_in?: Maybe<Array<Scalars['Bytes']>>;
-  tokenListener_not?: Maybe<Scalars['Bytes']>;
-  tokenListener_not_contains?: Maybe<Scalars['Bytes']>;
-  tokenListener_not_in?: Maybe<Array<Scalars['Bytes']>>;
+  blockListedAddresses?: Maybe<Array<Scalars["Bytes"]>>;
+  blockListedAddresses_contains?: Maybe<Array<Scalars["Bytes"]>>;
+  blockListedAddresses_not?: Maybe<Array<Scalars["Bytes"]>>;
+  blockListedAddresses_not_contains?: Maybe<Array<Scalars["Bytes"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  numberOfWinners?: Maybe<Scalars["BigInt"]>;
+  numberOfWinners_gt?: Maybe<Scalars["BigInt"]>;
+  numberOfWinners_gte?: Maybe<Scalars["BigInt"]>;
+  numberOfWinners_in?: Maybe<Array<Scalars["BigInt"]>>;
+  numberOfWinners_lt?: Maybe<Scalars["BigInt"]>;
+  numberOfWinners_lte?: Maybe<Scalars["BigInt"]>;
+  numberOfWinners_not?: Maybe<Scalars["BigInt"]>;
+  numberOfWinners_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  owner?: Maybe<Scalars["Bytes"]>;
+  owner_contains?: Maybe<Scalars["Bytes"]>;
+  owner_in?: Maybe<Array<Scalars["Bytes"]>>;
+  owner_not?: Maybe<Scalars["Bytes"]>;
+  owner_not_contains?: Maybe<Scalars["Bytes"]>;
+  owner_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  prizePeriodEndAt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodEndAt_gt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodEndAt_gte?: Maybe<Scalars["BigInt"]>;
+  prizePeriodEndAt_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizePeriodEndAt_lt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodEndAt_lte?: Maybe<Scalars["BigInt"]>;
+  prizePeriodEndAt_not?: Maybe<Scalars["BigInt"]>;
+  prizePeriodEndAt_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizePeriodSeconds?: Maybe<Scalars["BigInt"]>;
+  prizePeriodSeconds_gt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodSeconds_gte?: Maybe<Scalars["BigInt"]>;
+  prizePeriodSeconds_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizePeriodSeconds_lt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodSeconds_lte?: Maybe<Scalars["BigInt"]>;
+  prizePeriodSeconds_not?: Maybe<Scalars["BigInt"]>;
+  prizePeriodSeconds_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizePeriodStartedAt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedAt_gt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedAt_gte?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedAt_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizePeriodStartedAt_lt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedAt_lte?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedAt_not?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedAt_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizePool?: Maybe<Scalars["String"]>;
+  prizePool_contains?: Maybe<Scalars["String"]>;
+  prizePool_ends_with?: Maybe<Scalars["String"]>;
+  prizePool_gt?: Maybe<Scalars["String"]>;
+  prizePool_gte?: Maybe<Scalars["String"]>;
+  prizePool_in?: Maybe<Array<Scalars["String"]>>;
+  prizePool_lt?: Maybe<Scalars["String"]>;
+  prizePool_lte?: Maybe<Scalars["String"]>;
+  prizePool_not?: Maybe<Scalars["String"]>;
+  prizePool_not_contains?: Maybe<Scalars["String"]>;
+  prizePool_not_ends_with?: Maybe<Scalars["String"]>;
+  prizePool_not_in?: Maybe<Array<Scalars["String"]>>;
+  prizePool_not_starts_with?: Maybe<Scalars["String"]>;
+  prizePool_starts_with?: Maybe<Scalars["String"]>;
+  rng?: Maybe<Scalars["Bytes"]>;
+  rng_contains?: Maybe<Scalars["Bytes"]>;
+  rng_in?: Maybe<Array<Scalars["Bytes"]>>;
+  rng_not?: Maybe<Scalars["Bytes"]>;
+  rng_not_contains?: Maybe<Scalars["Bytes"]>;
+  rng_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  splitExternalERC20Awards?: Maybe<Scalars["Boolean"]>;
+  splitExternalERC20Awards_in?: Maybe<Array<Scalars["Boolean"]>>;
+  splitExternalERC20Awards_not?: Maybe<Scalars["Boolean"]>;
+  splitExternalERC20Awards_not_in?: Maybe<Array<Scalars["Boolean"]>>;
+  sponsorship?: Maybe<Scalars["String"]>;
+  sponsorship_contains?: Maybe<Scalars["String"]>;
+  sponsorship_ends_with?: Maybe<Scalars["String"]>;
+  sponsorship_gt?: Maybe<Scalars["String"]>;
+  sponsorship_gte?: Maybe<Scalars["String"]>;
+  sponsorship_in?: Maybe<Array<Scalars["String"]>>;
+  sponsorship_lt?: Maybe<Scalars["String"]>;
+  sponsorship_lte?: Maybe<Scalars["String"]>;
+  sponsorship_not?: Maybe<Scalars["String"]>;
+  sponsorship_not_contains?: Maybe<Scalars["String"]>;
+  sponsorship_not_ends_with?: Maybe<Scalars["String"]>;
+  sponsorship_not_in?: Maybe<Array<Scalars["String"]>>;
+  sponsorship_not_starts_with?: Maybe<Scalars["String"]>;
+  sponsorship_starts_with?: Maybe<Scalars["String"]>;
+  ticket?: Maybe<Scalars["String"]>;
+  ticket_contains?: Maybe<Scalars["String"]>;
+  ticket_ends_with?: Maybe<Scalars["String"]>;
+  ticket_gt?: Maybe<Scalars["String"]>;
+  ticket_gte?: Maybe<Scalars["String"]>;
+  ticket_in?: Maybe<Array<Scalars["String"]>>;
+  ticket_lt?: Maybe<Scalars["String"]>;
+  ticket_lte?: Maybe<Scalars["String"]>;
+  ticket_not?: Maybe<Scalars["String"]>;
+  ticket_not_contains?: Maybe<Scalars["String"]>;
+  ticket_not_ends_with?: Maybe<Scalars["String"]>;
+  ticket_not_in?: Maybe<Array<Scalars["String"]>>;
+  ticket_not_starts_with?: Maybe<Scalars["String"]>;
+  ticket_starts_with?: Maybe<Scalars["String"]>;
+  tokenListener?: Maybe<Scalars["Bytes"]>;
+  tokenListener_contains?: Maybe<Scalars["Bytes"]>;
+  tokenListener_in?: Maybe<Array<Scalars["Bytes"]>>;
+  tokenListener_not?: Maybe<Scalars["Bytes"]>;
+  tokenListener_not_contains?: Maybe<Scalars["Bytes"]>;
+  tokenListener_not_in?: Maybe<Array<Scalars["Bytes"]>>;
 };
 
 export enum MultipleWinnersPrizeStrategy_OrderBy {
-  BlockListedAddresses = 'blockListedAddresses',
-  ExternalErc20Awards = 'externalErc20Awards',
-  ExternalErc721Awards = 'externalErc721Awards',
-  Id = 'id',
-  NumberOfWinners = 'numberOfWinners',
-  Owner = 'owner',
-  PrizePeriodEndAt = 'prizePeriodEndAt',
-  PrizePeriodSeconds = 'prizePeriodSeconds',
-  PrizePeriodStartedAt = 'prizePeriodStartedAt',
-  PrizePool = 'prizePool',
-  PrizeSplits = 'prizeSplits',
-  Rng = 'rng',
-  SplitExternalErc20Awards = 'splitExternalERC20Awards',
-  Sponsorship = 'sponsorship',
-  Ticket = 'ticket',
-  TokenListener = 'tokenListener'
+  BlockListedAddresses = "blockListedAddresses",
+  ExternalErc20Awards = "externalErc20Awards",
+  ExternalErc721Awards = "externalErc721Awards",
+  Id = "id",
+  NumberOfWinners = "numberOfWinners",
+  Owner = "owner",
+  PrizePeriodEndAt = "prizePeriodEndAt",
+  PrizePeriodSeconds = "prizePeriodSeconds",
+  PrizePeriodStartedAt = "prizePeriodStartedAt",
+  PrizePool = "prizePool",
+  PrizeSplits = "prizeSplits",
+  Rng = "rng",
+  SplitExternalErc20Awards = "splitExternalERC20Awards",
+  Sponsorship = "sponsorship",
+  Ticket = "ticket",
+  TokenListener = "tokenListener",
 }
 
 export enum OrderDirection {
-  Asc = 'asc',
-  Desc = 'desc'
+  Asc = "asc",
+  Desc = "desc",
 }
 
 export type Prize = {
-  __typename?: 'Prize';
-  awardStartOperator?: Maybe<Scalars['Bytes']>;
-  awardedBlock?: Maybe<Scalars['BigInt']>;
+  __typename?: "Prize";
+  awardStartOperator?: Maybe<Scalars["Bytes"]>;
+  awardedBlock?: Maybe<Scalars["BigInt"]>;
   awardedControlledTokens: Array<AwardedControlledToken>;
   awardedExternalErc20Tokens: Array<AwardedExternalErc20Token>;
   awardedExternalErc721Nfts: Array<AwardedExternalErc721Nft>;
-  awardedOperator?: Maybe<Scalars['Bytes']>;
-  awardedTimestamp?: Maybe<Scalars['BigInt']>;
-  id: Scalars['ID'];
-  lockBlock?: Maybe<Scalars['BigInt']>;
-  numberOfExternalAwardedErc20Winners?: Maybe<Scalars['BigInt']>;
-  numberOfSubWinners?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedTimestamp?: Maybe<Scalars['BigInt']>;
+  awardedOperator?: Maybe<Scalars["Bytes"]>;
+  awardedTimestamp?: Maybe<Scalars["BigInt"]>;
+  id: Scalars["ID"];
+  lockBlock?: Maybe<Scalars["BigInt"]>;
+  numberOfExternalAwardedErc20Winners?: Maybe<Scalars["BigInt"]>;
+  numberOfSubWinners?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedTimestamp?: Maybe<Scalars["BigInt"]>;
   prizePool: PrizePool;
-  randomNumber?: Maybe<Scalars['BigInt']>;
-  rngRequestId?: Maybe<Scalars['BigInt']>;
-  totalTicketSupply?: Maybe<Scalars['BigInt']>;
+  randomNumber?: Maybe<Scalars["BigInt"]>;
+  rngRequestId?: Maybe<Scalars["BigInt"]>;
+  totalTicketSupply?: Maybe<Scalars["BigInt"]>;
 };
 
-
 export type PrizeAwardedControlledTokensArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<AwardedControlledToken_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<AwardedControlledToken_Filter>;
 };
 
-
 export type PrizeAwardedExternalErc20TokensArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<AwardedExternalErc20Token_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<AwardedExternalErc20Token_Filter>;
 };
 
-
 export type PrizeAwardedExternalErc721NftsArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<AwardedExternalErc721Nft_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<AwardedExternalErc721Nft_Filter>;
 };
 
 export type PrizePool = {
-  __typename?: 'PrizePool';
+  __typename?: "PrizePool";
   compoundPrizePool?: Maybe<CompoundPrizePool>;
   controlledTokens: Array<ControlledToken>;
-  cumulativePrizeGross: Scalars['BigInt'];
-  cumulativePrizeNet: Scalars['BigInt'];
-  cumulativePrizeReserveFee: Scalars['BigInt'];
-  currentPrizeId: Scalars['BigInt'];
+  cumulativePrizeGross: Scalars["BigInt"];
+  cumulativePrizeNet: Scalars["BigInt"];
+  cumulativePrizeReserveFee: Scalars["BigInt"];
+  currentPrizeId: Scalars["BigInt"];
   currentState: PrizePoolState;
-  deactivated: Scalars['Boolean'];
-  id: Scalars['ID'];
-  liquidityCap: Scalars['BigInt'];
-  maxExitFeeMantissa: Scalars['BigInt'];
-  owner?: Maybe<Scalars['Bytes']>;
+  deactivated: Scalars["Boolean"];
+  id: Scalars["ID"];
+  liquidityCap: Scalars["BigInt"];
+  maxExitFeeMantissa: Scalars["BigInt"];
+  owner?: Maybe<Scalars["Bytes"]>;
   prizePoolAccounts: Array<PrizePoolAccount>;
   prizePoolType?: Maybe<PrizePoolType>;
   prizeStrategy?: Maybe<PrizeStrategy>;
   prizes: Array<Prize>;
-  reserveFeeControlledToken: Scalars['Bytes'];
-  reserveRegistry?: Maybe<Scalars['Bytes']>;
+  reserveFeeControlledToken: Scalars["Bytes"];
+  reserveRegistry?: Maybe<Scalars["Bytes"]>;
   sablierStream?: Maybe<SablierStream>;
   stakePrizePool?: Maybe<StakePrizePool>;
   tokenCreditBalances: Array<CreditBalance>;
   tokenCreditRates: Array<CreditRate>;
-  underlyingCollateralDecimals?: Maybe<Scalars['BigInt']>;
-  underlyingCollateralName?: Maybe<Scalars['String']>;
-  underlyingCollateralSymbol?: Maybe<Scalars['String']>;
-  underlyingCollateralToken?: Maybe<Scalars['Bytes']>;
+  underlyingCollateralDecimals?: Maybe<Scalars["BigInt"]>;
+  underlyingCollateralName?: Maybe<Scalars["String"]>;
+  underlyingCollateralSymbol?: Maybe<Scalars["String"]>;
+  underlyingCollateralToken?: Maybe<Scalars["Bytes"]>;
   yieldSourcePrizePool?: Maybe<YieldSourcePrizePool>;
 };
 
-
 export type PrizePoolControlledTokensArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<ControlledToken_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<ControlledToken_Filter>;
 };
 
-
 export type PrizePoolPrizePoolAccountsArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<PrizePoolAccount_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<PrizePoolAccount_Filter>;
 };
 
-
 export type PrizePoolPrizesArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<Prize_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<Prize_Filter>;
 };
 
-
 export type PrizePoolTokenCreditBalancesArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<CreditBalance_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<CreditBalance_Filter>;
 };
 
-
 export type PrizePoolTokenCreditRatesArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<CreditRate_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<CreditRate_Filter>;
 };
 
 export type PrizePoolAccount = {
-  __typename?: 'PrizePoolAccount';
+  __typename?: "PrizePoolAccount";
   account: Account;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   prizePool: PrizePool;
 };
 
 export type PrizePoolAccount_Filter = {
-  account?: Maybe<Scalars['String']>;
-  account_contains?: Maybe<Scalars['String']>;
-  account_ends_with?: Maybe<Scalars['String']>;
-  account_gt?: Maybe<Scalars['String']>;
-  account_gte?: Maybe<Scalars['String']>;
-  account_in?: Maybe<Array<Scalars['String']>>;
-  account_lt?: Maybe<Scalars['String']>;
-  account_lte?: Maybe<Scalars['String']>;
-  account_not?: Maybe<Scalars['String']>;
-  account_not_contains?: Maybe<Scalars['String']>;
-  account_not_ends_with?: Maybe<Scalars['String']>;
-  account_not_in?: Maybe<Array<Scalars['String']>>;
-  account_not_starts_with?: Maybe<Scalars['String']>;
-  account_starts_with?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  prizePool?: Maybe<Scalars['String']>;
-  prizePool_contains?: Maybe<Scalars['String']>;
-  prizePool_ends_with?: Maybe<Scalars['String']>;
-  prizePool_gt?: Maybe<Scalars['String']>;
-  prizePool_gte?: Maybe<Scalars['String']>;
-  prizePool_in?: Maybe<Array<Scalars['String']>>;
-  prizePool_lt?: Maybe<Scalars['String']>;
-  prizePool_lte?: Maybe<Scalars['String']>;
-  prizePool_not?: Maybe<Scalars['String']>;
-  prizePool_not_contains?: Maybe<Scalars['String']>;
-  prizePool_not_ends_with?: Maybe<Scalars['String']>;
-  prizePool_not_in?: Maybe<Array<Scalars['String']>>;
-  prizePool_not_starts_with?: Maybe<Scalars['String']>;
-  prizePool_starts_with?: Maybe<Scalars['String']>;
+  account?: Maybe<Scalars["String"]>;
+  account_contains?: Maybe<Scalars["String"]>;
+  account_ends_with?: Maybe<Scalars["String"]>;
+  account_gt?: Maybe<Scalars["String"]>;
+  account_gte?: Maybe<Scalars["String"]>;
+  account_in?: Maybe<Array<Scalars["String"]>>;
+  account_lt?: Maybe<Scalars["String"]>;
+  account_lte?: Maybe<Scalars["String"]>;
+  account_not?: Maybe<Scalars["String"]>;
+  account_not_contains?: Maybe<Scalars["String"]>;
+  account_not_ends_with?: Maybe<Scalars["String"]>;
+  account_not_in?: Maybe<Array<Scalars["String"]>>;
+  account_not_starts_with?: Maybe<Scalars["String"]>;
+  account_starts_with?: Maybe<Scalars["String"]>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  prizePool?: Maybe<Scalars["String"]>;
+  prizePool_contains?: Maybe<Scalars["String"]>;
+  prizePool_ends_with?: Maybe<Scalars["String"]>;
+  prizePool_gt?: Maybe<Scalars["String"]>;
+  prizePool_gte?: Maybe<Scalars["String"]>;
+  prizePool_in?: Maybe<Array<Scalars["String"]>>;
+  prizePool_lt?: Maybe<Scalars["String"]>;
+  prizePool_lte?: Maybe<Scalars["String"]>;
+  prizePool_not?: Maybe<Scalars["String"]>;
+  prizePool_not_contains?: Maybe<Scalars["String"]>;
+  prizePool_not_ends_with?: Maybe<Scalars["String"]>;
+  prizePool_not_in?: Maybe<Array<Scalars["String"]>>;
+  prizePool_not_starts_with?: Maybe<Scalars["String"]>;
+  prizePool_starts_with?: Maybe<Scalars["String"]>;
 };
 
 export enum PrizePoolAccount_OrderBy {
-  Account = 'account',
-  Id = 'id',
-  PrizePool = 'prizePool'
+  Account = "account",
+  Id = "id",
+  PrizePool = "prizePool",
 }
 
 export enum PrizePoolState {
-  Awarded = 'Awarded',
-  Opened = 'Opened',
-  Started = 'Started'
+  Awarded = "Awarded",
+  Opened = "Opened",
+  Started = "Started",
 }
 
 export enum PrizePoolType {
-  Compound = 'Compound',
-  Stake = 'Stake',
-  YieldSource = 'YieldSource',
-  YVault = 'yVault'
+  Compound = "Compound",
+  Stake = "Stake",
+  YieldSource = "YieldSource",
+  YVault = "yVault",
 }
 
 export type PrizePool_Filter = {
-  compoundPrizePool?: Maybe<Scalars['String']>;
-  compoundPrizePool_contains?: Maybe<Scalars['String']>;
-  compoundPrizePool_ends_with?: Maybe<Scalars['String']>;
-  compoundPrizePool_gt?: Maybe<Scalars['String']>;
-  compoundPrizePool_gte?: Maybe<Scalars['String']>;
-  compoundPrizePool_in?: Maybe<Array<Scalars['String']>>;
-  compoundPrizePool_lt?: Maybe<Scalars['String']>;
-  compoundPrizePool_lte?: Maybe<Scalars['String']>;
-  compoundPrizePool_not?: Maybe<Scalars['String']>;
-  compoundPrizePool_not_contains?: Maybe<Scalars['String']>;
-  compoundPrizePool_not_ends_with?: Maybe<Scalars['String']>;
-  compoundPrizePool_not_in?: Maybe<Array<Scalars['String']>>;
-  compoundPrizePool_not_starts_with?: Maybe<Scalars['String']>;
-  compoundPrizePool_starts_with?: Maybe<Scalars['String']>;
-  cumulativePrizeGross?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeGross_gt?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeGross_gte?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeGross_in?: Maybe<Array<Scalars['BigInt']>>;
-  cumulativePrizeGross_lt?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeGross_lte?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeGross_not?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeGross_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  cumulativePrizeNet?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeNet_gt?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeNet_gte?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeNet_in?: Maybe<Array<Scalars['BigInt']>>;
-  cumulativePrizeNet_lt?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeNet_lte?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeNet_not?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeNet_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  cumulativePrizeReserveFee?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeReserveFee_gt?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeReserveFee_gte?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeReserveFee_in?: Maybe<Array<Scalars['BigInt']>>;
-  cumulativePrizeReserveFee_lt?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeReserveFee_lte?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeReserveFee_not?: Maybe<Scalars['BigInt']>;
-  cumulativePrizeReserveFee_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  currentPrizeId?: Maybe<Scalars['BigInt']>;
-  currentPrizeId_gt?: Maybe<Scalars['BigInt']>;
-  currentPrizeId_gte?: Maybe<Scalars['BigInt']>;
-  currentPrizeId_in?: Maybe<Array<Scalars['BigInt']>>;
-  currentPrizeId_lt?: Maybe<Scalars['BigInt']>;
-  currentPrizeId_lte?: Maybe<Scalars['BigInt']>;
-  currentPrizeId_not?: Maybe<Scalars['BigInt']>;
-  currentPrizeId_not_in?: Maybe<Array<Scalars['BigInt']>>;
+  compoundPrizePool?: Maybe<Scalars["String"]>;
+  compoundPrizePool_contains?: Maybe<Scalars["String"]>;
+  compoundPrizePool_ends_with?: Maybe<Scalars["String"]>;
+  compoundPrizePool_gt?: Maybe<Scalars["String"]>;
+  compoundPrizePool_gte?: Maybe<Scalars["String"]>;
+  compoundPrizePool_in?: Maybe<Array<Scalars["String"]>>;
+  compoundPrizePool_lt?: Maybe<Scalars["String"]>;
+  compoundPrizePool_lte?: Maybe<Scalars["String"]>;
+  compoundPrizePool_not?: Maybe<Scalars["String"]>;
+  compoundPrizePool_not_contains?: Maybe<Scalars["String"]>;
+  compoundPrizePool_not_ends_with?: Maybe<Scalars["String"]>;
+  compoundPrizePool_not_in?: Maybe<Array<Scalars["String"]>>;
+  compoundPrizePool_not_starts_with?: Maybe<Scalars["String"]>;
+  compoundPrizePool_starts_with?: Maybe<Scalars["String"]>;
+  cumulativePrizeGross?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeGross_gt?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeGross_gte?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeGross_in?: Maybe<Array<Scalars["BigInt"]>>;
+  cumulativePrizeGross_lt?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeGross_lte?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeGross_not?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeGross_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  cumulativePrizeNet?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeNet_gt?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeNet_gte?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeNet_in?: Maybe<Array<Scalars["BigInt"]>>;
+  cumulativePrizeNet_lt?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeNet_lte?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeNet_not?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeNet_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  cumulativePrizeReserveFee?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeReserveFee_gt?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeReserveFee_gte?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeReserveFee_in?: Maybe<Array<Scalars["BigInt"]>>;
+  cumulativePrizeReserveFee_lt?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeReserveFee_lte?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeReserveFee_not?: Maybe<Scalars["BigInt"]>;
+  cumulativePrizeReserveFee_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  currentPrizeId?: Maybe<Scalars["BigInt"]>;
+  currentPrizeId_gt?: Maybe<Scalars["BigInt"]>;
+  currentPrizeId_gte?: Maybe<Scalars["BigInt"]>;
+  currentPrizeId_in?: Maybe<Array<Scalars["BigInt"]>>;
+  currentPrizeId_lt?: Maybe<Scalars["BigInt"]>;
+  currentPrizeId_lte?: Maybe<Scalars["BigInt"]>;
+  currentPrizeId_not?: Maybe<Scalars["BigInt"]>;
+  currentPrizeId_not_in?: Maybe<Array<Scalars["BigInt"]>>;
   currentState?: Maybe<PrizePoolState>;
   currentState_in?: Maybe<Array<PrizePoolState>>;
   currentState_not?: Maybe<PrizePoolState>;
   currentState_not_in?: Maybe<Array<PrizePoolState>>;
-  deactivated?: Maybe<Scalars['Boolean']>;
-  deactivated_in?: Maybe<Array<Scalars['Boolean']>>;
-  deactivated_not?: Maybe<Scalars['Boolean']>;
-  deactivated_not_in?: Maybe<Array<Scalars['Boolean']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  liquidityCap?: Maybe<Scalars['BigInt']>;
-  liquidityCap_gt?: Maybe<Scalars['BigInt']>;
-  liquidityCap_gte?: Maybe<Scalars['BigInt']>;
-  liquidityCap_in?: Maybe<Array<Scalars['BigInt']>>;
-  liquidityCap_lt?: Maybe<Scalars['BigInt']>;
-  liquidityCap_lte?: Maybe<Scalars['BigInt']>;
-  liquidityCap_not?: Maybe<Scalars['BigInt']>;
-  liquidityCap_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  maxExitFeeMantissa?: Maybe<Scalars['BigInt']>;
-  maxExitFeeMantissa_gt?: Maybe<Scalars['BigInt']>;
-  maxExitFeeMantissa_gte?: Maybe<Scalars['BigInt']>;
-  maxExitFeeMantissa_in?: Maybe<Array<Scalars['BigInt']>>;
-  maxExitFeeMantissa_lt?: Maybe<Scalars['BigInt']>;
-  maxExitFeeMantissa_lte?: Maybe<Scalars['BigInt']>;
-  maxExitFeeMantissa_not?: Maybe<Scalars['BigInt']>;
-  maxExitFeeMantissa_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  owner?: Maybe<Scalars['Bytes']>;
-  owner_contains?: Maybe<Scalars['Bytes']>;
-  owner_in?: Maybe<Array<Scalars['Bytes']>>;
-  owner_not?: Maybe<Scalars['Bytes']>;
-  owner_not_contains?: Maybe<Scalars['Bytes']>;
-  owner_not_in?: Maybe<Array<Scalars['Bytes']>>;
+  deactivated?: Maybe<Scalars["Boolean"]>;
+  deactivated_in?: Maybe<Array<Scalars["Boolean"]>>;
+  deactivated_not?: Maybe<Scalars["Boolean"]>;
+  deactivated_not_in?: Maybe<Array<Scalars["Boolean"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  liquidityCap?: Maybe<Scalars["BigInt"]>;
+  liquidityCap_gt?: Maybe<Scalars["BigInt"]>;
+  liquidityCap_gte?: Maybe<Scalars["BigInt"]>;
+  liquidityCap_in?: Maybe<Array<Scalars["BigInt"]>>;
+  liquidityCap_lt?: Maybe<Scalars["BigInt"]>;
+  liquidityCap_lte?: Maybe<Scalars["BigInt"]>;
+  liquidityCap_not?: Maybe<Scalars["BigInt"]>;
+  liquidityCap_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  maxExitFeeMantissa?: Maybe<Scalars["BigInt"]>;
+  maxExitFeeMantissa_gt?: Maybe<Scalars["BigInt"]>;
+  maxExitFeeMantissa_gte?: Maybe<Scalars["BigInt"]>;
+  maxExitFeeMantissa_in?: Maybe<Array<Scalars["BigInt"]>>;
+  maxExitFeeMantissa_lt?: Maybe<Scalars["BigInt"]>;
+  maxExitFeeMantissa_lte?: Maybe<Scalars["BigInt"]>;
+  maxExitFeeMantissa_not?: Maybe<Scalars["BigInt"]>;
+  maxExitFeeMantissa_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  owner?: Maybe<Scalars["Bytes"]>;
+  owner_contains?: Maybe<Scalars["Bytes"]>;
+  owner_in?: Maybe<Array<Scalars["Bytes"]>>;
+  owner_not?: Maybe<Scalars["Bytes"]>;
+  owner_not_contains?: Maybe<Scalars["Bytes"]>;
+  owner_not_in?: Maybe<Array<Scalars["Bytes"]>>;
   prizePoolType?: Maybe<PrizePoolType>;
   prizePoolType_in?: Maybe<Array<PrizePoolType>>;
   prizePoolType_not?: Maybe<PrizePoolType>;
   prizePoolType_not_in?: Maybe<Array<PrizePoolType>>;
-  prizeStrategy?: Maybe<Scalars['String']>;
-  prizeStrategy_contains?: Maybe<Scalars['String']>;
-  prizeStrategy_ends_with?: Maybe<Scalars['String']>;
-  prizeStrategy_gt?: Maybe<Scalars['String']>;
-  prizeStrategy_gte?: Maybe<Scalars['String']>;
-  prizeStrategy_in?: Maybe<Array<Scalars['String']>>;
-  prizeStrategy_lt?: Maybe<Scalars['String']>;
-  prizeStrategy_lte?: Maybe<Scalars['String']>;
-  prizeStrategy_not?: Maybe<Scalars['String']>;
-  prizeStrategy_not_contains?: Maybe<Scalars['String']>;
-  prizeStrategy_not_ends_with?: Maybe<Scalars['String']>;
-  prizeStrategy_not_in?: Maybe<Array<Scalars['String']>>;
-  prizeStrategy_not_starts_with?: Maybe<Scalars['String']>;
-  prizeStrategy_starts_with?: Maybe<Scalars['String']>;
-  reserveFeeControlledToken?: Maybe<Scalars['Bytes']>;
-  reserveFeeControlledToken_contains?: Maybe<Scalars['Bytes']>;
-  reserveFeeControlledToken_in?: Maybe<Array<Scalars['Bytes']>>;
-  reserveFeeControlledToken_not?: Maybe<Scalars['Bytes']>;
-  reserveFeeControlledToken_not_contains?: Maybe<Scalars['Bytes']>;
-  reserveFeeControlledToken_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  reserveRegistry?: Maybe<Scalars['Bytes']>;
-  reserveRegistry_contains?: Maybe<Scalars['Bytes']>;
-  reserveRegistry_in?: Maybe<Array<Scalars['Bytes']>>;
-  reserveRegistry_not?: Maybe<Scalars['Bytes']>;
-  reserveRegistry_not_contains?: Maybe<Scalars['Bytes']>;
-  reserveRegistry_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  stakePrizePool?: Maybe<Scalars['String']>;
-  stakePrizePool_contains?: Maybe<Scalars['String']>;
-  stakePrizePool_ends_with?: Maybe<Scalars['String']>;
-  stakePrizePool_gt?: Maybe<Scalars['String']>;
-  stakePrizePool_gte?: Maybe<Scalars['String']>;
-  stakePrizePool_in?: Maybe<Array<Scalars['String']>>;
-  stakePrizePool_lt?: Maybe<Scalars['String']>;
-  stakePrizePool_lte?: Maybe<Scalars['String']>;
-  stakePrizePool_not?: Maybe<Scalars['String']>;
-  stakePrizePool_not_contains?: Maybe<Scalars['String']>;
-  stakePrizePool_not_ends_with?: Maybe<Scalars['String']>;
-  stakePrizePool_not_in?: Maybe<Array<Scalars['String']>>;
-  stakePrizePool_not_starts_with?: Maybe<Scalars['String']>;
-  stakePrizePool_starts_with?: Maybe<Scalars['String']>;
-  underlyingCollateralDecimals?: Maybe<Scalars['BigInt']>;
-  underlyingCollateralDecimals_gt?: Maybe<Scalars['BigInt']>;
-  underlyingCollateralDecimals_gte?: Maybe<Scalars['BigInt']>;
-  underlyingCollateralDecimals_in?: Maybe<Array<Scalars['BigInt']>>;
-  underlyingCollateralDecimals_lt?: Maybe<Scalars['BigInt']>;
-  underlyingCollateralDecimals_lte?: Maybe<Scalars['BigInt']>;
-  underlyingCollateralDecimals_not?: Maybe<Scalars['BigInt']>;
-  underlyingCollateralDecimals_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  underlyingCollateralName?: Maybe<Scalars['String']>;
-  underlyingCollateralName_contains?: Maybe<Scalars['String']>;
-  underlyingCollateralName_ends_with?: Maybe<Scalars['String']>;
-  underlyingCollateralName_gt?: Maybe<Scalars['String']>;
-  underlyingCollateralName_gte?: Maybe<Scalars['String']>;
-  underlyingCollateralName_in?: Maybe<Array<Scalars['String']>>;
-  underlyingCollateralName_lt?: Maybe<Scalars['String']>;
-  underlyingCollateralName_lte?: Maybe<Scalars['String']>;
-  underlyingCollateralName_not?: Maybe<Scalars['String']>;
-  underlyingCollateralName_not_contains?: Maybe<Scalars['String']>;
-  underlyingCollateralName_not_ends_with?: Maybe<Scalars['String']>;
-  underlyingCollateralName_not_in?: Maybe<Array<Scalars['String']>>;
-  underlyingCollateralName_not_starts_with?: Maybe<Scalars['String']>;
-  underlyingCollateralName_starts_with?: Maybe<Scalars['String']>;
-  underlyingCollateralSymbol?: Maybe<Scalars['String']>;
-  underlyingCollateralSymbol_contains?: Maybe<Scalars['String']>;
-  underlyingCollateralSymbol_ends_with?: Maybe<Scalars['String']>;
-  underlyingCollateralSymbol_gt?: Maybe<Scalars['String']>;
-  underlyingCollateralSymbol_gte?: Maybe<Scalars['String']>;
-  underlyingCollateralSymbol_in?: Maybe<Array<Scalars['String']>>;
-  underlyingCollateralSymbol_lt?: Maybe<Scalars['String']>;
-  underlyingCollateralSymbol_lte?: Maybe<Scalars['String']>;
-  underlyingCollateralSymbol_not?: Maybe<Scalars['String']>;
-  underlyingCollateralSymbol_not_contains?: Maybe<Scalars['String']>;
-  underlyingCollateralSymbol_not_ends_with?: Maybe<Scalars['String']>;
-  underlyingCollateralSymbol_not_in?: Maybe<Array<Scalars['String']>>;
-  underlyingCollateralSymbol_not_starts_with?: Maybe<Scalars['String']>;
-  underlyingCollateralSymbol_starts_with?: Maybe<Scalars['String']>;
-  underlyingCollateralToken?: Maybe<Scalars['Bytes']>;
-  underlyingCollateralToken_contains?: Maybe<Scalars['Bytes']>;
-  underlyingCollateralToken_in?: Maybe<Array<Scalars['Bytes']>>;
-  underlyingCollateralToken_not?: Maybe<Scalars['Bytes']>;
-  underlyingCollateralToken_not_contains?: Maybe<Scalars['Bytes']>;
-  underlyingCollateralToken_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  yieldSourcePrizePool?: Maybe<Scalars['String']>;
-  yieldSourcePrizePool_contains?: Maybe<Scalars['String']>;
-  yieldSourcePrizePool_ends_with?: Maybe<Scalars['String']>;
-  yieldSourcePrizePool_gt?: Maybe<Scalars['String']>;
-  yieldSourcePrizePool_gte?: Maybe<Scalars['String']>;
-  yieldSourcePrizePool_in?: Maybe<Array<Scalars['String']>>;
-  yieldSourcePrizePool_lt?: Maybe<Scalars['String']>;
-  yieldSourcePrizePool_lte?: Maybe<Scalars['String']>;
-  yieldSourcePrizePool_not?: Maybe<Scalars['String']>;
-  yieldSourcePrizePool_not_contains?: Maybe<Scalars['String']>;
-  yieldSourcePrizePool_not_ends_with?: Maybe<Scalars['String']>;
-  yieldSourcePrizePool_not_in?: Maybe<Array<Scalars['String']>>;
-  yieldSourcePrizePool_not_starts_with?: Maybe<Scalars['String']>;
-  yieldSourcePrizePool_starts_with?: Maybe<Scalars['String']>;
+  prizeStrategy?: Maybe<Scalars["String"]>;
+  prizeStrategy_contains?: Maybe<Scalars["String"]>;
+  prizeStrategy_ends_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_gt?: Maybe<Scalars["String"]>;
+  prizeStrategy_gte?: Maybe<Scalars["String"]>;
+  prizeStrategy_in?: Maybe<Array<Scalars["String"]>>;
+  prizeStrategy_lt?: Maybe<Scalars["String"]>;
+  prizeStrategy_lte?: Maybe<Scalars["String"]>;
+  prizeStrategy_not?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_contains?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_ends_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_in?: Maybe<Array<Scalars["String"]>>;
+  prizeStrategy_not_starts_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_starts_with?: Maybe<Scalars["String"]>;
+  reserveFeeControlledToken?: Maybe<Scalars["Bytes"]>;
+  reserveFeeControlledToken_contains?: Maybe<Scalars["Bytes"]>;
+  reserveFeeControlledToken_in?: Maybe<Array<Scalars["Bytes"]>>;
+  reserveFeeControlledToken_not?: Maybe<Scalars["Bytes"]>;
+  reserveFeeControlledToken_not_contains?: Maybe<Scalars["Bytes"]>;
+  reserveFeeControlledToken_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  reserveRegistry?: Maybe<Scalars["Bytes"]>;
+  reserveRegistry_contains?: Maybe<Scalars["Bytes"]>;
+  reserveRegistry_in?: Maybe<Array<Scalars["Bytes"]>>;
+  reserveRegistry_not?: Maybe<Scalars["Bytes"]>;
+  reserveRegistry_not_contains?: Maybe<Scalars["Bytes"]>;
+  reserveRegistry_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  stakePrizePool?: Maybe<Scalars["String"]>;
+  stakePrizePool_contains?: Maybe<Scalars["String"]>;
+  stakePrizePool_ends_with?: Maybe<Scalars["String"]>;
+  stakePrizePool_gt?: Maybe<Scalars["String"]>;
+  stakePrizePool_gte?: Maybe<Scalars["String"]>;
+  stakePrizePool_in?: Maybe<Array<Scalars["String"]>>;
+  stakePrizePool_lt?: Maybe<Scalars["String"]>;
+  stakePrizePool_lte?: Maybe<Scalars["String"]>;
+  stakePrizePool_not?: Maybe<Scalars["String"]>;
+  stakePrizePool_not_contains?: Maybe<Scalars["String"]>;
+  stakePrizePool_not_ends_with?: Maybe<Scalars["String"]>;
+  stakePrizePool_not_in?: Maybe<Array<Scalars["String"]>>;
+  stakePrizePool_not_starts_with?: Maybe<Scalars["String"]>;
+  stakePrizePool_starts_with?: Maybe<Scalars["String"]>;
+  underlyingCollateralDecimals?: Maybe<Scalars["BigInt"]>;
+  underlyingCollateralDecimals_gt?: Maybe<Scalars["BigInt"]>;
+  underlyingCollateralDecimals_gte?: Maybe<Scalars["BigInt"]>;
+  underlyingCollateralDecimals_in?: Maybe<Array<Scalars["BigInt"]>>;
+  underlyingCollateralDecimals_lt?: Maybe<Scalars["BigInt"]>;
+  underlyingCollateralDecimals_lte?: Maybe<Scalars["BigInt"]>;
+  underlyingCollateralDecimals_not?: Maybe<Scalars["BigInt"]>;
+  underlyingCollateralDecimals_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  underlyingCollateralName?: Maybe<Scalars["String"]>;
+  underlyingCollateralName_contains?: Maybe<Scalars["String"]>;
+  underlyingCollateralName_ends_with?: Maybe<Scalars["String"]>;
+  underlyingCollateralName_gt?: Maybe<Scalars["String"]>;
+  underlyingCollateralName_gte?: Maybe<Scalars["String"]>;
+  underlyingCollateralName_in?: Maybe<Array<Scalars["String"]>>;
+  underlyingCollateralName_lt?: Maybe<Scalars["String"]>;
+  underlyingCollateralName_lte?: Maybe<Scalars["String"]>;
+  underlyingCollateralName_not?: Maybe<Scalars["String"]>;
+  underlyingCollateralName_not_contains?: Maybe<Scalars["String"]>;
+  underlyingCollateralName_not_ends_with?: Maybe<Scalars["String"]>;
+  underlyingCollateralName_not_in?: Maybe<Array<Scalars["String"]>>;
+  underlyingCollateralName_not_starts_with?: Maybe<Scalars["String"]>;
+  underlyingCollateralName_starts_with?: Maybe<Scalars["String"]>;
+  underlyingCollateralSymbol?: Maybe<Scalars["String"]>;
+  underlyingCollateralSymbol_contains?: Maybe<Scalars["String"]>;
+  underlyingCollateralSymbol_ends_with?: Maybe<Scalars["String"]>;
+  underlyingCollateralSymbol_gt?: Maybe<Scalars["String"]>;
+  underlyingCollateralSymbol_gte?: Maybe<Scalars["String"]>;
+  underlyingCollateralSymbol_in?: Maybe<Array<Scalars["String"]>>;
+  underlyingCollateralSymbol_lt?: Maybe<Scalars["String"]>;
+  underlyingCollateralSymbol_lte?: Maybe<Scalars["String"]>;
+  underlyingCollateralSymbol_not?: Maybe<Scalars["String"]>;
+  underlyingCollateralSymbol_not_contains?: Maybe<Scalars["String"]>;
+  underlyingCollateralSymbol_not_ends_with?: Maybe<Scalars["String"]>;
+  underlyingCollateralSymbol_not_in?: Maybe<Array<Scalars["String"]>>;
+  underlyingCollateralSymbol_not_starts_with?: Maybe<Scalars["String"]>;
+  underlyingCollateralSymbol_starts_with?: Maybe<Scalars["String"]>;
+  underlyingCollateralToken?: Maybe<Scalars["Bytes"]>;
+  underlyingCollateralToken_contains?: Maybe<Scalars["Bytes"]>;
+  underlyingCollateralToken_in?: Maybe<Array<Scalars["Bytes"]>>;
+  underlyingCollateralToken_not?: Maybe<Scalars["Bytes"]>;
+  underlyingCollateralToken_not_contains?: Maybe<Scalars["Bytes"]>;
+  underlyingCollateralToken_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  yieldSourcePrizePool?: Maybe<Scalars["String"]>;
+  yieldSourcePrizePool_contains?: Maybe<Scalars["String"]>;
+  yieldSourcePrizePool_ends_with?: Maybe<Scalars["String"]>;
+  yieldSourcePrizePool_gt?: Maybe<Scalars["String"]>;
+  yieldSourcePrizePool_gte?: Maybe<Scalars["String"]>;
+  yieldSourcePrizePool_in?: Maybe<Array<Scalars["String"]>>;
+  yieldSourcePrizePool_lt?: Maybe<Scalars["String"]>;
+  yieldSourcePrizePool_lte?: Maybe<Scalars["String"]>;
+  yieldSourcePrizePool_not?: Maybe<Scalars["String"]>;
+  yieldSourcePrizePool_not_contains?: Maybe<Scalars["String"]>;
+  yieldSourcePrizePool_not_ends_with?: Maybe<Scalars["String"]>;
+  yieldSourcePrizePool_not_in?: Maybe<Array<Scalars["String"]>>;
+  yieldSourcePrizePool_not_starts_with?: Maybe<Scalars["String"]>;
+  yieldSourcePrizePool_starts_with?: Maybe<Scalars["String"]>;
 };
 
 export enum PrizePool_OrderBy {
-  CompoundPrizePool = 'compoundPrizePool',
-  ControlledTokens = 'controlledTokens',
-  CumulativePrizeGross = 'cumulativePrizeGross',
-  CumulativePrizeNet = 'cumulativePrizeNet',
-  CumulativePrizeReserveFee = 'cumulativePrizeReserveFee',
-  CurrentPrizeId = 'currentPrizeId',
-  CurrentState = 'currentState',
-  Deactivated = 'deactivated',
-  Id = 'id',
-  LiquidityCap = 'liquidityCap',
-  MaxExitFeeMantissa = 'maxExitFeeMantissa',
-  Owner = 'owner',
-  PrizePoolAccounts = 'prizePoolAccounts',
-  PrizePoolType = 'prizePoolType',
-  PrizeStrategy = 'prizeStrategy',
-  Prizes = 'prizes',
-  ReserveFeeControlledToken = 'reserveFeeControlledToken',
-  ReserveRegistry = 'reserveRegistry',
-  SablierStream = 'sablierStream',
-  StakePrizePool = 'stakePrizePool',
-  TokenCreditBalances = 'tokenCreditBalances',
-  TokenCreditRates = 'tokenCreditRates',
-  UnderlyingCollateralDecimals = 'underlyingCollateralDecimals',
-  UnderlyingCollateralName = 'underlyingCollateralName',
-  UnderlyingCollateralSymbol = 'underlyingCollateralSymbol',
-  UnderlyingCollateralToken = 'underlyingCollateralToken',
-  YieldSourcePrizePool = 'yieldSourcePrizePool'
+  CompoundPrizePool = "compoundPrizePool",
+  ControlledTokens = "controlledTokens",
+  CumulativePrizeGross = "cumulativePrizeGross",
+  CumulativePrizeNet = "cumulativePrizeNet",
+  CumulativePrizeReserveFee = "cumulativePrizeReserveFee",
+  CurrentPrizeId = "currentPrizeId",
+  CurrentState = "currentState",
+  Deactivated = "deactivated",
+  Id = "id",
+  LiquidityCap = "liquidityCap",
+  MaxExitFeeMantissa = "maxExitFeeMantissa",
+  Owner = "owner",
+  PrizePoolAccounts = "prizePoolAccounts",
+  PrizePoolType = "prizePoolType",
+  PrizeStrategy = "prizeStrategy",
+  Prizes = "prizes",
+  ReserveFeeControlledToken = "reserveFeeControlledToken",
+  ReserveRegistry = "reserveRegistry",
+  SablierStream = "sablierStream",
+  StakePrizePool = "stakePrizePool",
+  TokenCreditBalances = "tokenCreditBalances",
+  TokenCreditRates = "tokenCreditRates",
+  UnderlyingCollateralDecimals = "underlyingCollateralDecimals",
+  UnderlyingCollateralName = "underlyingCollateralName",
+  UnderlyingCollateralSymbol = "underlyingCollateralSymbol",
+  UnderlyingCollateralToken = "underlyingCollateralToken",
+  YieldSourcePrizePool = "yieldSourcePrizePool",
 }
 
 export type PrizeSplit = {
-  __typename?: 'PrizeSplit';
-  id: Scalars['ID'];
-  percentage: Scalars['BigInt'];
+  __typename?: "PrizeSplit";
+  id: Scalars["ID"];
+  percentage: Scalars["BigInt"];
   prizeStrategy?: Maybe<MultipleWinnersPrizeStrategy>;
-  target: Scalars['Bytes'];
-  tokenType: Scalars['BigInt'];
+  target: Scalars["Bytes"];
+  tokenType: Scalars["BigInt"];
 };
 
 export type PrizeSplit_Filter = {
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  percentage?: Maybe<Scalars['BigInt']>;
-  percentage_gt?: Maybe<Scalars['BigInt']>;
-  percentage_gte?: Maybe<Scalars['BigInt']>;
-  percentage_in?: Maybe<Array<Scalars['BigInt']>>;
-  percentage_lt?: Maybe<Scalars['BigInt']>;
-  percentage_lte?: Maybe<Scalars['BigInt']>;
-  percentage_not?: Maybe<Scalars['BigInt']>;
-  percentage_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizeStrategy?: Maybe<Scalars['String']>;
-  prizeStrategy_contains?: Maybe<Scalars['String']>;
-  prizeStrategy_ends_with?: Maybe<Scalars['String']>;
-  prizeStrategy_gt?: Maybe<Scalars['String']>;
-  prizeStrategy_gte?: Maybe<Scalars['String']>;
-  prizeStrategy_in?: Maybe<Array<Scalars['String']>>;
-  prizeStrategy_lt?: Maybe<Scalars['String']>;
-  prizeStrategy_lte?: Maybe<Scalars['String']>;
-  prizeStrategy_not?: Maybe<Scalars['String']>;
-  prizeStrategy_not_contains?: Maybe<Scalars['String']>;
-  prizeStrategy_not_ends_with?: Maybe<Scalars['String']>;
-  prizeStrategy_not_in?: Maybe<Array<Scalars['String']>>;
-  prizeStrategy_not_starts_with?: Maybe<Scalars['String']>;
-  prizeStrategy_starts_with?: Maybe<Scalars['String']>;
-  target?: Maybe<Scalars['Bytes']>;
-  target_contains?: Maybe<Scalars['Bytes']>;
-  target_in?: Maybe<Array<Scalars['Bytes']>>;
-  target_not?: Maybe<Scalars['Bytes']>;
-  target_not_contains?: Maybe<Scalars['Bytes']>;
-  target_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  tokenType?: Maybe<Scalars['BigInt']>;
-  tokenType_gt?: Maybe<Scalars['BigInt']>;
-  tokenType_gte?: Maybe<Scalars['BigInt']>;
-  tokenType_in?: Maybe<Array<Scalars['BigInt']>>;
-  tokenType_lt?: Maybe<Scalars['BigInt']>;
-  tokenType_lte?: Maybe<Scalars['BigInt']>;
-  tokenType_not?: Maybe<Scalars['BigInt']>;
-  tokenType_not_in?: Maybe<Array<Scalars['BigInt']>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  percentage?: Maybe<Scalars["BigInt"]>;
+  percentage_gt?: Maybe<Scalars["BigInt"]>;
+  percentage_gte?: Maybe<Scalars["BigInt"]>;
+  percentage_in?: Maybe<Array<Scalars["BigInt"]>>;
+  percentage_lt?: Maybe<Scalars["BigInt"]>;
+  percentage_lte?: Maybe<Scalars["BigInt"]>;
+  percentage_not?: Maybe<Scalars["BigInt"]>;
+  percentage_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizeStrategy?: Maybe<Scalars["String"]>;
+  prizeStrategy_contains?: Maybe<Scalars["String"]>;
+  prizeStrategy_ends_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_gt?: Maybe<Scalars["String"]>;
+  prizeStrategy_gte?: Maybe<Scalars["String"]>;
+  prizeStrategy_in?: Maybe<Array<Scalars["String"]>>;
+  prizeStrategy_lt?: Maybe<Scalars["String"]>;
+  prizeStrategy_lte?: Maybe<Scalars["String"]>;
+  prizeStrategy_not?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_contains?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_ends_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_in?: Maybe<Array<Scalars["String"]>>;
+  prizeStrategy_not_starts_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_starts_with?: Maybe<Scalars["String"]>;
+  target?: Maybe<Scalars["Bytes"]>;
+  target_contains?: Maybe<Scalars["Bytes"]>;
+  target_in?: Maybe<Array<Scalars["Bytes"]>>;
+  target_not?: Maybe<Scalars["Bytes"]>;
+  target_not_contains?: Maybe<Scalars["Bytes"]>;
+  target_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  tokenType?: Maybe<Scalars["BigInt"]>;
+  tokenType_gt?: Maybe<Scalars["BigInt"]>;
+  tokenType_gte?: Maybe<Scalars["BigInt"]>;
+  tokenType_in?: Maybe<Array<Scalars["BigInt"]>>;
+  tokenType_lt?: Maybe<Scalars["BigInt"]>;
+  tokenType_lte?: Maybe<Scalars["BigInt"]>;
+  tokenType_not?: Maybe<Scalars["BigInt"]>;
+  tokenType_not_in?: Maybe<Array<Scalars["BigInt"]>>;
 };
 
 export enum PrizeSplit_OrderBy {
-  Id = 'id',
-  Percentage = 'percentage',
-  PrizeStrategy = 'prizeStrategy',
-  Target = 'target',
-  TokenType = 'tokenType'
+  Id = "id",
+  Percentage = "percentage",
+  PrizeStrategy = "prizeStrategy",
+  Target = "target",
+  TokenType = "tokenType",
 }
 
 export type PrizeStrategy = {
-  __typename?: 'PrizeStrategy';
-  id: Scalars['ID'];
+  __typename?: "PrizeStrategy";
+  id: Scalars["ID"];
   multipleWinners?: Maybe<MultipleWinnersPrizeStrategy>;
   singleRandomWinner?: Maybe<SingleRandomWinnerPrizeStrategy>;
 };
 
 export type PrizeStrategy_Filter = {
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  multipleWinners?: Maybe<Scalars['String']>;
-  multipleWinners_contains?: Maybe<Scalars['String']>;
-  multipleWinners_ends_with?: Maybe<Scalars['String']>;
-  multipleWinners_gt?: Maybe<Scalars['String']>;
-  multipleWinners_gte?: Maybe<Scalars['String']>;
-  multipleWinners_in?: Maybe<Array<Scalars['String']>>;
-  multipleWinners_lt?: Maybe<Scalars['String']>;
-  multipleWinners_lte?: Maybe<Scalars['String']>;
-  multipleWinners_not?: Maybe<Scalars['String']>;
-  multipleWinners_not_contains?: Maybe<Scalars['String']>;
-  multipleWinners_not_ends_with?: Maybe<Scalars['String']>;
-  multipleWinners_not_in?: Maybe<Array<Scalars['String']>>;
-  multipleWinners_not_starts_with?: Maybe<Scalars['String']>;
-  multipleWinners_starts_with?: Maybe<Scalars['String']>;
-  singleRandomWinner?: Maybe<Scalars['String']>;
-  singleRandomWinner_contains?: Maybe<Scalars['String']>;
-  singleRandomWinner_ends_with?: Maybe<Scalars['String']>;
-  singleRandomWinner_gt?: Maybe<Scalars['String']>;
-  singleRandomWinner_gte?: Maybe<Scalars['String']>;
-  singleRandomWinner_in?: Maybe<Array<Scalars['String']>>;
-  singleRandomWinner_lt?: Maybe<Scalars['String']>;
-  singleRandomWinner_lte?: Maybe<Scalars['String']>;
-  singleRandomWinner_not?: Maybe<Scalars['String']>;
-  singleRandomWinner_not_contains?: Maybe<Scalars['String']>;
-  singleRandomWinner_not_ends_with?: Maybe<Scalars['String']>;
-  singleRandomWinner_not_in?: Maybe<Array<Scalars['String']>>;
-  singleRandomWinner_not_starts_with?: Maybe<Scalars['String']>;
-  singleRandomWinner_starts_with?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  multipleWinners?: Maybe<Scalars["String"]>;
+  multipleWinners_contains?: Maybe<Scalars["String"]>;
+  multipleWinners_ends_with?: Maybe<Scalars["String"]>;
+  multipleWinners_gt?: Maybe<Scalars["String"]>;
+  multipleWinners_gte?: Maybe<Scalars["String"]>;
+  multipleWinners_in?: Maybe<Array<Scalars["String"]>>;
+  multipleWinners_lt?: Maybe<Scalars["String"]>;
+  multipleWinners_lte?: Maybe<Scalars["String"]>;
+  multipleWinners_not?: Maybe<Scalars["String"]>;
+  multipleWinners_not_contains?: Maybe<Scalars["String"]>;
+  multipleWinners_not_ends_with?: Maybe<Scalars["String"]>;
+  multipleWinners_not_in?: Maybe<Array<Scalars["String"]>>;
+  multipleWinners_not_starts_with?: Maybe<Scalars["String"]>;
+  multipleWinners_starts_with?: Maybe<Scalars["String"]>;
+  singleRandomWinner?: Maybe<Scalars["String"]>;
+  singleRandomWinner_contains?: Maybe<Scalars["String"]>;
+  singleRandomWinner_ends_with?: Maybe<Scalars["String"]>;
+  singleRandomWinner_gt?: Maybe<Scalars["String"]>;
+  singleRandomWinner_gte?: Maybe<Scalars["String"]>;
+  singleRandomWinner_in?: Maybe<Array<Scalars["String"]>>;
+  singleRandomWinner_lt?: Maybe<Scalars["String"]>;
+  singleRandomWinner_lte?: Maybe<Scalars["String"]>;
+  singleRandomWinner_not?: Maybe<Scalars["String"]>;
+  singleRandomWinner_not_contains?: Maybe<Scalars["String"]>;
+  singleRandomWinner_not_ends_with?: Maybe<Scalars["String"]>;
+  singleRandomWinner_not_in?: Maybe<Array<Scalars["String"]>>;
+  singleRandomWinner_not_starts_with?: Maybe<Scalars["String"]>;
+  singleRandomWinner_starts_with?: Maybe<Scalars["String"]>;
 };
 
 export enum PrizeStrategy_OrderBy {
-  Id = 'id',
-  MultipleWinners = 'multipleWinners',
-  SingleRandomWinner = 'singleRandomWinner'
+  Id = "id",
+  MultipleWinners = "multipleWinners",
+  SingleRandomWinner = "singleRandomWinner",
 }
 
 export type Prize_Filter = {
-  awardStartOperator?: Maybe<Scalars['Bytes']>;
-  awardStartOperator_contains?: Maybe<Scalars['Bytes']>;
-  awardStartOperator_in?: Maybe<Array<Scalars['Bytes']>>;
-  awardStartOperator_not?: Maybe<Scalars['Bytes']>;
-  awardStartOperator_not_contains?: Maybe<Scalars['Bytes']>;
-  awardStartOperator_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  awardedBlock?: Maybe<Scalars['BigInt']>;
-  awardedBlock_gt?: Maybe<Scalars['BigInt']>;
-  awardedBlock_gte?: Maybe<Scalars['BigInt']>;
-  awardedBlock_in?: Maybe<Array<Scalars['BigInt']>>;
-  awardedBlock_lt?: Maybe<Scalars['BigInt']>;
-  awardedBlock_lte?: Maybe<Scalars['BigInt']>;
-  awardedBlock_not?: Maybe<Scalars['BigInt']>;
-  awardedBlock_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  awardedOperator?: Maybe<Scalars['Bytes']>;
-  awardedOperator_contains?: Maybe<Scalars['Bytes']>;
-  awardedOperator_in?: Maybe<Array<Scalars['Bytes']>>;
-  awardedOperator_not?: Maybe<Scalars['Bytes']>;
-  awardedOperator_not_contains?: Maybe<Scalars['Bytes']>;
-  awardedOperator_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  awardedTimestamp?: Maybe<Scalars['BigInt']>;
-  awardedTimestamp_gt?: Maybe<Scalars['BigInt']>;
-  awardedTimestamp_gte?: Maybe<Scalars['BigInt']>;
-  awardedTimestamp_in?: Maybe<Array<Scalars['BigInt']>>;
-  awardedTimestamp_lt?: Maybe<Scalars['BigInt']>;
-  awardedTimestamp_lte?: Maybe<Scalars['BigInt']>;
-  awardedTimestamp_not?: Maybe<Scalars['BigInt']>;
-  awardedTimestamp_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  lockBlock?: Maybe<Scalars['BigInt']>;
-  lockBlock_gt?: Maybe<Scalars['BigInt']>;
-  lockBlock_gte?: Maybe<Scalars['BigInt']>;
-  lockBlock_in?: Maybe<Array<Scalars['BigInt']>>;
-  lockBlock_lt?: Maybe<Scalars['BigInt']>;
-  lockBlock_lte?: Maybe<Scalars['BigInt']>;
-  lockBlock_not?: Maybe<Scalars['BigInt']>;
-  lockBlock_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  numberOfExternalAwardedErc20Winners?: Maybe<Scalars['BigInt']>;
-  numberOfExternalAwardedErc20Winners_gt?: Maybe<Scalars['BigInt']>;
-  numberOfExternalAwardedErc20Winners_gte?: Maybe<Scalars['BigInt']>;
-  numberOfExternalAwardedErc20Winners_in?: Maybe<Array<Scalars['BigInt']>>;
-  numberOfExternalAwardedErc20Winners_lt?: Maybe<Scalars['BigInt']>;
-  numberOfExternalAwardedErc20Winners_lte?: Maybe<Scalars['BigInt']>;
-  numberOfExternalAwardedErc20Winners_not?: Maybe<Scalars['BigInt']>;
-  numberOfExternalAwardedErc20Winners_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  numberOfSubWinners?: Maybe<Scalars['BigInt']>;
-  numberOfSubWinners_gt?: Maybe<Scalars['BigInt']>;
-  numberOfSubWinners_gte?: Maybe<Scalars['BigInt']>;
-  numberOfSubWinners_in?: Maybe<Array<Scalars['BigInt']>>;
-  numberOfSubWinners_lt?: Maybe<Scalars['BigInt']>;
-  numberOfSubWinners_lte?: Maybe<Scalars['BigInt']>;
-  numberOfSubWinners_not?: Maybe<Scalars['BigInt']>;
-  numberOfSubWinners_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizePeriodStartedTimestamp?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedTimestamp_gt?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedTimestamp_gte?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedTimestamp_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizePeriodStartedTimestamp_lt?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedTimestamp_lte?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedTimestamp_not?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedTimestamp_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizePool?: Maybe<Scalars['String']>;
-  prizePool_contains?: Maybe<Scalars['String']>;
-  prizePool_ends_with?: Maybe<Scalars['String']>;
-  prizePool_gt?: Maybe<Scalars['String']>;
-  prizePool_gte?: Maybe<Scalars['String']>;
-  prizePool_in?: Maybe<Array<Scalars['String']>>;
-  prizePool_lt?: Maybe<Scalars['String']>;
-  prizePool_lte?: Maybe<Scalars['String']>;
-  prizePool_not?: Maybe<Scalars['String']>;
-  prizePool_not_contains?: Maybe<Scalars['String']>;
-  prizePool_not_ends_with?: Maybe<Scalars['String']>;
-  prizePool_not_in?: Maybe<Array<Scalars['String']>>;
-  prizePool_not_starts_with?: Maybe<Scalars['String']>;
-  prizePool_starts_with?: Maybe<Scalars['String']>;
-  randomNumber?: Maybe<Scalars['BigInt']>;
-  randomNumber_gt?: Maybe<Scalars['BigInt']>;
-  randomNumber_gte?: Maybe<Scalars['BigInt']>;
-  randomNumber_in?: Maybe<Array<Scalars['BigInt']>>;
-  randomNumber_lt?: Maybe<Scalars['BigInt']>;
-  randomNumber_lte?: Maybe<Scalars['BigInt']>;
-  randomNumber_not?: Maybe<Scalars['BigInt']>;
-  randomNumber_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  rngRequestId?: Maybe<Scalars['BigInt']>;
-  rngRequestId_gt?: Maybe<Scalars['BigInt']>;
-  rngRequestId_gte?: Maybe<Scalars['BigInt']>;
-  rngRequestId_in?: Maybe<Array<Scalars['BigInt']>>;
-  rngRequestId_lt?: Maybe<Scalars['BigInt']>;
-  rngRequestId_lte?: Maybe<Scalars['BigInt']>;
-  rngRequestId_not?: Maybe<Scalars['BigInt']>;
-  rngRequestId_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  totalTicketSupply?: Maybe<Scalars['BigInt']>;
-  totalTicketSupply_gt?: Maybe<Scalars['BigInt']>;
-  totalTicketSupply_gte?: Maybe<Scalars['BigInt']>;
-  totalTicketSupply_in?: Maybe<Array<Scalars['BigInt']>>;
-  totalTicketSupply_lt?: Maybe<Scalars['BigInt']>;
-  totalTicketSupply_lte?: Maybe<Scalars['BigInt']>;
-  totalTicketSupply_not?: Maybe<Scalars['BigInt']>;
-  totalTicketSupply_not_in?: Maybe<Array<Scalars['BigInt']>>;
+  awardStartOperator?: Maybe<Scalars["Bytes"]>;
+  awardStartOperator_contains?: Maybe<Scalars["Bytes"]>;
+  awardStartOperator_in?: Maybe<Array<Scalars["Bytes"]>>;
+  awardStartOperator_not?: Maybe<Scalars["Bytes"]>;
+  awardStartOperator_not_contains?: Maybe<Scalars["Bytes"]>;
+  awardStartOperator_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  awardedBlock?: Maybe<Scalars["BigInt"]>;
+  awardedBlock_gt?: Maybe<Scalars["BigInt"]>;
+  awardedBlock_gte?: Maybe<Scalars["BigInt"]>;
+  awardedBlock_in?: Maybe<Array<Scalars["BigInt"]>>;
+  awardedBlock_lt?: Maybe<Scalars["BigInt"]>;
+  awardedBlock_lte?: Maybe<Scalars["BigInt"]>;
+  awardedBlock_not?: Maybe<Scalars["BigInt"]>;
+  awardedBlock_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  awardedOperator?: Maybe<Scalars["Bytes"]>;
+  awardedOperator_contains?: Maybe<Scalars["Bytes"]>;
+  awardedOperator_in?: Maybe<Array<Scalars["Bytes"]>>;
+  awardedOperator_not?: Maybe<Scalars["Bytes"]>;
+  awardedOperator_not_contains?: Maybe<Scalars["Bytes"]>;
+  awardedOperator_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  awardedTimestamp?: Maybe<Scalars["BigInt"]>;
+  awardedTimestamp_gt?: Maybe<Scalars["BigInt"]>;
+  awardedTimestamp_gte?: Maybe<Scalars["BigInt"]>;
+  awardedTimestamp_in?: Maybe<Array<Scalars["BigInt"]>>;
+  awardedTimestamp_lt?: Maybe<Scalars["BigInt"]>;
+  awardedTimestamp_lte?: Maybe<Scalars["BigInt"]>;
+  awardedTimestamp_not?: Maybe<Scalars["BigInt"]>;
+  awardedTimestamp_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  lockBlock?: Maybe<Scalars["BigInt"]>;
+  lockBlock_gt?: Maybe<Scalars["BigInt"]>;
+  lockBlock_gte?: Maybe<Scalars["BigInt"]>;
+  lockBlock_in?: Maybe<Array<Scalars["BigInt"]>>;
+  lockBlock_lt?: Maybe<Scalars["BigInt"]>;
+  lockBlock_lte?: Maybe<Scalars["BigInt"]>;
+  lockBlock_not?: Maybe<Scalars["BigInt"]>;
+  lockBlock_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  numberOfExternalAwardedErc20Winners?: Maybe<Scalars["BigInt"]>;
+  numberOfExternalAwardedErc20Winners_gt?: Maybe<Scalars["BigInt"]>;
+  numberOfExternalAwardedErc20Winners_gte?: Maybe<Scalars["BigInt"]>;
+  numberOfExternalAwardedErc20Winners_in?: Maybe<Array<Scalars["BigInt"]>>;
+  numberOfExternalAwardedErc20Winners_lt?: Maybe<Scalars["BigInt"]>;
+  numberOfExternalAwardedErc20Winners_lte?: Maybe<Scalars["BigInt"]>;
+  numberOfExternalAwardedErc20Winners_not?: Maybe<Scalars["BigInt"]>;
+  numberOfExternalAwardedErc20Winners_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  numberOfSubWinners?: Maybe<Scalars["BigInt"]>;
+  numberOfSubWinners_gt?: Maybe<Scalars["BigInt"]>;
+  numberOfSubWinners_gte?: Maybe<Scalars["BigInt"]>;
+  numberOfSubWinners_in?: Maybe<Array<Scalars["BigInt"]>>;
+  numberOfSubWinners_lt?: Maybe<Scalars["BigInt"]>;
+  numberOfSubWinners_lte?: Maybe<Scalars["BigInt"]>;
+  numberOfSubWinners_not?: Maybe<Scalars["BigInt"]>;
+  numberOfSubWinners_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizePeriodStartedTimestamp?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedTimestamp_gt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedTimestamp_gte?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedTimestamp_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizePeriodStartedTimestamp_lt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedTimestamp_lte?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedTimestamp_not?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedTimestamp_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizePool?: Maybe<Scalars["String"]>;
+  prizePool_contains?: Maybe<Scalars["String"]>;
+  prizePool_ends_with?: Maybe<Scalars["String"]>;
+  prizePool_gt?: Maybe<Scalars["String"]>;
+  prizePool_gte?: Maybe<Scalars["String"]>;
+  prizePool_in?: Maybe<Array<Scalars["String"]>>;
+  prizePool_lt?: Maybe<Scalars["String"]>;
+  prizePool_lte?: Maybe<Scalars["String"]>;
+  prizePool_not?: Maybe<Scalars["String"]>;
+  prizePool_not_contains?: Maybe<Scalars["String"]>;
+  prizePool_not_ends_with?: Maybe<Scalars["String"]>;
+  prizePool_not_in?: Maybe<Array<Scalars["String"]>>;
+  prizePool_not_starts_with?: Maybe<Scalars["String"]>;
+  prizePool_starts_with?: Maybe<Scalars["String"]>;
+  randomNumber?: Maybe<Scalars["BigInt"]>;
+  randomNumber_gt?: Maybe<Scalars["BigInt"]>;
+  randomNumber_gte?: Maybe<Scalars["BigInt"]>;
+  randomNumber_in?: Maybe<Array<Scalars["BigInt"]>>;
+  randomNumber_lt?: Maybe<Scalars["BigInt"]>;
+  randomNumber_lte?: Maybe<Scalars["BigInt"]>;
+  randomNumber_not?: Maybe<Scalars["BigInt"]>;
+  randomNumber_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  rngRequestId?: Maybe<Scalars["BigInt"]>;
+  rngRequestId_gt?: Maybe<Scalars["BigInt"]>;
+  rngRequestId_gte?: Maybe<Scalars["BigInt"]>;
+  rngRequestId_in?: Maybe<Array<Scalars["BigInt"]>>;
+  rngRequestId_lt?: Maybe<Scalars["BigInt"]>;
+  rngRequestId_lte?: Maybe<Scalars["BigInt"]>;
+  rngRequestId_not?: Maybe<Scalars["BigInt"]>;
+  rngRequestId_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  totalTicketSupply?: Maybe<Scalars["BigInt"]>;
+  totalTicketSupply_gt?: Maybe<Scalars["BigInt"]>;
+  totalTicketSupply_gte?: Maybe<Scalars["BigInt"]>;
+  totalTicketSupply_in?: Maybe<Array<Scalars["BigInt"]>>;
+  totalTicketSupply_lt?: Maybe<Scalars["BigInt"]>;
+  totalTicketSupply_lte?: Maybe<Scalars["BigInt"]>;
+  totalTicketSupply_not?: Maybe<Scalars["BigInt"]>;
+  totalTicketSupply_not_in?: Maybe<Array<Scalars["BigInt"]>>;
 };
 
 export enum Prize_OrderBy {
-  AwardStartOperator = 'awardStartOperator',
-  AwardedBlock = 'awardedBlock',
-  AwardedControlledTokens = 'awardedControlledTokens',
-  AwardedExternalErc20Tokens = 'awardedExternalErc20Tokens',
-  AwardedExternalErc721Nfts = 'awardedExternalErc721Nfts',
-  AwardedOperator = 'awardedOperator',
-  AwardedTimestamp = 'awardedTimestamp',
-  Id = 'id',
-  LockBlock = 'lockBlock',
-  NumberOfExternalAwardedErc20Winners = 'numberOfExternalAwardedErc20Winners',
-  NumberOfSubWinners = 'numberOfSubWinners',
-  PrizePeriodStartedTimestamp = 'prizePeriodStartedTimestamp',
-  PrizePool = 'prizePool',
-  RandomNumber = 'randomNumber',
-  RngRequestId = 'rngRequestId',
-  TotalTicketSupply = 'totalTicketSupply'
+  AwardStartOperator = "awardStartOperator",
+  AwardedBlock = "awardedBlock",
+  AwardedControlledTokens = "awardedControlledTokens",
+  AwardedExternalErc20Tokens = "awardedExternalErc20Tokens",
+  AwardedExternalErc721Nfts = "awardedExternalErc721Nfts",
+  AwardedOperator = "awardedOperator",
+  AwardedTimestamp = "awardedTimestamp",
+  Id = "id",
+  LockBlock = "lockBlock",
+  NumberOfExternalAwardedErc20Winners = "numberOfExternalAwardedErc20Winners",
+  NumberOfSubWinners = "numberOfSubWinners",
+  PrizePeriodStartedTimestamp = "prizePeriodStartedTimestamp",
+  PrizePool = "prizePool",
+  RandomNumber = "randomNumber",
+  RngRequestId = "rngRequestId",
+  TotalTicketSupply = "totalTicketSupply",
 }
 
 export type Query = {
-  __typename?: 'Query';
+  __typename?: "Query";
   /** Access to subgraph metadata */
   _meta?: Maybe<_Meta_>;
   account?: Maybe<Account>;
@@ -1926,906 +1908,843 @@ export type Query = {
   yieldSourcePrizePool?: Maybe<YieldSourcePrizePool>;
   yieldSourcePrizePools: Array<YieldSourcePrizePool>;
 };
-
 
 export type Query_MetaArgs = {
   block?: Maybe<Block_Height>;
 };
 
-
 export type QueryAccountArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryAccountsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<Account_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<Account_Filter>;
 };
 
-
 export type QueryAwardedControlledTokenArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryAwardedControlledTokensArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<AwardedControlledToken_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<AwardedControlledToken_Filter>;
 };
 
-
 export type QueryAwardedExternalErc20TokenArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryAwardedExternalErc20TokensArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<AwardedExternalErc20Token_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<AwardedExternalErc20Token_Filter>;
 };
 
-
 export type QueryAwardedExternalErc721NftArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryAwardedExternalErc721NftsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<AwardedExternalErc721Nft_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<AwardedExternalErc721Nft_Filter>;
 };
 
-
 export type QueryBalanceDripArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
-
 
 export type QueryBalanceDripPlayerArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryBalanceDripPlayersArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<BalanceDripPlayer_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<BalanceDripPlayer_Filter>;
 };
 
-
 export type QueryBalanceDripsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<BalanceDrip_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<BalanceDrip_Filter>;
 };
 
-
 export type QueryCompoundPrizePoolArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryCompoundPrizePoolsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<CompoundPrizePool_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<CompoundPrizePool_Filter>;
 };
 
-
 export type QueryComptrollerArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryComptrollersArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<Comptroller_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<Comptroller_Filter>;
 };
 
-
 export type QueryControlledTokenArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
-
 
 export type QueryControlledTokenBalanceArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryControlledTokenBalancesArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<ControlledTokenBalance_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<ControlledTokenBalance_Filter>;
 };
 
-
 export type QueryControlledTokensArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<ControlledToken_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<ControlledToken_Filter>;
 };
 
-
 export type QueryCreditBalanceArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryCreditBalancesArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<CreditBalance_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<CreditBalance_Filter>;
 };
 
-
 export type QueryCreditRateArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryCreditRatesArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<CreditRate_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<CreditRate_Filter>;
 };
 
-
 export type QueryDripTokenPlayerArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryDripTokenPlayersArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<DripTokenPlayer_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<DripTokenPlayer_Filter>;
 };
 
-
 export type QueryMultipleWinnersExternalErc20AwardArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryMultipleWinnersExternalErc20AwardsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<MultipleWinnersExternalErc20Award_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<MultipleWinnersExternalErc20Award_Filter>;
 };
 
-
 export type QueryMultipleWinnersExternalErc721AwardArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryMultipleWinnersExternalErc721AwardsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<MultipleWinnersExternalErc721Award_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<MultipleWinnersExternalErc721Award_Filter>;
 };
 
-
 export type QueryMultipleWinnersPrizeStrategiesArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<MultipleWinnersPrizeStrategy_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<MultipleWinnersPrizeStrategy_Filter>;
 };
 
-
 export type QueryMultipleWinnersPrizeStrategyArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
-
 
 export type QueryPrizeArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
-
 
 export type QueryPrizePoolArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
-
 
 export type QueryPrizePoolAccountArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryPrizePoolAccountsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<PrizePoolAccount_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<PrizePoolAccount_Filter>;
 };
 
-
 export type QueryPrizePoolsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<PrizePool_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<PrizePool_Filter>;
 };
 
-
 export type QueryPrizeSplitArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryPrizeSplitsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<PrizeSplit_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<PrizeSplit_Filter>;
 };
 
-
 export type QueryPrizeStrategiesArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<PrizeStrategy_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<PrizeStrategy_Filter>;
 };
 
-
 export type QueryPrizeStrategyArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryPrizesArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<Prize_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<Prize_Filter>;
 };
 
-
 export type QuerySablierStreamArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QuerySablierStreamsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<SablierStream_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<SablierStream_Filter>;
 };
 
-
 export type QuerySingleRandomWinnerExternalErc20AwardArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QuerySingleRandomWinnerExternalErc20AwardsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<SingleRandomWinnerExternalErc20Award_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<SingleRandomWinnerExternalErc20Award_Filter>;
 };
 
-
 export type QuerySingleRandomWinnerExternalErc721AwardArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QuerySingleRandomWinnerExternalErc721AwardsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<SingleRandomWinnerExternalErc721Award_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<SingleRandomWinnerExternalErc721Award_Filter>;
 };
 
-
 export type QuerySingleRandomWinnerPrizeStrategiesArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<SingleRandomWinnerPrizeStrategy_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<SingleRandomWinnerPrizeStrategy_Filter>;
 };
 
-
 export type QuerySingleRandomWinnerPrizeStrategyArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
-
 
 export type QueryStakePrizePoolArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryStakePrizePoolsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<StakePrizePool_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<StakePrizePool_Filter>;
 };
 
-
 export type QueryVolumeDripArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
-
 
 export type QueryVolumeDripPeriodArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryVolumeDripPeriodsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<VolumeDripPeriod_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<VolumeDripPeriod_Filter>;
 };
 
-
 export type QueryVolumeDripPlayerArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryVolumeDripPlayersArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<VolumeDripPlayer_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<VolumeDripPlayer_Filter>;
 };
 
-
 export type QueryVolumeDripsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<VolumeDrip_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<VolumeDrip_Filter>;
 };
 
-
 export type QueryYieldSourcePrizePoolArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type QueryYieldSourcePrizePoolsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<YieldSourcePrizePool_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<YieldSourcePrizePool_Filter>;
 };
 
 export type SablierStream = {
-  __typename?: 'SablierStream';
-  id: Scalars['ID'];
+  __typename?: "SablierStream";
+  id: Scalars["ID"];
   prizePool: PrizePool;
 };
 
 export type SablierStream_Filter = {
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  prizePool?: Maybe<Scalars['String']>;
-  prizePool_contains?: Maybe<Scalars['String']>;
-  prizePool_ends_with?: Maybe<Scalars['String']>;
-  prizePool_gt?: Maybe<Scalars['String']>;
-  prizePool_gte?: Maybe<Scalars['String']>;
-  prizePool_in?: Maybe<Array<Scalars['String']>>;
-  prizePool_lt?: Maybe<Scalars['String']>;
-  prizePool_lte?: Maybe<Scalars['String']>;
-  prizePool_not?: Maybe<Scalars['String']>;
-  prizePool_not_contains?: Maybe<Scalars['String']>;
-  prizePool_not_ends_with?: Maybe<Scalars['String']>;
-  prizePool_not_in?: Maybe<Array<Scalars['String']>>;
-  prizePool_not_starts_with?: Maybe<Scalars['String']>;
-  prizePool_starts_with?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  prizePool?: Maybe<Scalars["String"]>;
+  prizePool_contains?: Maybe<Scalars["String"]>;
+  prizePool_ends_with?: Maybe<Scalars["String"]>;
+  prizePool_gt?: Maybe<Scalars["String"]>;
+  prizePool_gte?: Maybe<Scalars["String"]>;
+  prizePool_in?: Maybe<Array<Scalars["String"]>>;
+  prizePool_lt?: Maybe<Scalars["String"]>;
+  prizePool_lte?: Maybe<Scalars["String"]>;
+  prizePool_not?: Maybe<Scalars["String"]>;
+  prizePool_not_contains?: Maybe<Scalars["String"]>;
+  prizePool_not_ends_with?: Maybe<Scalars["String"]>;
+  prizePool_not_in?: Maybe<Array<Scalars["String"]>>;
+  prizePool_not_starts_with?: Maybe<Scalars["String"]>;
+  prizePool_starts_with?: Maybe<Scalars["String"]>;
 };
 
 export enum SablierStream_OrderBy {
-  Id = 'id',
-  PrizePool = 'prizePool'
+  Id = "id",
+  PrizePool = "prizePool",
 }
 
 export type SingleRandomWinnerExternalErc20Award = {
-  __typename?: 'SingleRandomWinnerExternalErc20Award';
-  address: Scalars['Bytes'];
-  decimals?: Maybe<Scalars['BigInt']>;
-  id: Scalars['ID'];
-  name?: Maybe<Scalars['String']>;
+  __typename?: "SingleRandomWinnerExternalErc20Award";
+  address: Scalars["Bytes"];
+  decimals?: Maybe<Scalars["BigInt"]>;
+  id: Scalars["ID"];
+  name?: Maybe<Scalars["String"]>;
   prizeStrategy?: Maybe<SingleRandomWinnerPrizeStrategy>;
-  symbol?: Maybe<Scalars['String']>;
+  symbol?: Maybe<Scalars["String"]>;
 };
 
 export type SingleRandomWinnerExternalErc20Award_Filter = {
-  address?: Maybe<Scalars['Bytes']>;
-  address_contains?: Maybe<Scalars['Bytes']>;
-  address_in?: Maybe<Array<Scalars['Bytes']>>;
-  address_not?: Maybe<Scalars['Bytes']>;
-  address_not_contains?: Maybe<Scalars['Bytes']>;
-  address_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  decimals?: Maybe<Scalars['BigInt']>;
-  decimals_gt?: Maybe<Scalars['BigInt']>;
-  decimals_gte?: Maybe<Scalars['BigInt']>;
-  decimals_in?: Maybe<Array<Scalars['BigInt']>>;
-  decimals_lt?: Maybe<Scalars['BigInt']>;
-  decimals_lte?: Maybe<Scalars['BigInt']>;
-  decimals_not?: Maybe<Scalars['BigInt']>;
-  decimals_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  name?: Maybe<Scalars['String']>;
-  name_contains?: Maybe<Scalars['String']>;
-  name_ends_with?: Maybe<Scalars['String']>;
-  name_gt?: Maybe<Scalars['String']>;
-  name_gte?: Maybe<Scalars['String']>;
-  name_in?: Maybe<Array<Scalars['String']>>;
-  name_lt?: Maybe<Scalars['String']>;
-  name_lte?: Maybe<Scalars['String']>;
-  name_not?: Maybe<Scalars['String']>;
-  name_not_contains?: Maybe<Scalars['String']>;
-  name_not_ends_with?: Maybe<Scalars['String']>;
-  name_not_in?: Maybe<Array<Scalars['String']>>;
-  name_not_starts_with?: Maybe<Scalars['String']>;
-  name_starts_with?: Maybe<Scalars['String']>;
-  prizeStrategy?: Maybe<Scalars['String']>;
-  prizeStrategy_contains?: Maybe<Scalars['String']>;
-  prizeStrategy_ends_with?: Maybe<Scalars['String']>;
-  prizeStrategy_gt?: Maybe<Scalars['String']>;
-  prizeStrategy_gte?: Maybe<Scalars['String']>;
-  prizeStrategy_in?: Maybe<Array<Scalars['String']>>;
-  prizeStrategy_lt?: Maybe<Scalars['String']>;
-  prizeStrategy_lte?: Maybe<Scalars['String']>;
-  prizeStrategy_not?: Maybe<Scalars['String']>;
-  prizeStrategy_not_contains?: Maybe<Scalars['String']>;
-  prizeStrategy_not_ends_with?: Maybe<Scalars['String']>;
-  prizeStrategy_not_in?: Maybe<Array<Scalars['String']>>;
-  prizeStrategy_not_starts_with?: Maybe<Scalars['String']>;
-  prizeStrategy_starts_with?: Maybe<Scalars['String']>;
-  symbol?: Maybe<Scalars['String']>;
-  symbol_contains?: Maybe<Scalars['String']>;
-  symbol_ends_with?: Maybe<Scalars['String']>;
-  symbol_gt?: Maybe<Scalars['String']>;
-  symbol_gte?: Maybe<Scalars['String']>;
-  symbol_in?: Maybe<Array<Scalars['String']>>;
-  symbol_lt?: Maybe<Scalars['String']>;
-  symbol_lte?: Maybe<Scalars['String']>;
-  symbol_not?: Maybe<Scalars['String']>;
-  symbol_not_contains?: Maybe<Scalars['String']>;
-  symbol_not_ends_with?: Maybe<Scalars['String']>;
-  symbol_not_in?: Maybe<Array<Scalars['String']>>;
-  symbol_not_starts_with?: Maybe<Scalars['String']>;
-  symbol_starts_with?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars["Bytes"]>;
+  address_contains?: Maybe<Scalars["Bytes"]>;
+  address_in?: Maybe<Array<Scalars["Bytes"]>>;
+  address_not?: Maybe<Scalars["Bytes"]>;
+  address_not_contains?: Maybe<Scalars["Bytes"]>;
+  address_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  decimals?: Maybe<Scalars["BigInt"]>;
+  decimals_gt?: Maybe<Scalars["BigInt"]>;
+  decimals_gte?: Maybe<Scalars["BigInt"]>;
+  decimals_in?: Maybe<Array<Scalars["BigInt"]>>;
+  decimals_lt?: Maybe<Scalars["BigInt"]>;
+  decimals_lte?: Maybe<Scalars["BigInt"]>;
+  decimals_not?: Maybe<Scalars["BigInt"]>;
+  decimals_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  name?: Maybe<Scalars["String"]>;
+  name_contains?: Maybe<Scalars["String"]>;
+  name_ends_with?: Maybe<Scalars["String"]>;
+  name_gt?: Maybe<Scalars["String"]>;
+  name_gte?: Maybe<Scalars["String"]>;
+  name_in?: Maybe<Array<Scalars["String"]>>;
+  name_lt?: Maybe<Scalars["String"]>;
+  name_lte?: Maybe<Scalars["String"]>;
+  name_not?: Maybe<Scalars["String"]>;
+  name_not_contains?: Maybe<Scalars["String"]>;
+  name_not_ends_with?: Maybe<Scalars["String"]>;
+  name_not_in?: Maybe<Array<Scalars["String"]>>;
+  name_not_starts_with?: Maybe<Scalars["String"]>;
+  name_starts_with?: Maybe<Scalars["String"]>;
+  prizeStrategy?: Maybe<Scalars["String"]>;
+  prizeStrategy_contains?: Maybe<Scalars["String"]>;
+  prizeStrategy_ends_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_gt?: Maybe<Scalars["String"]>;
+  prizeStrategy_gte?: Maybe<Scalars["String"]>;
+  prizeStrategy_in?: Maybe<Array<Scalars["String"]>>;
+  prizeStrategy_lt?: Maybe<Scalars["String"]>;
+  prizeStrategy_lte?: Maybe<Scalars["String"]>;
+  prizeStrategy_not?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_contains?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_ends_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_in?: Maybe<Array<Scalars["String"]>>;
+  prizeStrategy_not_starts_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_starts_with?: Maybe<Scalars["String"]>;
+  symbol?: Maybe<Scalars["String"]>;
+  symbol_contains?: Maybe<Scalars["String"]>;
+  symbol_ends_with?: Maybe<Scalars["String"]>;
+  symbol_gt?: Maybe<Scalars["String"]>;
+  symbol_gte?: Maybe<Scalars["String"]>;
+  symbol_in?: Maybe<Array<Scalars["String"]>>;
+  symbol_lt?: Maybe<Scalars["String"]>;
+  symbol_lte?: Maybe<Scalars["String"]>;
+  symbol_not?: Maybe<Scalars["String"]>;
+  symbol_not_contains?: Maybe<Scalars["String"]>;
+  symbol_not_ends_with?: Maybe<Scalars["String"]>;
+  symbol_not_in?: Maybe<Array<Scalars["String"]>>;
+  symbol_not_starts_with?: Maybe<Scalars["String"]>;
+  symbol_starts_with?: Maybe<Scalars["String"]>;
 };
 
 export enum SingleRandomWinnerExternalErc20Award_OrderBy {
-  Address = 'address',
-  Decimals = 'decimals',
-  Id = 'id',
-  Name = 'name',
-  PrizeStrategy = 'prizeStrategy',
-  Symbol = 'symbol'
+  Address = "address",
+  Decimals = "decimals",
+  Id = "id",
+  Name = "name",
+  PrizeStrategy = "prizeStrategy",
+  Symbol = "symbol",
 }
 
 export type SingleRandomWinnerExternalErc721Award = {
-  __typename?: 'SingleRandomWinnerExternalErc721Award';
-  address: Scalars['Bytes'];
-  id: Scalars['ID'];
+  __typename?: "SingleRandomWinnerExternalErc721Award";
+  address: Scalars["Bytes"];
+  id: Scalars["ID"];
   prizeStrategy?: Maybe<SingleRandomWinnerPrizeStrategy>;
-  tokenIds?: Maybe<Array<Scalars['BigInt']>>;
+  tokenIds?: Maybe<Array<Scalars["BigInt"]>>;
 };
 
 export type SingleRandomWinnerExternalErc721Award_Filter = {
-  address?: Maybe<Scalars['Bytes']>;
-  address_contains?: Maybe<Scalars['Bytes']>;
-  address_in?: Maybe<Array<Scalars['Bytes']>>;
-  address_not?: Maybe<Scalars['Bytes']>;
-  address_not_contains?: Maybe<Scalars['Bytes']>;
-  address_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  prizeStrategy?: Maybe<Scalars['String']>;
-  prizeStrategy_contains?: Maybe<Scalars['String']>;
-  prizeStrategy_ends_with?: Maybe<Scalars['String']>;
-  prizeStrategy_gt?: Maybe<Scalars['String']>;
-  prizeStrategy_gte?: Maybe<Scalars['String']>;
-  prizeStrategy_in?: Maybe<Array<Scalars['String']>>;
-  prizeStrategy_lt?: Maybe<Scalars['String']>;
-  prizeStrategy_lte?: Maybe<Scalars['String']>;
-  prizeStrategy_not?: Maybe<Scalars['String']>;
-  prizeStrategy_not_contains?: Maybe<Scalars['String']>;
-  prizeStrategy_not_ends_with?: Maybe<Scalars['String']>;
-  prizeStrategy_not_in?: Maybe<Array<Scalars['String']>>;
-  prizeStrategy_not_starts_with?: Maybe<Scalars['String']>;
-  prizeStrategy_starts_with?: Maybe<Scalars['String']>;
-  tokenIds?: Maybe<Array<Scalars['BigInt']>>;
-  tokenIds_contains?: Maybe<Array<Scalars['BigInt']>>;
-  tokenIds_not?: Maybe<Array<Scalars['BigInt']>>;
-  tokenIds_not_contains?: Maybe<Array<Scalars['BigInt']>>;
+  address?: Maybe<Scalars["Bytes"]>;
+  address_contains?: Maybe<Scalars["Bytes"]>;
+  address_in?: Maybe<Array<Scalars["Bytes"]>>;
+  address_not?: Maybe<Scalars["Bytes"]>;
+  address_not_contains?: Maybe<Scalars["Bytes"]>;
+  address_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  prizeStrategy?: Maybe<Scalars["String"]>;
+  prizeStrategy_contains?: Maybe<Scalars["String"]>;
+  prizeStrategy_ends_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_gt?: Maybe<Scalars["String"]>;
+  prizeStrategy_gte?: Maybe<Scalars["String"]>;
+  prizeStrategy_in?: Maybe<Array<Scalars["String"]>>;
+  prizeStrategy_lt?: Maybe<Scalars["String"]>;
+  prizeStrategy_lte?: Maybe<Scalars["String"]>;
+  prizeStrategy_not?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_contains?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_ends_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_not_in?: Maybe<Array<Scalars["String"]>>;
+  prizeStrategy_not_starts_with?: Maybe<Scalars["String"]>;
+  prizeStrategy_starts_with?: Maybe<Scalars["String"]>;
+  tokenIds?: Maybe<Array<Scalars["BigInt"]>>;
+  tokenIds_contains?: Maybe<Array<Scalars["BigInt"]>>;
+  tokenIds_not?: Maybe<Array<Scalars["BigInt"]>>;
+  tokenIds_not_contains?: Maybe<Array<Scalars["BigInt"]>>;
 };
 
 export enum SingleRandomWinnerExternalErc721Award_OrderBy {
-  Address = 'address',
-  Id = 'id',
-  PrizeStrategy = 'prizeStrategy',
-  TokenIds = 'tokenIds'
+  Address = "address",
+  Id = "id",
+  PrizeStrategy = "prizeStrategy",
+  TokenIds = "tokenIds",
 }
 
 export type SingleRandomWinnerPrizeStrategy = {
-  __typename?: 'SingleRandomWinnerPrizeStrategy';
+  __typename?: "SingleRandomWinnerPrizeStrategy";
   externalErc20Awards: Array<SingleRandomWinnerExternalErc20Award>;
   externalErc721Awards: Array<SingleRandomWinnerExternalErc721Award>;
-  id: Scalars['ID'];
-  owner?: Maybe<Scalars['Bytes']>;
-  prizePeriodEndAt: Scalars['BigInt'];
-  prizePeriodSeconds: Scalars['BigInt'];
-  prizePeriodStartedAt: Scalars['BigInt'];
+  id: Scalars["ID"];
+  owner?: Maybe<Scalars["Bytes"]>;
+  prizePeriodEndAt: Scalars["BigInt"];
+  prizePeriodSeconds: Scalars["BigInt"];
+  prizePeriodStartedAt: Scalars["BigInt"];
   prizePool?: Maybe<PrizePool>;
-  rng?: Maybe<Scalars['Bytes']>;
+  rng?: Maybe<Scalars["Bytes"]>;
   sponsorship?: Maybe<ControlledToken>;
   ticket?: Maybe<ControlledToken>;
   tokenListener?: Maybe<Comptroller>;
 };
 
-
 export type SingleRandomWinnerPrizeStrategyExternalErc20AwardsArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<SingleRandomWinnerExternalErc20Award_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<SingleRandomWinnerExternalErc20Award_Filter>;
 };
 
-
 export type SingleRandomWinnerPrizeStrategyExternalErc721AwardsArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<SingleRandomWinnerExternalErc721Award_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<SingleRandomWinnerExternalErc721Award_Filter>;
 };
 
 export type SingleRandomWinnerPrizeStrategy_Filter = {
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  owner?: Maybe<Scalars['Bytes']>;
-  owner_contains?: Maybe<Scalars['Bytes']>;
-  owner_in?: Maybe<Array<Scalars['Bytes']>>;
-  owner_not?: Maybe<Scalars['Bytes']>;
-  owner_not_contains?: Maybe<Scalars['Bytes']>;
-  owner_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  prizePeriodEndAt?: Maybe<Scalars['BigInt']>;
-  prizePeriodEndAt_gt?: Maybe<Scalars['BigInt']>;
-  prizePeriodEndAt_gte?: Maybe<Scalars['BigInt']>;
-  prizePeriodEndAt_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizePeriodEndAt_lt?: Maybe<Scalars['BigInt']>;
-  prizePeriodEndAt_lte?: Maybe<Scalars['BigInt']>;
-  prizePeriodEndAt_not?: Maybe<Scalars['BigInt']>;
-  prizePeriodEndAt_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizePeriodSeconds?: Maybe<Scalars['BigInt']>;
-  prizePeriodSeconds_gt?: Maybe<Scalars['BigInt']>;
-  prizePeriodSeconds_gte?: Maybe<Scalars['BigInt']>;
-  prizePeriodSeconds_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizePeriodSeconds_lt?: Maybe<Scalars['BigInt']>;
-  prizePeriodSeconds_lte?: Maybe<Scalars['BigInt']>;
-  prizePeriodSeconds_not?: Maybe<Scalars['BigInt']>;
-  prizePeriodSeconds_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizePeriodStartedAt?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedAt_gt?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedAt_gte?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedAt_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizePeriodStartedAt_lt?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedAt_lte?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedAt_not?: Maybe<Scalars['BigInt']>;
-  prizePeriodStartedAt_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  prizePool?: Maybe<Scalars['String']>;
-  prizePool_contains?: Maybe<Scalars['String']>;
-  prizePool_ends_with?: Maybe<Scalars['String']>;
-  prizePool_gt?: Maybe<Scalars['String']>;
-  prizePool_gte?: Maybe<Scalars['String']>;
-  prizePool_in?: Maybe<Array<Scalars['String']>>;
-  prizePool_lt?: Maybe<Scalars['String']>;
-  prizePool_lte?: Maybe<Scalars['String']>;
-  prizePool_not?: Maybe<Scalars['String']>;
-  prizePool_not_contains?: Maybe<Scalars['String']>;
-  prizePool_not_ends_with?: Maybe<Scalars['String']>;
-  prizePool_not_in?: Maybe<Array<Scalars['String']>>;
-  prizePool_not_starts_with?: Maybe<Scalars['String']>;
-  prizePool_starts_with?: Maybe<Scalars['String']>;
-  rng?: Maybe<Scalars['Bytes']>;
-  rng_contains?: Maybe<Scalars['Bytes']>;
-  rng_in?: Maybe<Array<Scalars['Bytes']>>;
-  rng_not?: Maybe<Scalars['Bytes']>;
-  rng_not_contains?: Maybe<Scalars['Bytes']>;
-  rng_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  sponsorship?: Maybe<Scalars['String']>;
-  sponsorship_contains?: Maybe<Scalars['String']>;
-  sponsorship_ends_with?: Maybe<Scalars['String']>;
-  sponsorship_gt?: Maybe<Scalars['String']>;
-  sponsorship_gte?: Maybe<Scalars['String']>;
-  sponsorship_in?: Maybe<Array<Scalars['String']>>;
-  sponsorship_lt?: Maybe<Scalars['String']>;
-  sponsorship_lte?: Maybe<Scalars['String']>;
-  sponsorship_not?: Maybe<Scalars['String']>;
-  sponsorship_not_contains?: Maybe<Scalars['String']>;
-  sponsorship_not_ends_with?: Maybe<Scalars['String']>;
-  sponsorship_not_in?: Maybe<Array<Scalars['String']>>;
-  sponsorship_not_starts_with?: Maybe<Scalars['String']>;
-  sponsorship_starts_with?: Maybe<Scalars['String']>;
-  ticket?: Maybe<Scalars['String']>;
-  ticket_contains?: Maybe<Scalars['String']>;
-  ticket_ends_with?: Maybe<Scalars['String']>;
-  ticket_gt?: Maybe<Scalars['String']>;
-  ticket_gte?: Maybe<Scalars['String']>;
-  ticket_in?: Maybe<Array<Scalars['String']>>;
-  ticket_lt?: Maybe<Scalars['String']>;
-  ticket_lte?: Maybe<Scalars['String']>;
-  ticket_not?: Maybe<Scalars['String']>;
-  ticket_not_contains?: Maybe<Scalars['String']>;
-  ticket_not_ends_with?: Maybe<Scalars['String']>;
-  ticket_not_in?: Maybe<Array<Scalars['String']>>;
-  ticket_not_starts_with?: Maybe<Scalars['String']>;
-  ticket_starts_with?: Maybe<Scalars['String']>;
-  tokenListener?: Maybe<Scalars['String']>;
-  tokenListener_contains?: Maybe<Scalars['String']>;
-  tokenListener_ends_with?: Maybe<Scalars['String']>;
-  tokenListener_gt?: Maybe<Scalars['String']>;
-  tokenListener_gte?: Maybe<Scalars['String']>;
-  tokenListener_in?: Maybe<Array<Scalars['String']>>;
-  tokenListener_lt?: Maybe<Scalars['String']>;
-  tokenListener_lte?: Maybe<Scalars['String']>;
-  tokenListener_not?: Maybe<Scalars['String']>;
-  tokenListener_not_contains?: Maybe<Scalars['String']>;
-  tokenListener_not_ends_with?: Maybe<Scalars['String']>;
-  tokenListener_not_in?: Maybe<Array<Scalars['String']>>;
-  tokenListener_not_starts_with?: Maybe<Scalars['String']>;
-  tokenListener_starts_with?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  owner?: Maybe<Scalars["Bytes"]>;
+  owner_contains?: Maybe<Scalars["Bytes"]>;
+  owner_in?: Maybe<Array<Scalars["Bytes"]>>;
+  owner_not?: Maybe<Scalars["Bytes"]>;
+  owner_not_contains?: Maybe<Scalars["Bytes"]>;
+  owner_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  prizePeriodEndAt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodEndAt_gt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodEndAt_gte?: Maybe<Scalars["BigInt"]>;
+  prizePeriodEndAt_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizePeriodEndAt_lt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodEndAt_lte?: Maybe<Scalars["BigInt"]>;
+  prizePeriodEndAt_not?: Maybe<Scalars["BigInt"]>;
+  prizePeriodEndAt_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizePeriodSeconds?: Maybe<Scalars["BigInt"]>;
+  prizePeriodSeconds_gt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodSeconds_gte?: Maybe<Scalars["BigInt"]>;
+  prizePeriodSeconds_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizePeriodSeconds_lt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodSeconds_lte?: Maybe<Scalars["BigInt"]>;
+  prizePeriodSeconds_not?: Maybe<Scalars["BigInt"]>;
+  prizePeriodSeconds_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizePeriodStartedAt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedAt_gt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedAt_gte?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedAt_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizePeriodStartedAt_lt?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedAt_lte?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedAt_not?: Maybe<Scalars["BigInt"]>;
+  prizePeriodStartedAt_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  prizePool?: Maybe<Scalars["String"]>;
+  prizePool_contains?: Maybe<Scalars["String"]>;
+  prizePool_ends_with?: Maybe<Scalars["String"]>;
+  prizePool_gt?: Maybe<Scalars["String"]>;
+  prizePool_gte?: Maybe<Scalars["String"]>;
+  prizePool_in?: Maybe<Array<Scalars["String"]>>;
+  prizePool_lt?: Maybe<Scalars["String"]>;
+  prizePool_lte?: Maybe<Scalars["String"]>;
+  prizePool_not?: Maybe<Scalars["String"]>;
+  prizePool_not_contains?: Maybe<Scalars["String"]>;
+  prizePool_not_ends_with?: Maybe<Scalars["String"]>;
+  prizePool_not_in?: Maybe<Array<Scalars["String"]>>;
+  prizePool_not_starts_with?: Maybe<Scalars["String"]>;
+  prizePool_starts_with?: Maybe<Scalars["String"]>;
+  rng?: Maybe<Scalars["Bytes"]>;
+  rng_contains?: Maybe<Scalars["Bytes"]>;
+  rng_in?: Maybe<Array<Scalars["Bytes"]>>;
+  rng_not?: Maybe<Scalars["Bytes"]>;
+  rng_not_contains?: Maybe<Scalars["Bytes"]>;
+  rng_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  sponsorship?: Maybe<Scalars["String"]>;
+  sponsorship_contains?: Maybe<Scalars["String"]>;
+  sponsorship_ends_with?: Maybe<Scalars["String"]>;
+  sponsorship_gt?: Maybe<Scalars["String"]>;
+  sponsorship_gte?: Maybe<Scalars["String"]>;
+  sponsorship_in?: Maybe<Array<Scalars["String"]>>;
+  sponsorship_lt?: Maybe<Scalars["String"]>;
+  sponsorship_lte?: Maybe<Scalars["String"]>;
+  sponsorship_not?: Maybe<Scalars["String"]>;
+  sponsorship_not_contains?: Maybe<Scalars["String"]>;
+  sponsorship_not_ends_with?: Maybe<Scalars["String"]>;
+  sponsorship_not_in?: Maybe<Array<Scalars["String"]>>;
+  sponsorship_not_starts_with?: Maybe<Scalars["String"]>;
+  sponsorship_starts_with?: Maybe<Scalars["String"]>;
+  ticket?: Maybe<Scalars["String"]>;
+  ticket_contains?: Maybe<Scalars["String"]>;
+  ticket_ends_with?: Maybe<Scalars["String"]>;
+  ticket_gt?: Maybe<Scalars["String"]>;
+  ticket_gte?: Maybe<Scalars["String"]>;
+  ticket_in?: Maybe<Array<Scalars["String"]>>;
+  ticket_lt?: Maybe<Scalars["String"]>;
+  ticket_lte?: Maybe<Scalars["String"]>;
+  ticket_not?: Maybe<Scalars["String"]>;
+  ticket_not_contains?: Maybe<Scalars["String"]>;
+  ticket_not_ends_with?: Maybe<Scalars["String"]>;
+  ticket_not_in?: Maybe<Array<Scalars["String"]>>;
+  ticket_not_starts_with?: Maybe<Scalars["String"]>;
+  ticket_starts_with?: Maybe<Scalars["String"]>;
+  tokenListener?: Maybe<Scalars["String"]>;
+  tokenListener_contains?: Maybe<Scalars["String"]>;
+  tokenListener_ends_with?: Maybe<Scalars["String"]>;
+  tokenListener_gt?: Maybe<Scalars["String"]>;
+  tokenListener_gte?: Maybe<Scalars["String"]>;
+  tokenListener_in?: Maybe<Array<Scalars["String"]>>;
+  tokenListener_lt?: Maybe<Scalars["String"]>;
+  tokenListener_lte?: Maybe<Scalars["String"]>;
+  tokenListener_not?: Maybe<Scalars["String"]>;
+  tokenListener_not_contains?: Maybe<Scalars["String"]>;
+  tokenListener_not_ends_with?: Maybe<Scalars["String"]>;
+  tokenListener_not_in?: Maybe<Array<Scalars["String"]>>;
+  tokenListener_not_starts_with?: Maybe<Scalars["String"]>;
+  tokenListener_starts_with?: Maybe<Scalars["String"]>;
 };
 
 export enum SingleRandomWinnerPrizeStrategy_OrderBy {
-  ExternalErc20Awards = 'externalErc20Awards',
-  ExternalErc721Awards = 'externalErc721Awards',
-  Id = 'id',
-  Owner = 'owner',
-  PrizePeriodEndAt = 'prizePeriodEndAt',
-  PrizePeriodSeconds = 'prizePeriodSeconds',
-  PrizePeriodStartedAt = 'prizePeriodStartedAt',
-  PrizePool = 'prizePool',
-  Rng = 'rng',
-  Sponsorship = 'sponsorship',
-  Ticket = 'ticket',
-  TokenListener = 'tokenListener'
+  ExternalErc20Awards = "externalErc20Awards",
+  ExternalErc721Awards = "externalErc721Awards",
+  Id = "id",
+  Owner = "owner",
+  PrizePeriodEndAt = "prizePeriodEndAt",
+  PrizePeriodSeconds = "prizePeriodSeconds",
+  PrizePeriodStartedAt = "prizePeriodStartedAt",
+  PrizePool = "prizePool",
+  Rng = "rng",
+  Sponsorship = "sponsorship",
+  Ticket = "ticket",
+  TokenListener = "tokenListener",
 }
 
 export type StakePrizePool = {
-  __typename?: 'StakePrizePool';
-  id: Scalars['ID'];
-  stakeToken?: Maybe<Scalars['Bytes']>;
+  __typename?: "StakePrizePool";
+  id: Scalars["ID"];
+  stakeToken?: Maybe<Scalars["Bytes"]>;
 };
 
 export type StakePrizePool_Filter = {
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  stakeToken?: Maybe<Scalars['Bytes']>;
-  stakeToken_contains?: Maybe<Scalars['Bytes']>;
-  stakeToken_in?: Maybe<Array<Scalars['Bytes']>>;
-  stakeToken_not?: Maybe<Scalars['Bytes']>;
-  stakeToken_not_contains?: Maybe<Scalars['Bytes']>;
-  stakeToken_not_in?: Maybe<Array<Scalars['Bytes']>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  stakeToken?: Maybe<Scalars["Bytes"]>;
+  stakeToken_contains?: Maybe<Scalars["Bytes"]>;
+  stakeToken_in?: Maybe<Array<Scalars["Bytes"]>>;
+  stakeToken_not?: Maybe<Scalars["Bytes"]>;
+  stakeToken_not_contains?: Maybe<Scalars["Bytes"]>;
+  stakeToken_not_in?: Maybe<Array<Scalars["Bytes"]>>;
 };
 
 export enum StakePrizePool_OrderBy {
-  Id = 'id',
-  StakeToken = 'stakeToken'
+  Id = "id",
+  StakeToken = "stakeToken",
 }
 
 export type Subscription = {
-  __typename?: 'Subscription';
+  __typename?: "Subscription";
   /** Access to subgraph metadata */
   _meta?: Maybe<_Meta_>;
   account?: Maybe<Account>;
@@ -2890,860 +2809,797 @@ export type Subscription = {
   yieldSourcePrizePools: Array<YieldSourcePrizePool>;
 };
 
-
 export type Subscription_MetaArgs = {
   block?: Maybe<Block_Height>;
 };
 
-
 export type SubscriptionAccountArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionAccountsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<Account_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<Account_Filter>;
 };
 
-
 export type SubscriptionAwardedControlledTokenArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionAwardedControlledTokensArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<AwardedControlledToken_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<AwardedControlledToken_Filter>;
 };
 
-
 export type SubscriptionAwardedExternalErc20TokenArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionAwardedExternalErc20TokensArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<AwardedExternalErc20Token_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<AwardedExternalErc20Token_Filter>;
 };
 
-
 export type SubscriptionAwardedExternalErc721NftArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionAwardedExternalErc721NftsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<AwardedExternalErc721Nft_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<AwardedExternalErc721Nft_Filter>;
 };
 
-
 export type SubscriptionBalanceDripArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
-
 
 export type SubscriptionBalanceDripPlayerArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionBalanceDripPlayersArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<BalanceDripPlayer_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<BalanceDripPlayer_Filter>;
 };
 
-
 export type SubscriptionBalanceDripsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<BalanceDrip_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<BalanceDrip_Filter>;
 };
 
-
 export type SubscriptionCompoundPrizePoolArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionCompoundPrizePoolsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<CompoundPrizePool_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<CompoundPrizePool_Filter>;
 };
 
-
 export type SubscriptionComptrollerArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionComptrollersArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<Comptroller_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<Comptroller_Filter>;
 };
 
-
 export type SubscriptionControlledTokenArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
-
 
 export type SubscriptionControlledTokenBalanceArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionControlledTokenBalancesArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<ControlledTokenBalance_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<ControlledTokenBalance_Filter>;
 };
 
-
 export type SubscriptionControlledTokensArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<ControlledToken_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<ControlledToken_Filter>;
 };
 
-
 export type SubscriptionCreditBalanceArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionCreditBalancesArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<CreditBalance_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<CreditBalance_Filter>;
 };
 
-
 export type SubscriptionCreditRateArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionCreditRatesArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<CreditRate_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<CreditRate_Filter>;
 };
 
-
 export type SubscriptionDripTokenPlayerArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionDripTokenPlayersArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<DripTokenPlayer_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<DripTokenPlayer_Filter>;
 };
 
-
 export type SubscriptionMultipleWinnersExternalErc20AwardArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionMultipleWinnersExternalErc20AwardsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<MultipleWinnersExternalErc20Award_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<MultipleWinnersExternalErc20Award_Filter>;
 };
 
-
 export type SubscriptionMultipleWinnersExternalErc721AwardArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionMultipleWinnersExternalErc721AwardsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<MultipleWinnersExternalErc721Award_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<MultipleWinnersExternalErc721Award_Filter>;
 };
 
-
 export type SubscriptionMultipleWinnersPrizeStrategiesArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<MultipleWinnersPrizeStrategy_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<MultipleWinnersPrizeStrategy_Filter>;
 };
 
-
 export type SubscriptionMultipleWinnersPrizeStrategyArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
-
 
 export type SubscriptionPrizeArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
-
 
 export type SubscriptionPrizePoolArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
-
 
 export type SubscriptionPrizePoolAccountArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionPrizePoolAccountsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<PrizePoolAccount_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<PrizePoolAccount_Filter>;
 };
 
-
 export type SubscriptionPrizePoolsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<PrizePool_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<PrizePool_Filter>;
 };
 
-
 export type SubscriptionPrizeSplitArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionPrizeSplitsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<PrizeSplit_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<PrizeSplit_Filter>;
 };
 
-
 export type SubscriptionPrizeStrategiesArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<PrizeStrategy_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<PrizeStrategy_Filter>;
 };
 
-
 export type SubscriptionPrizeStrategyArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionPrizesArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<Prize_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<Prize_Filter>;
 };
 
-
 export type SubscriptionSablierStreamArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionSablierStreamsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<SablierStream_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<SablierStream_Filter>;
 };
 
-
 export type SubscriptionSingleRandomWinnerExternalErc20AwardArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionSingleRandomWinnerExternalErc20AwardsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<SingleRandomWinnerExternalErc20Award_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<SingleRandomWinnerExternalErc20Award_Filter>;
 };
 
-
 export type SubscriptionSingleRandomWinnerExternalErc721AwardArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionSingleRandomWinnerExternalErc721AwardsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<SingleRandomWinnerExternalErc721Award_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<SingleRandomWinnerExternalErc721Award_Filter>;
 };
 
-
 export type SubscriptionSingleRandomWinnerPrizeStrategiesArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<SingleRandomWinnerPrizeStrategy_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<SingleRandomWinnerPrizeStrategy_Filter>;
 };
 
-
 export type SubscriptionSingleRandomWinnerPrizeStrategyArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
-
 
 export type SubscriptionStakePrizePoolArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionStakePrizePoolsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<StakePrizePool_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<StakePrizePool_Filter>;
 };
 
-
 export type SubscriptionVolumeDripArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
-
 
 export type SubscriptionVolumeDripPeriodArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionVolumeDripPeriodsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<VolumeDripPeriod_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<VolumeDripPeriod_Filter>;
 };
 
-
 export type SubscriptionVolumeDripPlayerArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionVolumeDripPlayersArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<VolumeDripPlayer_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<VolumeDripPlayer_Filter>;
 };
 
-
 export type SubscriptionVolumeDripsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<VolumeDrip_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<VolumeDrip_Filter>;
 };
 
-
 export type SubscriptionYieldSourcePrizePoolArgs = {
   block?: Maybe<Block_Height>;
-  id: Scalars['ID'];
+  id: Scalars["ID"];
   subgraphError?: _SubgraphErrorPolicy_;
 };
 
-
 export type SubscriptionYieldSourcePrizePoolsArgs = {
   block?: Maybe<Block_Height>;
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<YieldSourcePrizePool_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   subgraphError?: _SubgraphErrorPolicy_;
   where?: Maybe<YieldSourcePrizePool_Filter>;
 };
 
 export type VolumeDrip = {
-  __typename?: 'VolumeDrip';
+  __typename?: "VolumeDrip";
   comptroller: Comptroller;
-  deactivated: Scalars['Boolean'];
+  deactivated: Scalars["Boolean"];
   deposits: Array<VolumeDripPlayer>;
-  dripAmount?: Maybe<Scalars['BigInt']>;
-  dripToken: Scalars['Bytes'];
-  id: Scalars['ID'];
-  measureToken: Scalars['Bytes'];
-  periodCount?: Maybe<Scalars['BigInt']>;
-  periodSeconds?: Maybe<Scalars['BigInt']>;
+  dripAmount?: Maybe<Scalars["BigInt"]>;
+  dripToken: Scalars["Bytes"];
+  id: Scalars["ID"];
+  measureToken: Scalars["Bytes"];
+  periodCount?: Maybe<Scalars["BigInt"]>;
+  periodSeconds?: Maybe<Scalars["BigInt"]>;
   periods: Array<VolumeDripPeriod>;
-  referral: Scalars['Boolean'];
-  sourceAddress: Scalars['Bytes'];
+  referral: Scalars["Boolean"];
+  sourceAddress: Scalars["Bytes"];
 };
 
-
 export type VolumeDripDepositsArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<VolumeDripPlayer_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<VolumeDripPlayer_Filter>;
 };
 
-
 export type VolumeDripPeriodsArgs = {
-  first?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars["Int"]>;
   orderBy?: Maybe<VolumeDripPeriod_OrderBy>;
   orderDirection?: Maybe<OrderDirection>;
-  skip?: Maybe<Scalars['Int']>;
+  skip?: Maybe<Scalars["Int"]>;
   where?: Maybe<VolumeDripPeriod_Filter>;
 };
 
 export type VolumeDripPeriod = {
-  __typename?: 'VolumeDripPeriod';
-  dripAmount?: Maybe<Scalars['BigInt']>;
-  endTime?: Maybe<Scalars['BigInt']>;
-  id: Scalars['ID'];
-  isDripping: Scalars['Boolean'];
-  periodIndex: Scalars['BigInt'];
-  totalSupply?: Maybe<Scalars['BigInt']>;
+  __typename?: "VolumeDripPeriod";
+  dripAmount?: Maybe<Scalars["BigInt"]>;
+  endTime?: Maybe<Scalars["BigInt"]>;
+  id: Scalars["ID"];
+  isDripping: Scalars["Boolean"];
+  periodIndex: Scalars["BigInt"];
+  totalSupply?: Maybe<Scalars["BigInt"]>;
   volumeDrip: VolumeDrip;
 };
 
 export type VolumeDripPeriod_Filter = {
-  dripAmount?: Maybe<Scalars['BigInt']>;
-  dripAmount_gt?: Maybe<Scalars['BigInt']>;
-  dripAmount_gte?: Maybe<Scalars['BigInt']>;
-  dripAmount_in?: Maybe<Array<Scalars['BigInt']>>;
-  dripAmount_lt?: Maybe<Scalars['BigInt']>;
-  dripAmount_lte?: Maybe<Scalars['BigInt']>;
-  dripAmount_not?: Maybe<Scalars['BigInt']>;
-  dripAmount_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  endTime?: Maybe<Scalars['BigInt']>;
-  endTime_gt?: Maybe<Scalars['BigInt']>;
-  endTime_gte?: Maybe<Scalars['BigInt']>;
-  endTime_in?: Maybe<Array<Scalars['BigInt']>>;
-  endTime_lt?: Maybe<Scalars['BigInt']>;
-  endTime_lte?: Maybe<Scalars['BigInt']>;
-  endTime_not?: Maybe<Scalars['BigInt']>;
-  endTime_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  isDripping?: Maybe<Scalars['Boolean']>;
-  isDripping_in?: Maybe<Array<Scalars['Boolean']>>;
-  isDripping_not?: Maybe<Scalars['Boolean']>;
-  isDripping_not_in?: Maybe<Array<Scalars['Boolean']>>;
-  periodIndex?: Maybe<Scalars['BigInt']>;
-  periodIndex_gt?: Maybe<Scalars['BigInt']>;
-  periodIndex_gte?: Maybe<Scalars['BigInt']>;
-  periodIndex_in?: Maybe<Array<Scalars['BigInt']>>;
-  periodIndex_lt?: Maybe<Scalars['BigInt']>;
-  periodIndex_lte?: Maybe<Scalars['BigInt']>;
-  periodIndex_not?: Maybe<Scalars['BigInt']>;
-  periodIndex_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  totalSupply?: Maybe<Scalars['BigInt']>;
-  totalSupply_gt?: Maybe<Scalars['BigInt']>;
-  totalSupply_gte?: Maybe<Scalars['BigInt']>;
-  totalSupply_in?: Maybe<Array<Scalars['BigInt']>>;
-  totalSupply_lt?: Maybe<Scalars['BigInt']>;
-  totalSupply_lte?: Maybe<Scalars['BigInt']>;
-  totalSupply_not?: Maybe<Scalars['BigInt']>;
-  totalSupply_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  volumeDrip?: Maybe<Scalars['String']>;
-  volumeDrip_contains?: Maybe<Scalars['String']>;
-  volumeDrip_ends_with?: Maybe<Scalars['String']>;
-  volumeDrip_gt?: Maybe<Scalars['String']>;
-  volumeDrip_gte?: Maybe<Scalars['String']>;
-  volumeDrip_in?: Maybe<Array<Scalars['String']>>;
-  volumeDrip_lt?: Maybe<Scalars['String']>;
-  volumeDrip_lte?: Maybe<Scalars['String']>;
-  volumeDrip_not?: Maybe<Scalars['String']>;
-  volumeDrip_not_contains?: Maybe<Scalars['String']>;
-  volumeDrip_not_ends_with?: Maybe<Scalars['String']>;
-  volumeDrip_not_in?: Maybe<Array<Scalars['String']>>;
-  volumeDrip_not_starts_with?: Maybe<Scalars['String']>;
-  volumeDrip_starts_with?: Maybe<Scalars['String']>;
+  dripAmount?: Maybe<Scalars["BigInt"]>;
+  dripAmount_gt?: Maybe<Scalars["BigInt"]>;
+  dripAmount_gte?: Maybe<Scalars["BigInt"]>;
+  dripAmount_in?: Maybe<Array<Scalars["BigInt"]>>;
+  dripAmount_lt?: Maybe<Scalars["BigInt"]>;
+  dripAmount_lte?: Maybe<Scalars["BigInt"]>;
+  dripAmount_not?: Maybe<Scalars["BigInt"]>;
+  dripAmount_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  endTime?: Maybe<Scalars["BigInt"]>;
+  endTime_gt?: Maybe<Scalars["BigInt"]>;
+  endTime_gte?: Maybe<Scalars["BigInt"]>;
+  endTime_in?: Maybe<Array<Scalars["BigInt"]>>;
+  endTime_lt?: Maybe<Scalars["BigInt"]>;
+  endTime_lte?: Maybe<Scalars["BigInt"]>;
+  endTime_not?: Maybe<Scalars["BigInt"]>;
+  endTime_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  isDripping?: Maybe<Scalars["Boolean"]>;
+  isDripping_in?: Maybe<Array<Scalars["Boolean"]>>;
+  isDripping_not?: Maybe<Scalars["Boolean"]>;
+  isDripping_not_in?: Maybe<Array<Scalars["Boolean"]>>;
+  periodIndex?: Maybe<Scalars["BigInt"]>;
+  periodIndex_gt?: Maybe<Scalars["BigInt"]>;
+  periodIndex_gte?: Maybe<Scalars["BigInt"]>;
+  periodIndex_in?: Maybe<Array<Scalars["BigInt"]>>;
+  periodIndex_lt?: Maybe<Scalars["BigInt"]>;
+  periodIndex_lte?: Maybe<Scalars["BigInt"]>;
+  periodIndex_not?: Maybe<Scalars["BigInt"]>;
+  periodIndex_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  totalSupply?: Maybe<Scalars["BigInt"]>;
+  totalSupply_gt?: Maybe<Scalars["BigInt"]>;
+  totalSupply_gte?: Maybe<Scalars["BigInt"]>;
+  totalSupply_in?: Maybe<Array<Scalars["BigInt"]>>;
+  totalSupply_lt?: Maybe<Scalars["BigInt"]>;
+  totalSupply_lte?: Maybe<Scalars["BigInt"]>;
+  totalSupply_not?: Maybe<Scalars["BigInt"]>;
+  totalSupply_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  volumeDrip?: Maybe<Scalars["String"]>;
+  volumeDrip_contains?: Maybe<Scalars["String"]>;
+  volumeDrip_ends_with?: Maybe<Scalars["String"]>;
+  volumeDrip_gt?: Maybe<Scalars["String"]>;
+  volumeDrip_gte?: Maybe<Scalars["String"]>;
+  volumeDrip_in?: Maybe<Array<Scalars["String"]>>;
+  volumeDrip_lt?: Maybe<Scalars["String"]>;
+  volumeDrip_lte?: Maybe<Scalars["String"]>;
+  volumeDrip_not?: Maybe<Scalars["String"]>;
+  volumeDrip_not_contains?: Maybe<Scalars["String"]>;
+  volumeDrip_not_ends_with?: Maybe<Scalars["String"]>;
+  volumeDrip_not_in?: Maybe<Array<Scalars["String"]>>;
+  volumeDrip_not_starts_with?: Maybe<Scalars["String"]>;
+  volumeDrip_starts_with?: Maybe<Scalars["String"]>;
 };
 
 export enum VolumeDripPeriod_OrderBy {
-  DripAmount = 'dripAmount',
-  EndTime = 'endTime',
-  Id = 'id',
-  IsDripping = 'isDripping',
-  PeriodIndex = 'periodIndex',
-  TotalSupply = 'totalSupply',
-  VolumeDrip = 'volumeDrip'
+  DripAmount = "dripAmount",
+  EndTime = "endTime",
+  Id = "id",
+  IsDripping = "isDripping",
+  PeriodIndex = "periodIndex",
+  TotalSupply = "totalSupply",
+  VolumeDrip = "volumeDrip",
 }
 
 export type VolumeDripPlayer = {
-  __typename?: 'VolumeDripPlayer';
-  address: Scalars['Bytes'];
-  balance: Scalars['BigInt'];
-  id: Scalars['ID'];
-  periodIndex: Scalars['BigInt'];
+  __typename?: "VolumeDripPlayer";
+  address: Scalars["Bytes"];
+  balance: Scalars["BigInt"];
+  id: Scalars["ID"];
+  periodIndex: Scalars["BigInt"];
   volumeDrip: VolumeDrip;
 };
 
 export type VolumeDripPlayer_Filter = {
-  address?: Maybe<Scalars['Bytes']>;
-  address_contains?: Maybe<Scalars['Bytes']>;
-  address_in?: Maybe<Array<Scalars['Bytes']>>;
-  address_not?: Maybe<Scalars['Bytes']>;
-  address_not_contains?: Maybe<Scalars['Bytes']>;
-  address_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  balance?: Maybe<Scalars['BigInt']>;
-  balance_gt?: Maybe<Scalars['BigInt']>;
-  balance_gte?: Maybe<Scalars['BigInt']>;
-  balance_in?: Maybe<Array<Scalars['BigInt']>>;
-  balance_lt?: Maybe<Scalars['BigInt']>;
-  balance_lte?: Maybe<Scalars['BigInt']>;
-  balance_not?: Maybe<Scalars['BigInt']>;
-  balance_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  periodIndex?: Maybe<Scalars['BigInt']>;
-  periodIndex_gt?: Maybe<Scalars['BigInt']>;
-  periodIndex_gte?: Maybe<Scalars['BigInt']>;
-  periodIndex_in?: Maybe<Array<Scalars['BigInt']>>;
-  periodIndex_lt?: Maybe<Scalars['BigInt']>;
-  periodIndex_lte?: Maybe<Scalars['BigInt']>;
-  periodIndex_not?: Maybe<Scalars['BigInt']>;
-  periodIndex_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  volumeDrip?: Maybe<Scalars['String']>;
-  volumeDrip_contains?: Maybe<Scalars['String']>;
-  volumeDrip_ends_with?: Maybe<Scalars['String']>;
-  volumeDrip_gt?: Maybe<Scalars['String']>;
-  volumeDrip_gte?: Maybe<Scalars['String']>;
-  volumeDrip_in?: Maybe<Array<Scalars['String']>>;
-  volumeDrip_lt?: Maybe<Scalars['String']>;
-  volumeDrip_lte?: Maybe<Scalars['String']>;
-  volumeDrip_not?: Maybe<Scalars['String']>;
-  volumeDrip_not_contains?: Maybe<Scalars['String']>;
-  volumeDrip_not_ends_with?: Maybe<Scalars['String']>;
-  volumeDrip_not_in?: Maybe<Array<Scalars['String']>>;
-  volumeDrip_not_starts_with?: Maybe<Scalars['String']>;
-  volumeDrip_starts_with?: Maybe<Scalars['String']>;
+  address?: Maybe<Scalars["Bytes"]>;
+  address_contains?: Maybe<Scalars["Bytes"]>;
+  address_in?: Maybe<Array<Scalars["Bytes"]>>;
+  address_not?: Maybe<Scalars["Bytes"]>;
+  address_not_contains?: Maybe<Scalars["Bytes"]>;
+  address_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  balance?: Maybe<Scalars["BigInt"]>;
+  balance_gt?: Maybe<Scalars["BigInt"]>;
+  balance_gte?: Maybe<Scalars["BigInt"]>;
+  balance_in?: Maybe<Array<Scalars["BigInt"]>>;
+  balance_lt?: Maybe<Scalars["BigInt"]>;
+  balance_lte?: Maybe<Scalars["BigInt"]>;
+  balance_not?: Maybe<Scalars["BigInt"]>;
+  balance_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  periodIndex?: Maybe<Scalars["BigInt"]>;
+  periodIndex_gt?: Maybe<Scalars["BigInt"]>;
+  periodIndex_gte?: Maybe<Scalars["BigInt"]>;
+  periodIndex_in?: Maybe<Array<Scalars["BigInt"]>>;
+  periodIndex_lt?: Maybe<Scalars["BigInt"]>;
+  periodIndex_lte?: Maybe<Scalars["BigInt"]>;
+  periodIndex_not?: Maybe<Scalars["BigInt"]>;
+  periodIndex_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  volumeDrip?: Maybe<Scalars["String"]>;
+  volumeDrip_contains?: Maybe<Scalars["String"]>;
+  volumeDrip_ends_with?: Maybe<Scalars["String"]>;
+  volumeDrip_gt?: Maybe<Scalars["String"]>;
+  volumeDrip_gte?: Maybe<Scalars["String"]>;
+  volumeDrip_in?: Maybe<Array<Scalars["String"]>>;
+  volumeDrip_lt?: Maybe<Scalars["String"]>;
+  volumeDrip_lte?: Maybe<Scalars["String"]>;
+  volumeDrip_not?: Maybe<Scalars["String"]>;
+  volumeDrip_not_contains?: Maybe<Scalars["String"]>;
+  volumeDrip_not_ends_with?: Maybe<Scalars["String"]>;
+  volumeDrip_not_in?: Maybe<Array<Scalars["String"]>>;
+  volumeDrip_not_starts_with?: Maybe<Scalars["String"]>;
+  volumeDrip_starts_with?: Maybe<Scalars["String"]>;
 };
 
 export enum VolumeDripPlayer_OrderBy {
-  Address = 'address',
-  Balance = 'balance',
-  Id = 'id',
-  PeriodIndex = 'periodIndex',
-  VolumeDrip = 'volumeDrip'
+  Address = "address",
+  Balance = "balance",
+  Id = "id",
+  PeriodIndex = "periodIndex",
+  VolumeDrip = "volumeDrip",
 }
 
 export type VolumeDrip_Filter = {
-  comptroller?: Maybe<Scalars['String']>;
-  comptroller_contains?: Maybe<Scalars['String']>;
-  comptroller_ends_with?: Maybe<Scalars['String']>;
-  comptroller_gt?: Maybe<Scalars['String']>;
-  comptroller_gte?: Maybe<Scalars['String']>;
-  comptroller_in?: Maybe<Array<Scalars['String']>>;
-  comptroller_lt?: Maybe<Scalars['String']>;
-  comptroller_lte?: Maybe<Scalars['String']>;
-  comptroller_not?: Maybe<Scalars['String']>;
-  comptroller_not_contains?: Maybe<Scalars['String']>;
-  comptroller_not_ends_with?: Maybe<Scalars['String']>;
-  comptroller_not_in?: Maybe<Array<Scalars['String']>>;
-  comptroller_not_starts_with?: Maybe<Scalars['String']>;
-  comptroller_starts_with?: Maybe<Scalars['String']>;
-  deactivated?: Maybe<Scalars['Boolean']>;
-  deactivated_in?: Maybe<Array<Scalars['Boolean']>>;
-  deactivated_not?: Maybe<Scalars['Boolean']>;
-  deactivated_not_in?: Maybe<Array<Scalars['Boolean']>>;
-  dripAmount?: Maybe<Scalars['BigInt']>;
-  dripAmount_gt?: Maybe<Scalars['BigInt']>;
-  dripAmount_gte?: Maybe<Scalars['BigInt']>;
-  dripAmount_in?: Maybe<Array<Scalars['BigInt']>>;
-  dripAmount_lt?: Maybe<Scalars['BigInt']>;
-  dripAmount_lte?: Maybe<Scalars['BigInt']>;
-  dripAmount_not?: Maybe<Scalars['BigInt']>;
-  dripAmount_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  dripToken?: Maybe<Scalars['Bytes']>;
-  dripToken_contains?: Maybe<Scalars['Bytes']>;
-  dripToken_in?: Maybe<Array<Scalars['Bytes']>>;
-  dripToken_not?: Maybe<Scalars['Bytes']>;
-  dripToken_not_contains?: Maybe<Scalars['Bytes']>;
-  dripToken_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  measureToken?: Maybe<Scalars['Bytes']>;
-  measureToken_contains?: Maybe<Scalars['Bytes']>;
-  measureToken_in?: Maybe<Array<Scalars['Bytes']>>;
-  measureToken_not?: Maybe<Scalars['Bytes']>;
-  measureToken_not_contains?: Maybe<Scalars['Bytes']>;
-  measureToken_not_in?: Maybe<Array<Scalars['Bytes']>>;
-  periodCount?: Maybe<Scalars['BigInt']>;
-  periodCount_gt?: Maybe<Scalars['BigInt']>;
-  periodCount_gte?: Maybe<Scalars['BigInt']>;
-  periodCount_in?: Maybe<Array<Scalars['BigInt']>>;
-  periodCount_lt?: Maybe<Scalars['BigInt']>;
-  periodCount_lte?: Maybe<Scalars['BigInt']>;
-  periodCount_not?: Maybe<Scalars['BigInt']>;
-  periodCount_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  periodSeconds?: Maybe<Scalars['BigInt']>;
-  periodSeconds_gt?: Maybe<Scalars['BigInt']>;
-  periodSeconds_gte?: Maybe<Scalars['BigInt']>;
-  periodSeconds_in?: Maybe<Array<Scalars['BigInt']>>;
-  periodSeconds_lt?: Maybe<Scalars['BigInt']>;
-  periodSeconds_lte?: Maybe<Scalars['BigInt']>;
-  periodSeconds_not?: Maybe<Scalars['BigInt']>;
-  periodSeconds_not_in?: Maybe<Array<Scalars['BigInt']>>;
-  referral?: Maybe<Scalars['Boolean']>;
-  referral_in?: Maybe<Array<Scalars['Boolean']>>;
-  referral_not?: Maybe<Scalars['Boolean']>;
-  referral_not_in?: Maybe<Array<Scalars['Boolean']>>;
-  sourceAddress?: Maybe<Scalars['Bytes']>;
-  sourceAddress_contains?: Maybe<Scalars['Bytes']>;
-  sourceAddress_in?: Maybe<Array<Scalars['Bytes']>>;
-  sourceAddress_not?: Maybe<Scalars['Bytes']>;
-  sourceAddress_not_contains?: Maybe<Scalars['Bytes']>;
-  sourceAddress_not_in?: Maybe<Array<Scalars['Bytes']>>;
+  comptroller?: Maybe<Scalars["String"]>;
+  comptroller_contains?: Maybe<Scalars["String"]>;
+  comptroller_ends_with?: Maybe<Scalars["String"]>;
+  comptroller_gt?: Maybe<Scalars["String"]>;
+  comptroller_gte?: Maybe<Scalars["String"]>;
+  comptroller_in?: Maybe<Array<Scalars["String"]>>;
+  comptroller_lt?: Maybe<Scalars["String"]>;
+  comptroller_lte?: Maybe<Scalars["String"]>;
+  comptroller_not?: Maybe<Scalars["String"]>;
+  comptroller_not_contains?: Maybe<Scalars["String"]>;
+  comptroller_not_ends_with?: Maybe<Scalars["String"]>;
+  comptroller_not_in?: Maybe<Array<Scalars["String"]>>;
+  comptroller_not_starts_with?: Maybe<Scalars["String"]>;
+  comptroller_starts_with?: Maybe<Scalars["String"]>;
+  deactivated?: Maybe<Scalars["Boolean"]>;
+  deactivated_in?: Maybe<Array<Scalars["Boolean"]>>;
+  deactivated_not?: Maybe<Scalars["Boolean"]>;
+  deactivated_not_in?: Maybe<Array<Scalars["Boolean"]>>;
+  dripAmount?: Maybe<Scalars["BigInt"]>;
+  dripAmount_gt?: Maybe<Scalars["BigInt"]>;
+  dripAmount_gte?: Maybe<Scalars["BigInt"]>;
+  dripAmount_in?: Maybe<Array<Scalars["BigInt"]>>;
+  dripAmount_lt?: Maybe<Scalars["BigInt"]>;
+  dripAmount_lte?: Maybe<Scalars["BigInt"]>;
+  dripAmount_not?: Maybe<Scalars["BigInt"]>;
+  dripAmount_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  dripToken?: Maybe<Scalars["Bytes"]>;
+  dripToken_contains?: Maybe<Scalars["Bytes"]>;
+  dripToken_in?: Maybe<Array<Scalars["Bytes"]>>;
+  dripToken_not?: Maybe<Scalars["Bytes"]>;
+  dripToken_not_contains?: Maybe<Scalars["Bytes"]>;
+  dripToken_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  measureToken?: Maybe<Scalars["Bytes"]>;
+  measureToken_contains?: Maybe<Scalars["Bytes"]>;
+  measureToken_in?: Maybe<Array<Scalars["Bytes"]>>;
+  measureToken_not?: Maybe<Scalars["Bytes"]>;
+  measureToken_not_contains?: Maybe<Scalars["Bytes"]>;
+  measureToken_not_in?: Maybe<Array<Scalars["Bytes"]>>;
+  periodCount?: Maybe<Scalars["BigInt"]>;
+  periodCount_gt?: Maybe<Scalars["BigInt"]>;
+  periodCount_gte?: Maybe<Scalars["BigInt"]>;
+  periodCount_in?: Maybe<Array<Scalars["BigInt"]>>;
+  periodCount_lt?: Maybe<Scalars["BigInt"]>;
+  periodCount_lte?: Maybe<Scalars["BigInt"]>;
+  periodCount_not?: Maybe<Scalars["BigInt"]>;
+  periodCount_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  periodSeconds?: Maybe<Scalars["BigInt"]>;
+  periodSeconds_gt?: Maybe<Scalars["BigInt"]>;
+  periodSeconds_gte?: Maybe<Scalars["BigInt"]>;
+  periodSeconds_in?: Maybe<Array<Scalars["BigInt"]>>;
+  periodSeconds_lt?: Maybe<Scalars["BigInt"]>;
+  periodSeconds_lte?: Maybe<Scalars["BigInt"]>;
+  periodSeconds_not?: Maybe<Scalars["BigInt"]>;
+  periodSeconds_not_in?: Maybe<Array<Scalars["BigInt"]>>;
+  referral?: Maybe<Scalars["Boolean"]>;
+  referral_in?: Maybe<Array<Scalars["Boolean"]>>;
+  referral_not?: Maybe<Scalars["Boolean"]>;
+  referral_not_in?: Maybe<Array<Scalars["Boolean"]>>;
+  sourceAddress?: Maybe<Scalars["Bytes"]>;
+  sourceAddress_contains?: Maybe<Scalars["Bytes"]>;
+  sourceAddress_in?: Maybe<Array<Scalars["Bytes"]>>;
+  sourceAddress_not?: Maybe<Scalars["Bytes"]>;
+  sourceAddress_not_contains?: Maybe<Scalars["Bytes"]>;
+  sourceAddress_not_in?: Maybe<Array<Scalars["Bytes"]>>;
 };
 
 export enum VolumeDrip_OrderBy {
-  Comptroller = 'comptroller',
-  Deactivated = 'deactivated',
-  Deposits = 'deposits',
-  DripAmount = 'dripAmount',
-  DripToken = 'dripToken',
-  Id = 'id',
-  MeasureToken = 'measureToken',
-  PeriodCount = 'periodCount',
-  PeriodSeconds = 'periodSeconds',
-  Periods = 'periods',
-  Referral = 'referral',
-  SourceAddress = 'sourceAddress'
+  Comptroller = "comptroller",
+  Deactivated = "deactivated",
+  Deposits = "deposits",
+  DripAmount = "dripAmount",
+  DripToken = "dripToken",
+  Id = "id",
+  MeasureToken = "measureToken",
+  PeriodCount = "periodCount",
+  PeriodSeconds = "periodSeconds",
+  Periods = "periods",
+  Referral = "referral",
+  SourceAddress = "sourceAddress",
 }
 
 export type YieldSourcePrizePool = {
-  __typename?: 'YieldSourcePrizePool';
-  id: Scalars['ID'];
-  yieldSource?: Maybe<Scalars['Bytes']>;
+  __typename?: "YieldSourcePrizePool";
+  id: Scalars["ID"];
+  yieldSource?: Maybe<Scalars["Bytes"]>;
 };
 
 export type YieldSourcePrizePool_Filter = {
-  id?: Maybe<Scalars['ID']>;
-  id_gt?: Maybe<Scalars['ID']>;
-  id_gte?: Maybe<Scalars['ID']>;
-  id_in?: Maybe<Array<Scalars['ID']>>;
-  id_lt?: Maybe<Scalars['ID']>;
-  id_lte?: Maybe<Scalars['ID']>;
-  id_not?: Maybe<Scalars['ID']>;
-  id_not_in?: Maybe<Array<Scalars['ID']>>;
-  yieldSource?: Maybe<Scalars['Bytes']>;
-  yieldSource_contains?: Maybe<Scalars['Bytes']>;
-  yieldSource_in?: Maybe<Array<Scalars['Bytes']>>;
-  yieldSource_not?: Maybe<Scalars['Bytes']>;
-  yieldSource_not_contains?: Maybe<Scalars['Bytes']>;
-  yieldSource_not_in?: Maybe<Array<Scalars['Bytes']>>;
+  id?: Maybe<Scalars["ID"]>;
+  id_gt?: Maybe<Scalars["ID"]>;
+  id_gte?: Maybe<Scalars["ID"]>;
+  id_in?: Maybe<Array<Scalars["ID"]>>;
+  id_lt?: Maybe<Scalars["ID"]>;
+  id_lte?: Maybe<Scalars["ID"]>;
+  id_not?: Maybe<Scalars["ID"]>;
+  id_not_in?: Maybe<Array<Scalars["ID"]>>;
+  yieldSource?: Maybe<Scalars["Bytes"]>;
+  yieldSource_contains?: Maybe<Scalars["Bytes"]>;
+  yieldSource_in?: Maybe<Array<Scalars["Bytes"]>>;
+  yieldSource_not?: Maybe<Scalars["Bytes"]>;
+  yieldSource_not_contains?: Maybe<Scalars["Bytes"]>;
+  yieldSource_not_in?: Maybe<Array<Scalars["Bytes"]>>;
 };
 
 export enum YieldSourcePrizePool_OrderBy {
-  Id = 'id',
-  YieldSource = 'yieldSource'
+  Id = "id",
+  YieldSource = "yieldSource",
 }
 
 export type _Block_ = {
-  __typename?: '_Block_';
+  __typename?: "_Block_";
   /** The hash of the block */
-  hash?: Maybe<Scalars['Bytes']>;
+  hash?: Maybe<Scalars["Bytes"]>;
   /** The block number */
-  number: Scalars['Int'];
+  number: Scalars["Int"];
 };
 
 /** The type for the top-level _meta field */
 export type _Meta_ = {
-  __typename?: '_Meta_';
+  __typename?: "_Meta_";
   /**
    * Information about a specific subgraph block. The hash of the block
    * will be null if the _meta field has a block constraint that asks for
@@ -3753,14 +3609,14 @@ export type _Meta_ = {
    */
   block: _Block_;
   /** The deployment ID */
-  deployment: Scalars['String'];
+  deployment: Scalars["String"];
   /** If `true`, the subgraph encountered indexing errors at some past block */
-  hasIndexingErrors: Scalars['Boolean'];
+  hasIndexingErrors: Scalars["Boolean"];
 };
 
 export enum _SubgraphErrorPolicy_ {
   /** Data will be returned even if the subgraph has indexing errors */
-  Allow = 'allow',
+  Allow = "allow",
   /** If the subgraph has indexing errors, data will be omitted. The default. */
-  Deny = 'deny'
+  Deny = "deny",
 }

--- a/src/views/33Together/33together.tsx
+++ b/src/views/33Together/33together.tsx
@@ -1,22 +1,23 @@
-import { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import "./33together.scss";
+
 import { t } from "@lingui/macro";
-import { Paper, Tab, Tabs, Box } from "@material-ui/core";
-import InfoTooltipMulti from "../../components/InfoTooltip/InfoTooltipMulti";
+import { Box, Paper, Tab, Tabs } from "@material-ui/core";
+import { useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
+import { addresses, POOL_GRAPH_URLS } from "src/constants";
+import { calculateOdds, trimOdds } from "src/helpers/33Together";
+import { useAppSelector, useWeb3Context } from "src/hooks";
+import { apolloExt } from "src/lib/apolloClient";
+import { getPoolValues, getRNGStatus } from "src/slices/PoolThunk";
 import { Prize, PrizePool } from "src/typechain/pooltogether";
-import TabPanel from "../../components/TabPanel";
+
 import CardHeader from "../../components/CardHeader/CardHeader";
-import { PoolDeposit } from "./PoolDeposit";
-import { PoolWithdraw } from "./PoolWithdraw";
+import InfoTooltipMulti from "../../components/InfoTooltip/InfoTooltipMulti";
+import TabPanel from "../../components/TabPanel";
+import { poolDataQuery, yourAwardsQuery } from "./poolData";
 import { PoolInfo } from "./PoolInfo";
 import { PoolPrize } from "./PoolPrize";
-import "./33together.scss";
-import { addresses, POOL_GRAPH_URLS } from "src/constants";
-import { useWeb3Context, useAppSelector } from "src/hooks";
-import { apolloExt } from "src/lib/apolloClient";
-import { poolDataQuery, yourAwardsQuery } from "./poolData";
-import { calculateOdds, trimOdds } from "src/helpers/33Together";
-import { getPoolValues, getRNGStatus } from "src/slices/PoolThunk";
+import { PoolWithdraw } from "./PoolWithdraw";
 
 function a11yProps(index: number) {
   return {
@@ -35,7 +36,7 @@ const PoolTogether = () => {
   const [view, setView] = useState(0);
   const [zoomed, setZoomed] = useState(false);
 
-  const changeView = (_event: React.ChangeEvent<{}>, newView: number) => {
+  const changeView = (_event: React.ChangeEvent<any>, newView: number) => {
     setView(newView);
   };
 

--- a/src/views/33Together/ConfirmationModal.jsx
+++ b/src/views/33Together/ConfirmationModal.jsx
@@ -1,8 +1,9 @@
-import { Modal, Backdrop, Paper, SvgIcon, Box, Typography, Button, Fade, useTheme } from "@material-ui/core";
-import { ReactComponent as sOhmTokenImg } from "../../assets/tokens/token_sOHM.svg";
-import { ReactComponent as t33TokenImg } from "../../assets/tokens/token_33T.svg";
+import { Backdrop, Box, Button, Fade, Modal, Paper, SvgIcon, Typography, useTheme } from "@material-ui/core";
 import ArrowForwardOutlinedIcon from "@material-ui/icons/ArrowForwardOutlined";
+
 import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
+import { ReactComponent as t33TokenImg } from "../../assets/tokens/token_33T.svg";
+import { ReactComponent as sOhmTokenImg } from "../../assets/tokens/token_sOHM.svg";
 
 export const ConfirmationModal = props => {
   const theme = useTheme();

--- a/src/views/33Together/PoolDeposit.jsx
+++ b/src/views/33Together/PoolDeposit.jsx
@@ -1,6 +1,4 @@
-import { useCallback, useState, useEffect } from "react";
-import PropTypes from "prop-types";
-import { useDispatch, useSelector } from "react-redux";
+import { t, Trans } from "@lingui/macro";
 import {
   Box,
   Button,
@@ -11,16 +9,19 @@ import {
   Typography,
   useMediaQuery,
 } from "@material-ui/core";
-import { t, Trans } from "@lingui/macro";
-import ConnectButton from "../../components/ConnectButton.jsx";
-import { useWeb3Context } from "../../hooks";
-import { getTokenImage } from "src/helpers/index";
+import { Skeleton } from "@material-ui/lab";
+import PropTypes from "prop-types";
+import { useCallback, useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { trim } from "src/helpers";
+import { getTokenImage } from "src/helpers/index";
+
+import ConnectButton from "../../components/ConnectButton.jsx";
 import { calculateOdds } from "../../helpers/33Together";
+import { useWeb3Context } from "../../hooks";
+import { error } from "../../slices/MessagesSlice";
 import { isPendingTxn, txnButtonText } from "../../slices/PendingTxnsSlice";
 import { changeApproval, poolDeposit } from "../../slices/PoolThunk";
-import { Skeleton } from "@material-ui/lab";
-import { error } from "../../slices/MessagesSlice";
 import { ConfirmationModal } from "./ConfirmationModal.jsx";
 
 const sohmImg = getTokenImage("sohm");

--- a/src/views/33Together/PoolInfo.jsx
+++ b/src/views/33Together/PoolInfo.jsx
@@ -1,13 +1,13 @@
-import { useState, useEffect } from "react";
+import { Trans } from "@lingui/macro";
 import { Box, Button, Divider, Paper, SvgIcon, Typography, Zoom } from "@material-ui/core";
-import { useSelector } from "react-redux";
-import PropTypes from "prop-types";
 import { Skeleton } from "@material-ui/lab";
-import { t, Trans } from "@lingui/macro";
+import PropTypes from "prop-types";
+import { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
 
 import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
-import { useWeb3Context } from "../../hooks";
 import { poolTogetherUILinks } from "../../helpers/33Together";
+import { useWeb3Context } from "../../hooks";
 
 export const PoolInfo = props => {
   const [poolLoadedCount, setPoolLoadedCount] = useState(0);

--- a/src/views/33Together/PoolPrize.jsx
+++ b/src/views/33Together/PoolPrize.jsx
@@ -1,13 +1,12 @@
-import { useState, useEffect, useRef } from "react";
-import { useSelector, useDispatch } from "react-redux";
-import { t, Trans } from "@lingui/macro";
-import { useWeb3Context } from "../../hooks";
-import { awardProcess, getRNGStatus, getPoolValues } from "../../slices/PoolThunk";
-
-import { Paper, Box, Typography, Button } from "@material-ui/core";
+import { Trans } from "@lingui/macro";
+import { Box, Paper, Typography } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
+import { useEffect, useRef, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { subtractDates, trim } from "src/helpers";
 
-import { trim, subtractDates } from "src/helpers";
+import { useWeb3Context } from "../../hooks";
+import { awardProcess, getPoolValues, getRNGStatus } from "../../slices/PoolThunk";
 
 export const PoolPrize = () => {
   const { provider } = useWeb3Context();

--- a/src/views/33Together/PoolWithdraw.jsx
+++ b/src/views/33Together/PoolWithdraw.jsx
@@ -1,6 +1,4 @@
-import { useEffect, useState } from "react";
-import PropTypes from "prop-types";
-import { useDispatch, useSelector } from "react-redux";
+import { t, Trans } from "@lingui/macro";
 import {
   Box,
   Button,
@@ -14,16 +12,19 @@ import {
   useMediaQuery,
 } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
-import { t, Trans } from "@lingui/macro";
-import ConnectButton from "../../components/ConnectButton.jsx";
-import { useWeb3Context } from "../../hooks";
-import { getTokenImage } from "src/helpers/index";
+import PropTypes from "prop-types";
+import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { ReactComponent as ArrowUp } from "src/assets/icons/arrow-up.svg";
 import { trim } from "src/helpers";
+import { getTokenImage } from "src/helpers/index";
+
+import ConnectButton from "../../components/ConnectButton.jsx";
+import { calculateOdds } from "../../helpers/33Together";
+import { useWeb3Context } from "../../hooks";
+import { error } from "../../slices/MessagesSlice";
 import { isPendingTxn, txnButtonText } from "../../slices/PendingTxnsSlice";
 import { getEarlyExitFee, poolWithdraw } from "../../slices/PoolThunk";
-import { calculateOdds } from "../../helpers/33Together";
-import { ReactComponent as ArrowUp } from "src/assets/icons/arrow-up.svg";
-import { error } from "../../slices/MessagesSlice";
 
 const sohmImg = getTokenImage("sohm");
 

--- a/src/views/33Together/poolData.ts
+++ b/src/views/33Together/poolData.ts
@@ -65,7 +65,7 @@ query {
  * @returns string
  */
 export const yourAwardsQuery = (poolAddress: string, userAddress: string, tokenAddress: string) => {
-  let query = `
+  const query = `
   query {
       prizePool(id: "${poolAddress.toLowerCase()}") {
         prizes (where:{

--- a/src/views/404/NotFound.tsx
+++ b/src/views/404/NotFound.tsx
@@ -1,12 +1,14 @@
-import OlympusLogo from "../../assets/Olympus Logo.svg";
 import "./notfound.scss";
+
 import { Trans } from "@lingui/macro";
+
+import OlympusLogo from "../../assets/Olympus Logo.svg";
 
 export default function NotFound() {
   return (
     <div id="not-found">
       <div className="not-found-header">
-        <a href="https://olympusdao.finance" target="_blank">
+        <a href="https://olympusdao.finance" target="_blank" rel="noreferrer">
           <img className="branding-header-icon" src={OlympusLogo} alt="OlympusDAO" />
         </a>
 

--- a/src/views/Bond/AdvancedSettings.jsx
+++ b/src/views/Bond/AdvancedSettings.jsx
@@ -1,18 +1,20 @@
+import "./bondSettings.scss";
+
+import { Trans } from "@lingui/macro";
 import {
-  Typography,
   Box,
+  FormControl,
+  IconButton,
+  InputAdornment,
+  InputLabel,
   Modal,
+  OutlinedInput,
   Paper,
   SvgIcon,
-  IconButton,
-  FormControl,
-  OutlinedInput,
-  InputLabel,
-  InputAdornment,
+  Typography,
 } from "@material-ui/core";
+
 import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
-import { t, Trans } from "@lingui/macro";
-import "./bondSettings.scss";
 
 function AdvancedSettings({
   open,

--- a/src/views/Bond/Bond.tsx
+++ b/src/views/Bond/Bond.tsx
@@ -1,18 +1,20 @@
-import { ChangeEvent, Fragment, ReactNode, ReactElement, useEffect, useState } from "react";
-import { useHistory } from "react-router";
-import { usePathForNetwork } from "src/hooks/usePathForNetwork";
-import { t, Trans } from "@lingui/macro";
-import { formatCurrency, trim } from "../../helpers";
-import { Backdrop, Box, Fade, Grid, Paper, Tab, Tabs, Typography } from "@material-ui/core";
-import TabPanel from "../../components/TabPanel";
-import BondHeader from "./BondHeader";
-import BondRedeem from "./BondRedeem";
-import BondPurchase from "./BondPurchase";
 import "./bond.scss";
-import { useWeb3Context } from "src/hooks/web3Context";
+
+import { t, Trans } from "@lingui/macro";
+import { Backdrop, Box, Fade, Grid, Paper, Tab, Tabs, Typography } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
+import { ChangeEvent, Fragment, ReactElement, ReactNode, useEffect, useState } from "react";
+import { useHistory } from "react-router";
 import { useAppSelector } from "src/hooks";
 import { IAllBondData } from "src/hooks/Bonds";
+import { usePathForNetwork } from "src/hooks/usePathForNetwork";
+import { useWeb3Context } from "src/hooks/web3Context";
+
+import TabPanel from "../../components/TabPanel";
+import { formatCurrency, trim } from "../../helpers";
+import BondHeader from "./BondHeader";
+import BondPurchase from "./BondPurchase";
+import BondRedeem from "./BondRedeem";
 
 type InputEvent = ChangeEvent<HTMLInputElement>;
 
@@ -35,7 +37,7 @@ const Bond = ({ bond }: { bond: IAllBondData }) => {
   const [view, setView] = useState<number>(0);
   const [quantity, setQuantity] = useState<number | undefined>();
 
-  const isBondLoading = useAppSelector<boolean>(state => state.bonding.loading ?? true);
+  const isBondLoading = useAppSelector<boolean>(state => state.bonding?.loading ?? true);
 
   const onRecipientAddressChange = (e: InputEvent): void => {
     return setRecipientAddress(e.target.value);
@@ -56,7 +58,7 @@ const Bond = ({ bond }: { bond: IAllBondData }) => {
     if (address) setRecipientAddress(address);
   }, [provider, quantity, address]);
 
-  const changeView = (event: ChangeEvent<{}>, value: string | number): void => {
+  const changeView = (event: ChangeEvent<any>, value: string | number): void => {
     setView(Number(value));
   };
 

--- a/src/views/Bond/BondHeader.jsx
+++ b/src/views/Bond/BondHeader.jsx
@@ -1,11 +1,12 @@
+import { IconButton, Link, SvgIcon, Typography } from "@material-ui/core";
 import { useState } from "react";
 import { NavLink, useHistory } from "react-router-dom";
-import BondLogo from "../../components/BondLogo";
-import AdvancedSettings from "./AdvancedSettings";
-import { Typography, IconButton, SvgIcon, Link } from "@material-ui/core";
+
 import { ReactComponent as SettingsIcon } from "../../assets/icons/settings.svg";
 import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
+import BondLogo from "../../components/BondLogo";
 import useEscape from "../../hooks/useEscape";
+import AdvancedSettings from "./AdvancedSettings";
 
 function BondHeader({ bond, slippage, recipientAddress, onRecipientAddressChange, onSlippageChange }) {
   const [open, setOpen] = useState(false);
@@ -21,7 +22,7 @@ function BondHeader({ bond, slippage, recipientAddress, onRecipientAddressChange
   let history = useHistory();
 
   useEscape(() => {
-    if (open) handleClose;
+    if (open) handleClose();
     else history.push(`/bonds`);
   });
 

--- a/src/views/Bond/BondPurchase.jsx
+++ b/src/views/Bond/BondPurchase.jsx
@@ -1,5 +1,3 @@
-import { useCallback, useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
 import { t, Trans } from "@lingui/macro";
 import {
   Box,
@@ -11,15 +9,18 @@ import {
   Slide,
   Typography,
 } from "@material-ui/core";
-import { prettifySeconds, secondsUntilBlock, shorten, trim } from "../../helpers";
-import { bondAsset, calcBondDetails, changeApproval } from "../../slices/BondSlice";
+import { Skeleton } from "@material-ui/lab";
+import { useCallback, useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { useWeb3Context } from "src/hooks/web3Context";
 import { isPendingTxn, txnButtonText } from "src/slices/PendingTxnsSlice";
-import { Skeleton } from "@material-ui/lab";
+
+import ConnectButton from "../../components/ConnectButton";
+import { prettifySeconds, secondsUntilBlock, shorten, trim } from "../../helpers";
 import useDebounce from "../../hooks/Debounce";
+import { bondAsset, calcBondDetails, changeApproval } from "../../slices/BondSlice";
 import { error } from "../../slices/MessagesSlice";
 import { DisplayBondDiscount } from "./Bond";
-import ConnectButton from "../../components/ConnectButton";
 
 function BondPurchase({ bond, slippage, recipientAddress }) {
   const SECONDS_TO_REFRESH = 60;

--- a/src/views/Bond/BondRedeem.jsx
+++ b/src/views/Bond/BondRedeem.jsx
@@ -1,14 +1,14 @@
-import { useEffect } from "react";
-import { useSelector, useDispatch } from "react-redux";
-import { Button, Typography, Box, Slide } from "@material-ui/core";
 import { t, Trans } from "@lingui/macro";
-import { redeemBond } from "../../slices/BondSlice";
-import { useWeb3Context } from "src/hooks/web3Context";
-import { prettifySeconds, prettyVestingPeriod, secondsUntilBlock, trim } from "../../helpers";
-import { isPendingTxn, txnButtonText } from "src/slices/PendingTxnsSlice";
+import { Box, Button, Slide, Typography } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
-import { DisplayBondDiscount } from "./Bond";
+import { useDispatch, useSelector } from "react-redux";
+import { useWeb3Context } from "src/hooks/web3Context";
+import { isPendingTxn, txnButtonText } from "src/slices/PendingTxnsSlice";
+
 import ConnectButton from "../../components/ConnectButton";
+import { prettifySeconds, prettyVestingPeriod, secondsUntilBlock, trim } from "../../helpers";
+import { redeemBond } from "../../slices/BondSlice";
+import { DisplayBondDiscount } from "./Bond";
 
 function BondRedeem({ bond }) {
   // const { bond: bondName } = bond;

--- a/src/views/ChangeNetwork/ChangeNetwork.jsx
+++ b/src/views/ChangeNetwork/ChangeNetwork.jsx
@@ -1,14 +1,16 @@
-import { Backdrop, Fade, Grid, Link, Paper, SvgIcon, Typography } from "@material-ui/core";
-import { useHistory } from "react-router-dom";
-import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
 import "./changenetwork.scss";
-import useEscape from "../../hooks/useEscape";
+
+import { Backdrop, Fade, Grid, Link, Paper, SvgIcon, Typography } from "@material-ui/core";
 import Button from "@material-ui/core/Button";
-import { useWeb3Context } from "../../hooks/web3Context";
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { switchNetwork } from "../../slices/NetworkSlice";
+import { useHistory } from "react-router-dom";
+
+import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
 import { NETWORKS, USER_SELECTABLE_NETWORKS } from "../../constants";
+import useEscape from "../../hooks/useEscape";
+import { useWeb3Context } from "../../hooks/web3Context";
+import { switchNetwork } from "../../slices/NetworkSlice";
 
 function ChangeNetwork() {
   const dispatch = useDispatch();

--- a/src/views/ChooseBond/BondRow.jsx
+++ b/src/views/ChooseBond/BondRow.jsx
@@ -1,13 +1,15 @@
-import BondLogo from "../../components/BondLogo";
-import { DisplayBondPrice, DisplayBondDiscount } from "../Bond/Bond";
-import { Box, Button, Link, Paper, Typography, TableRow, TableCell, SvgIcon, Slide } from "@material-ui/core";
-import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
-import { NavLink } from "react-router-dom";
 import "./choosebond.scss";
+
 import { t, Trans } from "@lingui/macro";
+import { Button, Link, Paper, Slide, SvgIcon, TableCell, TableRow, Typography } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
-import useBonds from "src/hooks/Bonds";
 import { useSelector } from "react-redux";
+import { NavLink } from "react-router-dom";
+import useBonds from "src/hooks/Bonds";
+
+import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
+import BondLogo from "../../components/BondLogo";
+import { DisplayBondDiscount, DisplayBondPrice } from "../Bond/Bond";
 
 export function BondDataCard({ bond }) {
   const networkId = useSelector(state => state.network.networkId);

--- a/src/views/ChooseBond/ChooseBond.tsx
+++ b/src/views/ChooseBond/ChooseBond.tsx
@@ -1,4 +1,6 @@
-import { useSelector } from "react-redux";
+import "./choosebond.scss";
+
+import { t, Trans } from "@lingui/macro";
 import {
   Box,
   Grid,
@@ -12,21 +14,19 @@ import {
   Typography,
   Zoom,
 } from "@material-ui/core";
-import { t, Trans } from "@lingui/macro";
-import { BondDataCard, BondTableData } from "./BondRow";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
-import { formatCurrency } from "../../helpers";
-import useBonds from "../../hooks/Bonds";
-import { useHistory } from "react-router";
-import { usePathForNetwork } from "src/hooks/usePathForNetwork";
-import "./choosebond.scss";
-import { Skeleton } from "@material-ui/lab";
-import ClaimBonds from "./ClaimBonds";
 import isEmpty from "lodash/isEmpty";
+import { useHistory } from "react-router";
+import { Metric, MetricCollection } from "src/components/Metric";
 import { allBondsMap } from "src/helpers/AllBonds";
 import { useAppSelector } from "src/hooks";
+import { usePathForNetwork } from "src/hooks/usePathForNetwork";
 import { IUserBondDetails } from "src/slices/AccountSlice";
-import { Metric, MetricCollection } from "src/components/Metric";
+
+import { formatCurrency } from "../../helpers";
+import useBonds from "../../hooks/Bonds";
+import { BondDataCard, BondTableData } from "./BondRow";
+import ClaimBonds from "./ClaimBonds";
 
 function ChooseBond() {
   const networkId = useAppSelector(state => state.network.networkId);

--- a/src/views/ChooseBond/ClaimBonds.jsx
+++ b/src/views/ChooseBond/ClaimBonds.jsx
@@ -1,11 +1,6 @@
-import { useEffect, useState } from "react";
+import "./choosebond.scss";
+
 import { t, Trans } from "@lingui/macro";
-import { ClaimBondTableData, ClaimBondCardData } from "./ClaimRow";
-import { isPendingTxn, txnButtonTextGeneralPending } from "src/slices/PendingTxnsSlice";
-import { redeemAllBonds } from "src/slices/BondSlice";
-import CardHeader from "../../components/CardHeader/CardHeader";
-import { useWeb3Context } from "src/hooks/web3Context";
-import useBonds from "src/hooks/Bonds";
 import {
   Box,
   Button,
@@ -19,8 +14,15 @@ import {
   Zoom,
 } from "@material-ui/core";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
-import "./choosebond.scss";
+import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import useBonds from "src/hooks/Bonds";
+import { useWeb3Context } from "src/hooks/web3Context";
+import { redeemAllBonds } from "src/slices/BondSlice";
+import { isPendingTxn, txnButtonTextGeneralPending } from "src/slices/PendingTxnsSlice";
+
+import CardHeader from "../../components/CardHeader/CardHeader";
+import { ClaimBondCardData, ClaimBondTableData } from "./ClaimRow";
 
 function ClaimBonds({ activeBonds }) {
   const dispatch = useDispatch();

--- a/src/views/ChooseBond/ClaimRow.jsx
+++ b/src/views/ChooseBond/ClaimRow.jsx
@@ -1,14 +1,15 @@
-import { useEffect } from "react";
-import { useSelector, useDispatch } from "react-redux";
-import { t, Trans } from "@lingui/macro";
-import { shorten, trim, prettyVestingPeriod } from "../../helpers";
-import { redeemBond } from "../../slices/BondSlice";
-import BondLogo from "../../components/BondLogo";
-import { Box, Button, TableCell, TableRow, Typography } from "@material-ui/core";
 import "./choosebond.scss";
+
+import { t } from "@lingui/macro";
+import { Box, Button, TableCell, TableRow, Typography } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
+import { useDispatch, useSelector } from "react-redux";
 import { useBonds, useWeb3Context } from "src/hooks";
 import { isPendingTxn, txnButtonTextGeneralPending } from "src/slices/PendingTxnsSlice";
+
+import BondLogo from "../../components/BondLogo";
+import { prettyVestingPeriod, trim } from "../../helpers";
+import { redeemBond } from "../../slices/BondSlice";
 
 export function ClaimBondTableData({ userBond }) {
   const dispatch = useDispatch();

--- a/src/views/Give/CausesDashboard.tsx
+++ b/src/views/Give/CausesDashboard.tsx
@@ -1,26 +1,28 @@
-import { useMemo, useState } from "react";
 import "./give.scss";
-import { useLocation } from "react-router-dom";
-import { Button, Paper, Typography, Zoom, Grid, Container, Box } from "@material-ui/core";
-import { useWeb3Context } from "src/hooks/web3Context";
-import useMediaQuery from "@material-ui/core/useMediaQuery";
-import ProjectCard, { ProjectDetailsMode } from "src/components/GiveProject/ProjectCard";
-import data from "./projects.json";
-import { RecipientModal } from "src/views/Give/RecipientModal";
-import { SubmitCallback, CancelCallback } from "src/views/Give/Interfaces";
-import { BigNumber } from "bignumber.js";
-import { error } from "../../slices/MessagesSlice";
-import { useAppDispatch, useAppSelector } from "src/hooks";
-import { changeGive, changeMockGive, ACTION_GIVE, isSupportedChain } from "src/slices/GiveThunk";
-import { GiveInfo } from "./GiveInfo";
-import { useUIDSeed } from "react-uid";
-import { useSelector } from "react-redux";
+
 import { t, Trans } from "@lingui/macro";
+import { Box, Button, Container, Typography, Zoom } from "@material-ui/core";
+import useMediaQuery from "@material-ui/core/useMediaQuery";
+import { BigNumber } from "bignumber.js";
+import { useMemo, useState } from "react";
+import { useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
+import { useUIDSeed } from "react-uid";
+import { GiveHeader } from "src/components/GiveProject/GiveHeader";
+import ProjectCard, { ProjectDetailsMode } from "src/components/GiveProject/ProjectCard";
+import { EnvHelper } from "src/helpers/Environment";
+import { useAppDispatch, useAppSelector } from "src/hooks";
+import { useWeb3Context } from "src/hooks/web3Context";
 import { IAccountSlice } from "src/slices/AccountSlice";
 import { IAppData } from "src/slices/AppSlice";
+import { ACTION_GIVE, changeGive, changeMockGive, isSupportedChain } from "src/slices/GiveThunk";
 import { IPendingTxn } from "src/slices/PendingTxnsSlice";
-import { EnvHelper } from "src/helpers/Environment";
-import { GiveHeader } from "src/components/GiveProject/GiveHeader";
+import { CancelCallback, SubmitCallback } from "src/views/Give/Interfaces";
+import { RecipientModal } from "src/views/Give/RecipientModal";
+
+import { error } from "../../slices/MessagesSlice";
+import { GiveInfo } from "./GiveInfo";
+import data from "./projects.json";
 
 type State = {
   account: IAccountSlice;

--- a/src/views/Give/DepositYield.tsx
+++ b/src/views/Give/DepositYield.tsx
@@ -1,17 +1,18 @@
-import { useSelector } from "react-redux";
-import { useAppSelector } from "src/hooks";
-import { useLocation } from "react-router-dom";
-import { Paper, Typography, Zoom, Container, Box } from "@material-ui/core";
-import { BigNumber } from "bignumber.js";
-import useMediaQuery from "@material-ui/core/useMediaQuery";
-import InfoTooltip from "src/components/InfoTooltip/InfoTooltip";
-import YieldRecipients from "./YieldRecipients";
 import { t, Trans } from "@lingui/macro";
-import { IAccountSlice } from "src/slices/AccountSlice";
-import { IPendingTxn } from "src/slices/PendingTxnsSlice";
-import { IAppData } from "src/slices/AppSlice";
-import { EnvHelper } from "src/helpers/Environment";
+import { Box, Container, Paper, Typography, Zoom } from "@material-ui/core";
+import useMediaQuery from "@material-ui/core/useMediaQuery";
+import { BigNumber } from "bignumber.js";
+import { useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
 import { GiveHeader } from "src/components/GiveProject/GiveHeader";
+import InfoTooltip from "src/components/InfoTooltip/InfoTooltip";
+import { EnvHelper } from "src/helpers/Environment";
+import { useAppSelector } from "src/hooks";
+import { IAccountSlice } from "src/slices/AccountSlice";
+import { IAppData } from "src/slices/AppSlice";
+import { IPendingTxn } from "src/slices/PendingTxnsSlice";
+
+import YieldRecipients from "./YieldRecipients";
 
 type State = {
   account: IAccountSlice;

--- a/src/views/Give/Give.tsx
+++ b/src/views/Give/Give.tsx
@@ -1,16 +1,17 @@
-import { useState } from "react";
 import "./give.scss";
+
+import { Trans } from "@lingui/macro";
+import { Button, Paper, Typography, Zoom } from "@material-ui/core";
+import useMediaQuery from "@material-ui/core/useMediaQuery";
+import { useWeb3Context } from "src/hooks/web3Context";
+
 import DepositYield from "./DepositYield";
 import RedeemYield from "./RedeemYield";
-import { Button, Paper, Typography, Zoom } from "@material-ui/core";
-import { useWeb3Context } from "src/hooks/web3Context";
-import useMediaQuery from "@material-ui/core/useMediaQuery";
-import { t, Trans } from "@lingui/macro";
 
 function Give() {
   const { address, connect } = useWeb3Context();
   const isSmallScreen = useMediaQuery("(max-width: 705px)");
-  let connectButton = [];
+  const connectButton = [];
   connectButton.push(
     <Button variant="contained" color="primary" className="connect-button" onClick={connect} key={1}>
       <Trans>Connect Wallet</Trans>

--- a/src/views/Give/GiveInfo.jsx
+++ b/src/views/Give/GiveInfo.jsx
@@ -1,7 +1,8 @@
-import { Paper, Grid, Box, Button, Typography, SvgIcon } from "@material-ui/core";
-import { DepositSohm, LockInVault, ReceivesYield, ArrowGraphic } from "../../components/EducationCard";
-import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
 import { t, Trans } from "@lingui/macro";
+import { Box, Button, Grid, Paper, SvgIcon, Typography } from "@material-ui/core";
+
+import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
+import { DepositSohm, LockInVault, ReceivesYield } from "../../components/EducationCard";
 
 export function GiveInfo() {
   return (

--- a/src/views/Give/RecipientModal.tsx
+++ b/src/views/Give/RecipientModal.tsx
@@ -1,44 +1,44 @@
-import { Box, Modal, Paper, Typography, SvgIcon, Link, Button, Divider } from "@material-ui/core";
+import { isAddress } from "@ethersproject/address";
+import { t, Trans } from "@lingui/macro";
+import { Box, Button, Divider, Link, Modal, Paper, SvgIcon, Typography } from "@material-ui/core";
 import { FormControl, FormHelperText, InputAdornment } from "@material-ui/core";
 import { InputLabel } from "@material-ui/core";
 import { OutlinedInput } from "@material-ui/core";
+import useMediaQuery from "@material-ui/core/useMediaQuery";
+import { Skeleton } from "@material-ui/lab";
+import { BigNumber } from "bignumber.js";
 import { useCallback, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
-import { isAddress } from "@ethersproject/address";
+import { useLocation } from "react-router-dom";
+import { Project } from "src/components/GiveProject/project.type";
+import InfoTooltip from "src/components/InfoTooltip/InfoTooltip";
+import { shorten } from "src/helpers";
+import { EnvHelper } from "src/helpers/Environment";
+import { useAppSelector } from "src/hooks";
 import { useWeb3Context } from "src/hooks/web3Context";
-import { Skeleton } from "@material-ui/lab";
 import {
   changeApproval,
   changeMockApproval,
   hasPendingGiveTxn,
-  PENDING_TXN_GIVE,
   PENDING_TXN_EDIT_GIVE,
+  PENDING_TXN_GIVE,
   PENDING_TXN_GIVE_APPROVAL,
 } from "src/slices/GiveThunk";
-import { IPendingTxn, txnButtonText, isPendingTxn } from "../../slices/PendingTxnsSlice";
-import { getTokenImage } from "../../helpers";
-import { BigNumber } from "bignumber.js";
+
+import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
 import {
-  WalletGraphic,
-  VaultGraphic,
-  YieldGraphic,
+  ArrowGraphic,
   CurrPositionGraphic,
   NewPositionGraphic,
-  ArrowGraphic,
+  VaultGraphic,
+  WalletGraphic,
+  YieldGraphic,
 } from "../../components/EducationCard";
+import { getTokenImage } from "../../helpers";
 import { IAccountSlice } from "../../slices/AccountSlice";
-import { Project } from "src/components/GiveProject/project.type";
-const sOhmImg = getTokenImage("sohm");
-import { shorten } from "src/helpers";
-import InfoTooltip from "src/components/InfoTooltip/InfoTooltip";
-import { useAppSelector } from "src/hooks";
-import { t, Trans } from "@lingui/macro";
-import { useLocation } from "react-router-dom";
-import { EnvHelper } from "src/helpers/Environment";
+import { IPendingTxn, isPendingTxn, txnButtonText } from "../../slices/PendingTxnsSlice";
 import { CancelCallback, SubmitCallback } from "./Interfaces";
-import useMediaQuery from "@material-ui/core/useMediaQuery";
-import ConnectButton from "../../components/ConnectButton";
+const sOhmImg = getTokenImage("sohm");
 
 type RecipientModalProps = {
   isModalOpen: boolean;

--- a/src/views/Give/RedeemYield.tsx
+++ b/src/views/Give/RedeemYield.tsx
@@ -1,34 +1,35 @@
+import { t, Trans } from "@lingui/macro";
+import {
+  Box,
+  Button,
+  Container,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+  Zoom,
+} from "@material-ui/core";
+import useMediaQuery from "@material-ui/core/useMediaQuery";
+import { Skeleton } from "@material-ui/lab";
+import { BigNumber } from "bignumber.js";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import {
-  Paper,
-  Typography,
-  Button,
-  Zoom,
-  TableCell,
-  TableBody,
-  Table,
-  TableRow,
-  TableContainer,
-  Container,
-  Box,
-} from "@material-ui/core";
 import { useLocation } from "react-router-dom";
-import useMediaQuery from "@material-ui/core/useMediaQuery";
-import { useWeb3Context } from "src/hooks/web3Context";
-import { redeemBalance, redeemMockBalance } from "../../slices/RedeemThunk";
-import { Skeleton } from "@material-ui/lab";
-import { IAccountSlice, loadAccountDetails } from "src/slices/AccountSlice";
-import { IPendingTxn, isPendingTxn, txnButtonText } from "src/slices/PendingTxnsSlice";
-import { IAppData } from "src/slices/AppSlice";
-import { BigNumber } from "bignumber.js";
-import { t, Trans } from "@lingui/macro";
-import InfoTooltip from "src/components/InfoTooltip/InfoTooltip";
-import { VaultGraphic, ArrowGraphic, RedeemGraphic } from "../../components/EducationCard";
-import { RedeemCancelCallback, RedeemYieldModal } from "./RedeemYieldModal";
-import { useAppSelector } from "src/hooks";
-import { EnvHelper } from "src/helpers/Environment";
 import { GiveHeader } from "src/components/GiveProject/GiveHeader";
+import InfoTooltip from "src/components/InfoTooltip/InfoTooltip";
+import { EnvHelper } from "src/helpers/Environment";
+import { useAppSelector } from "src/hooks";
+import { useWeb3Context } from "src/hooks/web3Context";
+import { IAccountSlice, loadAccountDetails } from "src/slices/AccountSlice";
+import { IAppData } from "src/slices/AppSlice";
+import { IPendingTxn, isPendingTxn, txnButtonText } from "src/slices/PendingTxnsSlice";
+
+import { ArrowGraphic, RedeemGraphic, VaultGraphic } from "../../components/EducationCard";
+import { redeemBalance, redeemMockBalance } from "../../slices/RedeemThunk";
+import { RedeemCancelCallback, RedeemYieldModal } from "./RedeemYieldModal";
 
 // TODO consider shifting this into interfaces.ts
 type State = {

--- a/src/views/Give/RedeemYieldModal.tsx
+++ b/src/views/Give/RedeemYieldModal.tsx
@@ -1,15 +1,16 @@
-import { Modal, Paper, Typography, SvgIcon, Link, Button } from "@material-ui/core";
-import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
-import { FormControl } from "@material-ui/core";
-import { useWeb3Context } from "src/hooks/web3Context";
-import { txnButtonText } from "../../slices/PendingTxnsSlice";
-import { useSelector } from "react-redux";
-import { VaultGraphic, ArrowGraphic, RedeemGraphic } from "../../components/EducationCard";
-import { IAccountSlice } from "src/slices/AccountSlice";
-import { IPendingTxn, isPendingTxn } from "../../slices/PendingTxnsSlice";
-import { BigNumber } from "bignumber.js";
 import { t, Trans } from "@lingui/macro";
+import { Button, Link, Modal, Paper, SvgIcon, Typography } from "@material-ui/core";
+import { FormControl } from "@material-ui/core";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
+import { BigNumber } from "bignumber.js";
+import { useSelector } from "react-redux";
+import { useWeb3Context } from "src/hooks/web3Context";
+import { IAccountSlice } from "src/slices/AccountSlice";
+
+import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
+import { ArrowGraphic, RedeemGraphic, VaultGraphic } from "../../components/EducationCard";
+import { txnButtonText } from "../../slices/PendingTxnsSlice";
+import { IPendingTxn, isPendingTxn } from "../../slices/PendingTxnsSlice";
 
 export interface RedeemSubmitCallback {
   (): void;

--- a/src/views/Give/WithdrawDepositModal.tsx
+++ b/src/views/Give/WithdrawDepositModal.tsx
@@ -1,17 +1,18 @@
-import { Modal, Paper, Typography, SvgIcon, Link, Button } from "@material-ui/core";
-import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
-import { FormControl } from "@material-ui/core";
-import { useWeb3Context } from "src/hooks/web3Context";
-import { txnButtonText } from "../../slices/PendingTxnsSlice";
-import { useSelector } from "react-redux";
-import { WalletGraphic, VaultGraphic, ArrowGraphic } from "../../components/EducationCard";
-import { IAccountSlice } from "src/slices/AccountSlice";
-import { IPendingTxn } from "../../slices/PendingTxnsSlice";
-import { BigNumber } from "bignumber.js";
-import { Project } from "src/components/GiveProject/project.type";
-import { hasPendingGiveTxn, PENDING_TXN_WITHDRAW } from "src/slices/GiveThunk";
 import { t, Trans } from "@lingui/macro";
+import { Button, Link, Modal, Paper, SvgIcon, Typography } from "@material-ui/core";
+import { FormControl } from "@material-ui/core";
+import { BigNumber } from "bignumber.js";
+import { useSelector } from "react-redux";
+import { Project } from "src/components/GiveProject/project.type";
 import { shorten } from "src/helpers";
+import { useWeb3Context } from "src/hooks/web3Context";
+import { IAccountSlice } from "src/slices/AccountSlice";
+import { hasPendingGiveTxn, PENDING_TXN_WITHDRAW } from "src/slices/GiveThunk";
+
+import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
+import { ArrowGraphic, VaultGraphic, WalletGraphic } from "../../components/EducationCard";
+import { txnButtonText } from "../../slices/PendingTxnsSlice";
+import { IPendingTxn } from "../../slices/PendingTxnsSlice";
 
 export interface WithdrawSubmitCallback {
   (walletAddress: string, depositAmount: BigNumber): void;

--- a/src/views/Give/YieldRecipients.tsx
+++ b/src/views/Give/YieldRecipients.tsx
@@ -1,29 +1,28 @@
+import { t, Trans } from "@lingui/macro";
+import { Button, Divider, Grid, Typography } from "@material-ui/core";
+import useMediaQuery from "@material-ui/core/useMediaQuery";
+import { Skeleton } from "@material-ui/lab";
+import { BigNumber } from "bignumber.js";
 import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-
-import { Typography, Button, Grid, Divider } from "@material-ui/core";
 import { NavLink } from "react-router-dom";
-
-import { Skeleton } from "@material-ui/lab";
-import { useWeb3Context } from "src/hooks/web3Context";
-import { ACTION_GIVE_EDIT, ACTION_GIVE_WITHDRAW, changeGive, changeMockGive } from "../../slices/GiveThunk";
+import { useLocation } from "react-router-dom";
+import { Project } from "src/components/GiveProject/project.type";
 import InfoTooltip from "src/components/InfoTooltip/InfoTooltip";
-import { RecipientModal } from "src/views/Give/RecipientModal";
-import { SubmitCallback } from "src/views/Give/Interfaces";
-import { WithdrawDepositModal, WithdrawSubmitCallback, WithdrawCancelCallback } from "./WithdrawDepositModal";
 import { shorten } from "src/helpers";
-import { BigNumber } from "bignumber.js";
+import { EnvHelper } from "src/helpers/Environment";
+import { useAppSelector } from "src/hooks";
+import { useWeb3Context } from "src/hooks/web3Context";
 import { IAccountSlice } from "src/slices/AccountSlice";
 import { IAppData } from "src/slices/AppSlice";
 import { IPendingTxn } from "src/slices/PendingTxnsSlice";
+import { SubmitCallback } from "src/views/Give/Interfaces";
+import { RecipientModal } from "src/views/Give/RecipientModal";
+
+import { ACTION_GIVE_EDIT, ACTION_GIVE_WITHDRAW, changeGive, changeMockGive } from "../../slices/GiveThunk";
 import { error } from "../../slices/MessagesSlice";
 import data from "./projects.json";
-import { Project } from "src/components/GiveProject/project.type";
-import { useAppSelector } from "src/hooks";
-import { t, Trans } from "@lingui/macro";
-import useMediaQuery from "@material-ui/core/useMediaQuery";
-import { useLocation } from "react-router-dom";
-import { EnvHelper } from "src/helpers/Environment";
+import { WithdrawCancelCallback, WithdrawDepositModal, WithdrawSubmitCallback } from "./WithdrawDepositModal";
 
 // TODO consider shifting this into interfaces.ts
 type State = {

--- a/src/views/Give/give.scss
+++ b/src/views/Give/give.scss
@@ -846,7 +846,6 @@
   }
 }
 
-
 .subnav-paper {
   max-width: 833px;
   margin-bottom: 10rem;
@@ -861,5 +860,3 @@
     line-height: 20px;
   }
 }
-
-

--- a/src/views/Stake/ExternalStakePool.tsx
+++ b/src/views/Stake/ExternalStakePool.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react";
-import { useDispatch } from "react-redux";
+import { Trans } from "@lingui/macro";
 import {
   Box,
   Button,
@@ -13,14 +12,15 @@ import {
   Typography,
   Zoom,
 } from "@material-ui/core";
-import { Trans } from "@lingui/macro";
-
 import useMediaQuery from "@material-ui/core/useMediaQuery";
+import { useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
 import avaxImage from "src/assets/tokens/avax.png";
 import gOhmImage from "src/assets/tokens/gohm.png";
-import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
-import { useWeb3Context } from "src/hooks/web3Context";
 import MultiLogo from "src/components/MultiLogo";
+import { useWeb3Context } from "src/hooks/web3Context";
+
+import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
 import { useAppSelector } from "../../hooks";
 
 const avatarStyle = { height: "35px", width: "35px", marginInline: "-4px", marginTop: "16px" };

--- a/src/views/Stake/Stake.tsx
+++ b/src/views/Stake/Stake.tsx
@@ -1,48 +1,48 @@
-import { useCallback, useState, useEffect, ChangeEvent, ChangeEventHandler } from "react";
-import { useDispatch } from "react-redux";
-import { usePathForNetwork } from "src/hooks/usePathForNetwork";
-import { useHistory } from "react-router";
+import "./stake.scss";
+
+import { t, Trans } from "@lingui/macro";
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
   Button,
+  Checkbox,
+  Divider,
   FormControl,
   Grid,
   InputAdornment,
   InputLabel,
-  Link,
   OutlinedInput,
   Paper,
   Tab,
   Tabs,
   Typography,
   Zoom,
-  Divider,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-  Checkbox,
 } from "@material-ui/core";
-import { t, Trans } from "@lingui/macro";
+import { ExpandMore } from "@material-ui/icons";
 import CheckBoxIcon from "@material-ui/icons/CheckBox";
 import CheckBoxOutlineBlankIcon from "@material-ui/icons/CheckBoxOutlineBlank";
+import { Skeleton } from "@material-ui/lab";
+import { ethers } from "ethers";
+import { ChangeEvent, ChangeEventHandler, useCallback, useState } from "react";
+import { useDispatch } from "react-redux";
+import { useHistory } from "react-router";
+import { useAppSelector } from "src/hooks";
+import { usePathForNetwork } from "src/hooks/usePathForNetwork";
+import { useWeb3Context } from "src/hooks/web3Context";
+import { isPendingTxn, txnButtonText } from "src/slices/PendingTxnsSlice";
 
+import { Metric, MetricCollection } from "../../components/Metric";
 import RebaseTimer from "../../components/RebaseTimer/RebaseTimer";
 import TabPanel from "../../components/TabPanel";
 import { getGohmBalFromSohm, trim } from "../../helpers";
+import { error } from "../../slices/MessagesSlice";
 import { changeApproval, changeStake } from "../../slices/StakeThunk";
 import { changeApproval as changeGohmApproval } from "../../slices/WrapThunk";
-import "./stake.scss";
-import { useWeb3Context } from "src/hooks/web3Context";
-import { isPendingTxn, txnButtonText } from "src/slices/PendingTxnsSlice";
-import { Skeleton } from "@material-ui/lab";
-import ExternalStakePool from "./ExternalStakePool";
-import { error } from "../../slices/MessagesSlice";
-import { ethers } from "ethers";
 import ZapCta from "../Zap/ZapCta";
-import { useAppSelector } from "src/hooks";
-import { ExpandMore } from "@material-ui/icons";
+import ExternalStakePool from "./ExternalStakePool";
 import StakeRow from "./StakeRow";
-import { Metric, MetricCollection } from "../../components/Metric";
 
 function a11yProps(index: number) {
   return {
@@ -158,7 +158,7 @@ function Stake() {
     }
 
     // 1st catch if quantity > balance
-    let gweiValue = ethers.utils.parseUnits(quantity.toString(), "gwei");
+    const gweiValue = ethers.utils.parseUnits(quantity.toString(), "gwei");
     if (action === "stake" && gweiValue.gt(ethers.utils.parseUnits(ohmBalance, "gwei"))) {
       return dispatch(error(t`You cannot stake more than your OHM balance.`));
     }
@@ -209,7 +209,7 @@ function Stake() {
 
   const isAllowanceDataLoading = (stakeAllowance == null && view === 0) || (unstakeAllowance == null && view === 1);
 
-  let modalButton = [];
+  const modalButton = [];
 
   modalButton.push(
     <Button variant="contained" color="primary" className="connect-button" onClick={connect} key={1}>
@@ -217,7 +217,7 @@ function Stake() {
     </Button>,
   );
 
-  const changeView = (_event: React.ChangeEvent<{}>, newView: number) => {
+  const changeView = (_event: React.ChangeEvent<any>, newView: number) => {
     setView(newView);
   };
 

--- a/src/views/Stake/stake.scss
+++ b/src/views/Stake/stake.scss
@@ -12,7 +12,7 @@
   }
 
   .stake-to-ohm-checkbox {
-    svg{
+    svg {
       font-size: 0.8em;
     }
   }

--- a/src/views/TreasuryDashboard/TreasuryDashboard.tsx
+++ b/src/views/TreasuryDashboard/TreasuryDashboard.tsx
@@ -1,18 +1,19 @@
-import { memo } from "react";
 import "./treasury-dashboard.scss";
-import { Paper, Grid, Box, Zoom, Container, useMediaQuery, Typography } from "@material-ui/core";
+
+import { Box, Container, Grid, Paper, useMediaQuery, Zoom } from "@material-ui/core";
 import Alert from "@material-ui/lab/Alert";
-import { MarketCap, OHMPrice, GOHMPrice, CircSupply, BackingPerOHM, CurrentIndex } from "./components/Metric/Metric";
+import { memo } from "react";
+import { MetricCollection } from "src/components/Metric";
 
 import {
-  TotalValueDepositedGraph,
   MarketValueGraph,
-  RiskFreeValueGraph,
-  ProtocolOwnedLiquidityGraph,
   OHMStakedGraph,
+  ProtocolOwnedLiquidityGraph,
+  RiskFreeValueGraph,
   RunwayAvailableGraph,
+  TotalValueDepositedGraph,
 } from "./components/Graph/Graph";
-import { MetricCollection } from "src/components/Metric";
+import { BackingPerOHM, CircSupply, CurrentIndex, GOHMPrice, MarketCap, OHMPrice } from "./components/Metric/Metric";
 const TreasuryDashboard = memo(() => {
   const isSmallScreen = useMediaQuery("(max-width: 650px)");
   const isVerySmallScreen = useMediaQuery("(max-width: 379px)");

--- a/src/views/TreasuryDashboard/components/Graph/Graph.js
+++ b/src/views/TreasuryDashboard/components/Graph/Graph.js
@@ -1,8 +1,9 @@
-import Chart from "src/components/Chart/Chart.jsx";
 import { useTheme } from "@material-ui/core/styles";
-import { trim, formatCurrency } from "../../../../helpers";
+import Chart from "src/components/Chart/Chart.jsx";
+
+import { formatCurrency, trim } from "../../../../helpers";
 import { useTreasuryMetrics } from "../../hooks/useTreasuryMetrics";
-import { bulletpoints, tooltipItems, tooltipInfoMessages, itemType } from "../../treasuryData";
+import { bulletpoints, itemType, tooltipInfoMessages, tooltipItems } from "../../treasuryData";
 
 export const Graph = ({ children }) => <>{children}</>;
 

--- a/src/views/TreasuryDashboard/components/Metric/Metric.js
+++ b/src/views/TreasuryDashboard/components/Metric/Metric.js
@@ -1,7 +1,8 @@
-import { useSelector } from "react-redux";
-import { trim, formatCurrency } from "../../../../helpers";
-import { Metric } from "src/components/Metric";
 import { t } from "@lingui/macro";
+import { useSelector } from "react-redux";
+import { Metric } from "src/components/Metric";
+
+import { formatCurrency, trim } from "../../../../helpers";
 
 const sharedProps = {
   labelVariant: "h6",

--- a/src/views/TreasuryDashboard/hooks/useTreasuryMetrics.js
+++ b/src/views/TreasuryDashboard/hooks/useTreasuryMetrics.js
@@ -1,5 +1,6 @@
 import { useQuery } from "react-query";
 import apollo from "src/lib/apolloClient";
+
 import { treasuryDataQuery } from "../treasuryData";
 
 export const useTreasuryMetrics = options => {

--- a/src/views/TreasuryDashboard/hooks/useTreasuryRebases.js
+++ b/src/views/TreasuryDashboard/hooks/useTreasuryRebases.js
@@ -1,5 +1,6 @@
 import { useQuery } from "react-query";
 import apollo from "src/lib/apolloClient";
+
 import { rebasesDataQuery } from "../treasuryData";
 
 export const useTreasuryRebases = options => {

--- a/src/views/V1-Stake/V1-Stake.jsx
+++ b/src/views/V1-Stake/V1-Stake.jsx
@@ -1,45 +1,43 @@
-import { useCallback, useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import "../Stake/stake.scss";
+import "./v1stake.scss";
+
+import { t, Trans } from "@lingui/macro";
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
   Button,
+  Divider,
   FormControl,
   Grid,
   InputAdornment,
   InputLabel,
-  Link,
   OutlinedInput,
   Paper,
   Tab,
   Tabs,
   Typography,
   Zoom,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-  Divider,
 } from "@material-ui/core";
 import { ExpandMore } from "@material-ui/icons";
-import { t, Trans } from "@lingui/macro";
-import NewReleases from "@material-ui/icons/NewReleases";
-import RebaseTimer from "../../components/RebaseTimer/RebaseTimer";
-import TabPanel from "../../components/TabPanel";
-import { MigrateButton, LearnMoreButton } from "src/components/CallToAction/CallToAction";
-import { getOhmTokenImage, getTokenImage, trim } from "../../helpers";
-import { changeApproval, changeStake } from "../../slices/StakeThunk";
-import useMediaQuery from "@material-ui/core/useMediaQuery";
-import "../Stake/stake.scss";
-import "./v1stake.scss";
-import StakeRow from "../Stake/StakeRow";
+import { Skeleton } from "@material-ui/lab";
+import { ethers } from "ethers";
+import { useCallback, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useHistory } from "react-router-dom";
+import { LearnMoreButton, MigrateButton } from "src/components/CallToAction/CallToAction";
+import { useAppSelector } from "src/hooks";
 import { useWeb3Context } from "src/hooks/web3Context";
 import { isPendingTxn, txnButtonText } from "src/slices/PendingTxnsSlice";
-import { Skeleton } from "@material-ui/lab";
-import ExternalStakePool from "../Stake/ExternalStakePool";
+
+import RebaseTimer from "../../components/RebaseTimer/RebaseTimer";
+import TabPanel from "../../components/TabPanel";
+import { getOhmTokenImage, getTokenImage, trim } from "../../helpers";
 import { error } from "../../slices/MessagesSlice";
-import { ethers } from "ethers";
-import { getMigrationAllowances } from "src/slices/AccountSlice";
-import { useAppSelector } from "src/hooks";
-import { useHistory } from "react-router-dom";
+import { changeApproval, changeStake } from "../../slices/StakeThunk";
+import ExternalStakePool from "../Stake/ExternalStakePool";
+import StakeRow from "../Stake/StakeRow";
 
 function a11yProps(index) {
   return {

--- a/src/views/Wrap/Wrap.jsx
+++ b/src/views/Wrap/Wrap.jsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import "../Stake/stake.scss";
+
+import { t } from "@lingui/macro";
 import {
   Box,
   Button,
@@ -9,36 +10,30 @@ import {
   InputAdornment,
   InputLabel,
   Link,
+  makeStyles,
+  MenuItem,
   OutlinedInput,
   Paper,
-  Tab,
-  Tabs,
+  Select,
+  SvgIcon,
   Typography,
   Zoom,
-  SvgIcon,
-  makeStyles,
-  Select,
-  MenuItem,
 } from "@material-ui/core";
-import InfoTooltip from "../../components/InfoTooltip/InfoTooltip.jsx";
-import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
-
-import { getOhmTokenImage, getTokenImage, trim, formatCurrency } from "../../helpers";
-import { changeApproval, changeWrap, changeWrapV2 } from "../../slices/WrapThunk";
-import { migrateWithType, migrateCrossChainWSOHM } from "../../slices/MigrateThunk";
-import { switchNetwork } from "../../slices/NetworkSlice";
-import { useWeb3Context } from "src/hooks/web3Context";
-import { isPendingTxn, txnButtonText, txnButtonTextMultiType } from "src/slices/PendingTxnsSlice";
 import { Skeleton } from "@material-ui/lab";
-import { error } from "../../slices/MessagesSlice";
-import { NETWORKS } from "../../constants";
-import { ethers } from "ethers";
-import "../Stake/stake.scss";
+import { useCallback, useMemo, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { Metric, MetricCollection } from "src/components/Metric";
-import { t } from "@lingui/macro";
 import { useAppSelector } from "src/hooks/index.ts";
-import WrapCrossChain from "./WrapCrossChain.tsx";
+import { useWeb3Context } from "src/hooks/web3Context";
 import { loadAccountDetails } from "src/slices/AccountSlice";
+import { isPendingTxn, txnButtonTextMultiType } from "src/slices/PendingTxnsSlice";
+
+import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
+import { NETWORKS } from "../../constants";
+import { formatCurrency, trim } from "../../helpers";
+import { switchNetwork } from "../../slices/NetworkSlice";
+import { changeApproval, changeWrapV2 } from "../../slices/WrapThunk";
+import WrapCrossChain from "./WrapCrossChain.tsx";
 
 const useStyles = makeStyles(theme => ({
   textHighlight: {

--- a/src/views/Wrap/WrapCrossChain.tsx
+++ b/src/views/Wrap/WrapCrossChain.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { useDispatch } from "react-redux";
+import "../Stake/stake.scss";
+
 import {
   Box,
   Button,
@@ -11,29 +11,24 @@ import {
   Link,
   OutlinedInput,
   Paper,
-  Tab,
-  Tabs,
+  SvgIcon,
   Typography,
   Zoom,
-  SvgIcon,
-  makeStyles,
-  Select,
-  MenuItem,
 } from "@material-ui/core";
-import InfoTooltip from "../../components/InfoTooltip/InfoTooltip.jsx";
-import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
-
-import { getOhmTokenImage, getTokenImage, trim, formatCurrency } from "../../helpers";
-import { changeApproval, changeWrapV2 } from "../../slices/WrapThunk";
-import { migrateWithType, migrateCrossChainWSOHM, changeMigrationApproval } from "../../slices/MigrateThunk";
-import { switchNetwork } from "../../slices/NetworkSlice";
-import { useWeb3Context } from "src/hooks/web3Context";
-import { isPendingTxn, txnButtonText, txnButtonTextMultiType } from "src/slices/PendingTxnsSlice";
 import { Skeleton } from "@material-ui/lab";
-import { NETWORKS } from "../../constants";
-import "../Stake/stake.scss";
+import { useCallback, useState } from "react";
+import { useDispatch } from "react-redux";
 import { useAppSelector } from "src/hooks/index";
-import { getBalances, loadAccountDetails } from "src/slices/AccountSlice";
+import { useWeb3Context } from "src/hooks/web3Context";
+import { loadAccountDetails } from "src/slices/AccountSlice";
+import { isPendingTxn, txnButtonTextMultiType } from "src/slices/PendingTxnsSlice";
+
+import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
+import InfoTooltip from "../../components/InfoTooltip/InfoTooltip.jsx";
+import { NETWORKS } from "../../constants";
+import { formatCurrency, trim } from "../../helpers";
+import { changeMigrationApproval, migrateCrossChainWSOHM } from "../../slices/MigrateThunk";
+import { switchNetwork } from "../../slices/NetworkSlice";
 
 function WrapCrossChain() {
   const dispatch = useDispatch();
@@ -91,7 +86,7 @@ function WrapCrossChain() {
 
   const isDataLoading = useAppSelector(state => state.account.loading);
 
-  let modalButton = [];
+  const modalButton = [];
 
   modalButton.push(
     <Button variant="contained" color="primary" className="connect-button" onClick={connect} key={1}>

--- a/src/views/Zap/Zap.jsx
+++ b/src/views/Zap/Zap.jsx
@@ -1,14 +1,15 @@
-import { useState, useRef, useEffect, useMemo } from "react";
-import { Box, Button, Fade, Paper, Tab, Tabs, Typography, Zoom } from "@material-ui/core";
-import TabPanel from "../../components/TabPanel";
 import "./zap.scss";
-import { useWeb3Context } from "src/hooks/web3Context";
-import ZapStakeAction from "./ZapStakeAction";
-import ZapInfo from "./ZapInfo";
-import { useAppSelector } from "src/hooks";
+
 import { Trans } from "@lingui/macro";
-import { usePathForNetwork } from "src/hooks/usePathForNetwork";
+import { Box, Button, Paper, Typography, Zoom } from "@material-ui/core";
+import { useMemo } from "react";
 import { useHistory } from "react-router";
+import { useAppSelector } from "src/hooks";
+import { usePathForNetwork } from "src/hooks/usePathForNetwork";
+import { useWeb3Context } from "src/hooks/web3Context";
+
+import ZapInfo from "./ZapInfo";
+import ZapStakeAction from "./ZapStakeAction";
 
 function Zap() {
   const { address, connect } = useWeb3Context();

--- a/src/views/Zap/ZapCta.jsx
+++ b/src/views/Zap/ZapCta.jsx
@@ -1,10 +1,11 @@
-import { Box, Button, Paper, Typography, Grid, SvgIcon, Link } from "@material-ui/core";
 import "./zap.scss";
-import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
-import MultiLogo from "../../components/MultiLogo";
-import { NavLink } from "react-router-dom";
-import { makeStyles } from "@material-ui/core/styles";
+
 import { Trans } from "@lingui/macro";
+import { Box, Button, Grid, Link, Paper, Typography } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import { NavLink } from "react-router-dom";
+
+import MultiLogo from "../../components/MultiLogo";
 
 const useStyles = makeStyles(theme => ({
   subHeader: {

--- a/src/views/Zap/ZapInfo.jsx
+++ b/src/views/Zap/ZapInfo.jsx
@@ -1,12 +1,13 @@
-import { Box, Button, Paper, Typography, Grid, SvgIcon } from "@material-ui/core";
 import "./zap.scss";
-import { ReactComponent as CircleZapIcon } from "../../assets/icons/circle-zap.svg";
-import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
-import MultiLogo from "../../components/MultiLogo";
-import { makeStyles } from "@material-ui/core/styles";
-import { segmentUA } from "../../helpers/userAnalyticHelpers";
-import { useState } from "react";
+
 import { Trans } from "@lingui/macro";
+import { Box, Button, Grid, Paper, SvgIcon, Typography } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+
+import { ReactComponent as ArrowUp } from "../../assets/icons/arrow-up.svg";
+import { ReactComponent as CircleZapIcon } from "../../assets/icons/circle-zap.svg";
+import MultiLogo from "../../components/MultiLogo";
+import { segmentUA } from "../../helpers/userAnalyticHelpers";
 
 const useStyles = makeStyles(theme => ({
   infoBox: {

--- a/src/views/Zap/ZapStakeAction.jsx
+++ b/src/views/Zap/ZapStakeAction.jsx
@@ -1,44 +1,41 @@
+import { Trans } from "@lingui/macro";
 import {
+  Avatar,
   Box,
   Button,
-  FormControl,
-  Grid,
-  Icon,
-  InputAdornment,
-  InputLabel,
-  OutlinedInput,
-  Avatar,
-  Typography,
+  ButtonBase,
+  CircularProgress,
   Dialog,
   DialogTitle,
+  FormControl,
+  Grid,
+  InputAdornment,
+  InputLabel,
   List,
   ListItem,
   ListItemAvatar,
-  ButtonBase,
-  IconButton,
-  CardHeader,
   ListItemText,
-  SvgIcon,
-  CircularProgress,
+  OutlinedInput,
   Paper,
+  SvgIcon,
+  Typography,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
-import { changeZapTokenAllowance, executeZap, getTokenBalances, getZapTokenAllowance } from "src/slices/ZapSlice";
+import { ethers } from "ethers";
 import { useEffect, useMemo, useState } from "react";
 import { useDispatch } from "react-redux";
-import ZapStakeHeader from "./ZapStakeHeader";
+import { trim } from "src/helpers";
+import { useAppSelector, useWeb3Context } from "src/hooks";
+import { changeZapTokenAllowance, executeZap, getZapTokenAllowance } from "src/slices/ZapSlice";
+
 import { ReactComponent as DownIcon } from "../../assets/icons/arrow-down.svg";
+import { ReactComponent as ZapperIcon } from "../../assets/icons/powered-by-zapper.svg";
 import { ReactComponent as FirstStepIcon } from "../../assets/icons/step-1.svg";
 import { ReactComponent as SecondStepIcon } from "../../assets/icons/step-2.svg";
 import { ReactComponent as CompleteStepIcon } from "../../assets/icons/step-complete.svg";
-import { useAppSelector, useWeb3Context } from "src/hooks";
 import { ReactComponent as XIcon } from "../../assets/icons/x.svg";
-import { ReactComponent as ZapperIcon } from "../../assets/icons/powered-by-zapper.svg";
-import { ReactComponent as SettingsIcon } from "../../assets/icons/settings.svg";
-import { ethers } from "ethers";
 import { segmentUA } from "../../helpers/userAnalyticHelpers";
-import { trim } from "src/helpers";
-import { Trans } from "@lingui/macro";
+import ZapStakeHeader from "./ZapStakeHeader";
 
 const DISABLE_ZAPS = true;
 

--- a/src/views/Zap/ZapStakeHeader.jsx
+++ b/src/views/Zap/ZapStakeHeader.jsx
@@ -1,8 +1,9 @@
+import { t, Trans } from "@lingui/macro";
 import { Box, Grid, Typography, useMediaQuery } from "@material-ui/core";
-import MultiLogo from "../../components/MultiLogo";
+
 import { ReactComponent as MoreIcon } from "../../assets/icons/circle-more.svg";
 import { ReactComponent as CircleZapIcon } from "../../assets/icons/circle-zap.svg";
-import { t, Trans } from "@lingui/macro";
+import MultiLogo from "../../components/MultiLogo";
 
 export default function ZapStakeHeader({ images }) {
   const isSmallScreen = useMediaQuery("(max-width: 680px)");

--- a/yarn.lock
+++ b/yarn.lock
@@ -3370,11 +3370,6 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.1.tgz#e1303048d5389563e130f5bdd89d37a99acb75eb"
   integrity sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==
 
-"@types/prettier@^2.1.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.1.tgz#e1303048d5389563e130f5bdd89d37a99acb75eb"
-  integrity sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==
-
 "@types/prop-types@*":
   version "15.7.4"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
@@ -4240,7 +4235,7 @@ ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
-ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
+ansi-escapes@^4.2.1, ansi-escapes@^4.3.0, ansi-escapes@^4.3.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -4259,7 +4254,7 @@ ansi-html@0.0.7, ansi-html@^0.0.7:
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
   integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
 
-ansi-regex@5.0.1, ansi-regex@^2.0.0, ansi-regex@^3.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+ansi-regex@5.0.1, ansi-regex@^2.0.0, ansi-regex@^3.0.0, ansi-regex@^4.1.0, ansi-regex@^5.0.0, ansi-regex@^5.0.1, ansi-regex@^6.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -4287,6 +4282,11 @@ ansi-styles@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+ansi-styles@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.1.0.tgz#87313c102b8118abd57371afab34618bf7350ed3"
+  integrity sha512-VbqNsoz55SYGczauuup0MFUyXNQviSpFTj1RQtFzmQLk18qbVSpTFFGMT293rmDaQuKCT6InmbuEyUne4mTuxQ==
 
 ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
   version "0.1.0"
@@ -6006,6 +6006,22 @@ cli-truncate@^0.2.1:
     slice-ansi "0.0.4"
     string-width "^1.0.1"
 
+cli-truncate@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
+  integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
+  dependencies:
+    slice-ansi "^3.0.0"
+    string-width "^4.2.0"
+
+cli-truncate@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-3.1.0.tgz#3f23ab12535e3d73e839bb43e73c9de487db1389"
+  integrity sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==
+  dependencies:
+    slice-ansi "^5.0.0"
+    string-width "^5.0.0"
+
 cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
@@ -6197,6 +6213,11 @@ colorette@^1.2.2:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
   integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
 
+colorette@^2.0.16:
+  version "2.0.16"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
+  integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
+
 colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
@@ -6223,7 +6244,7 @@ command-line-args@^4.0.7:
     find-replace "^1.0.3"
     typical "^2.6.1"
 
-commander@*:
+commander@*, commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
@@ -7021,6 +7042,13 @@ debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
+
 decamelize-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
@@ -7536,7 +7564,7 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-emoji-regex@^9.0.0:
+emoji-regex@^9.0.0, emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
@@ -8464,6 +8492,21 @@ execa@^4.0.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
+execa@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
+  integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
+    strip-final-newline "^2.0.0"
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -9215,6 +9258,11 @@ get-stream@^5.0.0, get-stream@^5.1.0:
   integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
+
+get-stream@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
 get-symbol-description@^1.0.0:
   version "1.0.0"
@@ -10039,6 +10087,16 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+husky@^7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
+  integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
+
 hyphenate-style-name@^1.0.2, hyphenate-style-name@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
@@ -10568,6 +10626,11 @@ is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
+is-fullwidth-code-point@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz#fae3167c729e7463f8461ce512b080a49268aa88"
+  integrity sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==
 
 is-function@^1.0.1:
   version "1.0.2"
@@ -11991,6 +12054,11 @@ liftoff@^3.1.0:
     rechoir "^0.6.2"
     resolve "^1.1.7"
 
+lilconfig@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.4.tgz#f4507d043d7058b380b6a8f5cb7bcd4b34cee082"
+  integrity sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==
+
 lilconfig@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.3.tgz#68f3005e921dafbd2a2afb48379986aa6d2579fd"
@@ -12014,6 +12082,25 @@ linkify-it@^3.0.1:
   integrity sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==
   dependencies:
     uc.micro "^1.0.1"
+    
+lint-staged@^12.1.3:
+  version "12.1.3"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-12.1.3.tgz#a16e885c0a5e77de9cf559724d29a10348670e68"
+  integrity sha512-ajapdkaFxx+MVhvq6xQRg9zCnCLz49iQLJZP7+w8XaA3U4B35Z9xJJGq9vxmWo73QTvJLG+N2NxhjWiSexbAWQ==
+  dependencies:
+    cli-truncate "^3.1.0"
+    colorette "^2.0.16"
+    commander "^8.3.0"
+    debug "^4.3.3"
+    execa "^5.1.1"
+    lilconfig "2.0.4"
+    listr2 "^3.13.5"
+    micromatch "^4.0.4"
+    normalize-path "^3.0.0"
+    object-inspect "^1.11.1"
+    string-argv "^0.3.1"
+    supports-color "^9.2.1"
+    yaml "^1.10.2"
 
 listr-silent-renderer@^1.1.1:
   version "1.1.1"
@@ -12043,6 +12130,20 @@ listr-verbose-renderer@^0.5.0:
     cli-cursor "^2.1.0"
     date-fns "^1.27.2"
     figures "^2.0.0"
+
+listr2@^3.13.5:
+  version "3.13.5"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.13.5.tgz#105a813f2eb2329c4aae27373a281d610ee4985f"
+  integrity sha512-3n8heFQDSk+NcwBn3CgxEibZGaRzx+pC64n3YjpMD1qguV4nWus3Al+Oo3KooqFKTQEJ1v7MmnbnyyNspgx3NA==
+  dependencies:
+    cli-truncate "^2.1.0"
+    colorette "^2.0.16"
+    log-update "^4.0.0"
+    p-map "^4.0.0"
+    rfdc "^1.3.0"
+    rxjs "^7.4.0"
+    through "^2.3.8"
+    wrap-ansi "^7.0.0"
 
 listr@^0.14.3:
   version "0.14.3"
@@ -12262,6 +12363,16 @@ log-update@^2.3.0:
     ansi-escapes "^3.0.0"
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
+
+log-update@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
+  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
+  dependencies:
+    ansi-escapes "^4.3.0"
+    cli-cursor "^3.1.0"
+    slice-ansi "^4.0.0"
+    wrap-ansi "^6.2.0"
 
 loglevel@^1.6.8:
   version "1.7.1"
@@ -13151,7 +13262,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npm-run-path@^4.0.0:
+npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
@@ -13218,6 +13329,11 @@ object-inspect@^1.11.0, object-inspect@^1.9.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
   integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
+
+object-inspect@^1.11.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
+  integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
 
 object-is@^1.0.1:
   version "1.1.5"
@@ -13367,7 +13483,7 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-onetime@^5.1.0:
+onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
@@ -14662,11 +14778,6 @@ prettier-linter-helpers@^1.0.0:
     fast-diff "^1.1.2"
 
 prettier@^2.0.5, prettier@^2.1.2:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
-  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
-
-prettier@^2.1.2:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
   integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
@@ -15970,6 +16081,11 @@ rework@1.0.1:
     convert-source-map "^0.3.3"
     css "^2.0.0"
 
+rfdc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
+  integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
+
 rgb-regex@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/rgb-regex/-/rgb-regex-1.0.1.tgz#c0e0d6882df0e23be254a475e8edd41915feaeb1"
@@ -16086,6 +16202,13 @@ rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.6.0, rxjs@^6.6.3:
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
+
+rxjs@^7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.4.0.tgz#a12a44d7eebf016f5ff2441b87f28c9a51cebc68"
+  integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
+  dependencies:
+    tslib "~2.1.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -16482,6 +16605,11 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.5.tgz#9e3e8cc0c75a99472b44321033a7702e7738252f"
   integrity sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==
 
+signal-exit@^3.0.3:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
+  integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
+
 signedsource@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz#1ddace4981798f93bd833973803d80d52e93ad6a"
@@ -16514,6 +16642,15 @@ slice-ansi@0.0.4:
   resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
   integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
 
+slice-ansi@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
+  integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
+
 slice-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
@@ -16522,6 +16659,14 @@ slice-ansi@^4.0.0:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
+
+slice-ansi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-5.0.0.tgz#b73063c57aa96f9cd881654b15294d95d285c42a"
+  integrity sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==
+  dependencies:
+    ansi-styles "^6.0.0"
+    is-fullwidth-code-point "^4.0.0"
 
 snake-case@^3.0.4:
   version "3.0.4"
@@ -16869,6 +17014,11 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
+string-argv@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
+  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
+
 string-env-interpolation@1.0.1, string-env-interpolation@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz#ad4397ae4ac53fe6c91d1402ad6f6a52862c7152"
@@ -16921,6 +17071,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.0.1.tgz#0d8158335a6cfd8eb95da9b6b262ce314a036ffd"
+  integrity sha512-5ohWO/M4//8lErlUUtrFy3b11GtNOuMOU0ysKCDXFcfXuuvUXu95akgj/i8ofmaGdN0hCqyl6uu9i8dS/mQp5g==
+  dependencies:
+    emoji-regex "^9.2.2"
+    is-fullwidth-code-point "^4.0.0"
+    strip-ansi "^7.0.1"
 
 string.prototype.matchall@^4.0.5:
   version "4.0.6"
@@ -17014,6 +17173,13 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.1.tgz#61740a08ce36b61e50e65653f07060d000975fb2"
+  integrity sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==
+  dependencies:
+    ansi-regex "^6.0.1"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -17150,6 +17316,11 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
+
+supports-color@^9.2.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.2.1.tgz#599dc9d45acf74c6176e0d880bab1d7d718fe891"
+  integrity sha512-Obv7ycoCTG51N7y175StI9BlAXrmgZrFhZOb0/PyjHBher/NmsdBgbbQ1Inhq+gIhz6+7Gb+jWF2Vqi7Mf1xnQ==
 
 supports-hyperlinks@^2.0.0:
   version "2.2.0"
@@ -17414,7 +17585,7 @@ through2@^4.0.0:
   dependencies:
     readable-stream "3"
 
-through@2, through@^2.3.6:
+through@2, through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -17655,6 +17826,11 @@ tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, 
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils@^3.17.1, tsutils@^3.21.0:
   version "3.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7867,6 +7867,11 @@ eslint-plugin-react@^7.21.5, eslint-plugin-react@^7.22.0:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.5"
 
+eslint-plugin-simple-import-sort@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz#a1dad262f46d2184a90095a60c66fef74727f0f8"
+  integrity sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==
+
 eslint-plugin-testing-library@^3.9.2:
   version "3.10.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-3.10.2.tgz#609ec2b0369da7cf2e6d9edff5da153cc31d87bd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7879,6 +7879,13 @@ eslint-plugin-testing-library@^3.9.2:
   dependencies:
     "@typescript-eslint/experimental-utils" "^3.10.1"
 
+eslint-plugin-unused-imports@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz#d8db8c4d0cfa0637a8b51ce3fd7d1b6bc3f08520"
+  integrity sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
 eslint-rule-composer@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"


### PR DESCRIPTION
## Intro

`eslint` is one of the most important tools for any complex, collaborative project and allows us to easily find and fix bugs. So this PR aims to improve the current configuration to ensure we are utilising it to its full capacity.

## Problems

The existing configuration isn't very strict, allowing bugs to occur more easily while also being a detriment to the overall code quality of this repo.

## Solutions

I've gone ahead and added some recommended defaults, as well as some opinionated ones too.

1. `react-app` and `react-hooks/recommended` are important with react stuff.
2. `@typescript-eslint/recommended` and `@typescript-eslint/eslint-recommended` as recommended defaults.
3. `unused-imports` to automatically remove unused imports.
4. `simple-import-sort` to automatically sort imports alphabetically. This is opinionated, but I believe useful because it helps avoid merge conflicts with imports (and who doesn't like neat alphabetically sorted imports anyway).
5. `@typescript-eslint/explicit-function-return-type` and `@typescript-eslint/explicit-module-boundary-types` are turned off to prioritise inferred return types over explicit return types. This is opinionated, but often times the inference Typescript makes is good enough, and sometimes help prevents type mismatches that are a pain to debug.
6. `@typescript-eslint/ban-ts-comment` and `@typescript-eslint/ban-ts-ignore` are also turned off. This could possibly be temporary, but the ability to use `@ts-ignore`-like directives is certainly handy as an escape hatch as we encounter errors during the migration to TS.

## More possible solutions

1. Implement a pre-commit hook using something like `husky` to ensure all code is linted before being pushed to remote (this should probably be the last step of the PR).

## Discussion

Would love to hear any other defaults or eslint rules that you think should be added to the configuration.