### PR TITLE
fix mobile browser menu bar on top of bottom of the page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,6 +83,7 @@ const useStyles = makeStyles(theme => ({
     height: "100%",
     overflow: "auto",
     marginLeft: drawerWidth,
+    paddingBottom: "10rem",
   },
   contentShift: {
     transition: theme.transitions.create("margin", {


### PR DESCRIPTION
adds padding bottom on page content

the issue:

https://user-images.githubusercontent.com/6232729/147290087-7ae924de-3fdb-4e6e-ac70-b288651b2b44.MP4


