### PR TITLE
make this only run on PR

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,9 +1,6 @@
 name: Lighthouse PWA Test
 
 on:
-  # local lighthouse test can run on PR and push
-  push:
-
   # Netlify pre-deploy only works on pull_request
   pull_request:
   #  branches:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Lighthouse PWA Test](https://github.com/ivelin/olympus-frontend/actions/workflows/lighthouse.yml/badge.svg)](https://github.com/ivelin/olympus-frontend/actions/workflows/lighthouse.yml)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
 
-
 # [Ω Olympus Frontend](https://app.olympusdao.finance/)
 
 This is the front-end repo for Olympus that allows users be part of the future of _Meta Greece_.


### PR DESCRIPTION
This workflow is running twice on every pull request. It really only needs to run on PR and not PR and every push to the repo. Pushing new code to an open PR will retrigger the pull_request workflow again. 