### PR TITLE
update hover over cursor under my wallet [minor css fix]

### DIFF
--- a/src/components/TopBar/Wallet/InitialWalletView.tsx
+++ b/src/components/TopBar/Wallet/InitialWalletView.tsx
@@ -146,7 +146,7 @@ const WalletTotalValue = () => {
       <Typography style={{ lineHeight: 1.1, fontWeight: 600, fontSize: "0.975rem" }} color="textSecondary">
         MY WALLET
       </Typography>
-      <Typography style={{ fontWeight: 700 }} variant="h3">
+      <Typography style={{ fontWeight: 700, cursor: "pointer" }} variant="h3">
         {!isLoading ? formatCurrency(walletValue[currency], 2, currency) : <Skeleton variant="text" width={100} />}
       </Typography>
       <WalletAddressEns />


### PR DESCRIPTION
I noticed that when you hover over your "amount" your cursor keeps the typography input hover over state. This changes it to a "pointer" which is what it should be. 

normally I'd show a screenshot with the pointer but it was too hard to capture. 

👇  Changes the pointer when toggling between ohm and usd
<img width="351" alt="Screen Shot 2022-01-05 at 8 38 32 PM" src="https://user-images.githubusercontent.com/96147312/148324511-1d1e045c-7d65-4ffc-b5e2-421c04f5c800.png">

