### PR TITLE
fixing hotreload issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "**/prompts": "2.4.2",
     "**/shell-quote": "1.7.3",
     "**/ejs": "3.1.6",
-    "**/ansi-html": "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz"
+    "**/ansi-html": "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+    "react-error-overlay": "6.0.9"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15710,10 +15710,10 @@ react-dom@^16.8.6:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-error-overlay@^6.0.9:
-  version "6.0.10"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.10.tgz#0fe26db4fa85d9dbb8624729580e90e7159a59a6"
-  integrity sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==
+react-error-overlay@6.0.9, react-error-overlay@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
+  integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
 react-event-listener@^0.6.2:
   version "0.6.6"


### PR DESCRIPTION
See https://github.com/facebook/create-react-app/issues/11771

The issue stems from this commit where we fixed a few security issues: https://github.com/OlympusDAO/olympus-frontend/commit/d9257f42a0bc0a4fae2dacfa8d5a35e8f76ce33c

Resolving react-error-overlay back to 6.0.9 until the issue above is resolved seems to be the workaround. 
