### PR TITLE
Add Other to market value

### DIFF
--- a/src/views/TreasuryDashboard/components/Graph/Graph.js
+++ b/src/views/TreasuryDashboard/components/Graph/Graph.js
@@ -39,8 +39,8 @@ export const MarketValueGraph = () => {
         "treasuryDaiMarketValue",
         "treasuryFraxMarketValue",
         "treasuryWETHMarketValue",
-        "treasuryXsushiMarketValue",
         "treasuryLusdMarketValue",
+        "treasuryOtherMarketValue",
       ]}
       stopColor={[
         ["#F5AC37", "#EA9276"],

--- a/src/views/TreasuryDashboard/treasuryData.ts
+++ b/src/views/TreasuryDashboard/treasuryData.ts
@@ -22,6 +22,7 @@ query {
     treasuryWETHMarketValue
     treasuryLusdRiskFreeValue
     treasuryLusdMarketValue
+    treasuryOtherMarketValue
     currentAPY
     runway10k
     runway20k
@@ -164,7 +165,7 @@ export const bulletpoints = {
 
 export const tooltipItems = {
   tvl: ["Total Value Deposited"],
-  coin: ["DAI", "FRAX", "ETH", "SUSHI", "LUSD"],
+  coin: ["DAI", "FRAX", "ETH", "LUSD", "Other"],
   rfv: ["DAI", "FRAX", "LUSD"],
   holder: ["OHMies"],
   apy: ["APY"],


### PR DESCRIPTION
Switch Sushi with Other whitch also contains CVX and FXS.

I will keep adding all other assets in our treasury into this and would be too cluttered.


<img width="576" alt="Screenshot 2022-01-10 at 23 20 51" src="https://user-images.githubusercontent.com/78686347/148848420-6f7cfdb0-59f3-470f-b04b-a63b13411a52.png">
