### PR TITLE
Fix loading state of apy field

### DIFF
--- a/src/views/Stake/ConfirmDialog.tsx
+++ b/src/views/Stake/ConfirmDialog.tsx
@@ -4,7 +4,7 @@ import { InfoTooltip } from "@olympusdao/component-library";
 
 export interface ConfirmDialogProps {
   quantity: string;
-  currentIndex: string;
+  currentIndex: string | undefined;
   view: number;
   onConfirm: (value: boolean) => void;
 }
@@ -17,7 +17,7 @@ export function ConfirmDialog({ quantity, currentIndex, view, onConfirm }: Confi
     onConfirm(value);
   };
   const gohmQuantity = useMemo(
-    () => (quantity ? Number((Number(quantity) / Number(currentIndex)).toFixed(4)) : ""),
+    () => (quantity && currentIndex ? Number((Number(quantity) / Number(currentIndex)).toFixed(4)) : ""),
     [quantity, currentIndex],
   );
   const ohmQuantity = useMemo(() => (quantity ? Number(Number(quantity).toFixed(4)) : ""), [quantity]);

--- a/src/views/Stake/Stake.tsx
+++ b/src/views/Stake/Stake.tsx
@@ -63,7 +63,7 @@ function Stake() {
 
   const isAppLoading = useAppSelector(state => state.app.loading);
   const currentIndex = useAppSelector(state => {
-    return state.app.currentIndex ?? "1";
+    return state.app.currentIndex;
   });
   const fiveDayRate = useAppSelector(state => {
     return state.app.fiveDayRate;


### PR DESCRIPTION
Fix loading state of apy field: show skeleton instead of 1 when the app is loading