### PR TITLE
catch errors for bonding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,10 +159,13 @@ function App() {
   const loadApp = useCallback(
     loadProvider => {
       dispatch(loadAppDetails({ networkID: networkId, provider: loadProvider }));
-      // NOTE (appleseed) - tech debt - better network filtering for active bonds
       if (networkId === NetworkId.MAINNET || networkId === NetworkId.TESTNET_RINKEBY) {
         bonds.map(bond => {
-          dispatch(calcBondDetails({ bond, value: "", provider: loadProvider, networkID: networkId }));
+          // NOTE (appleseed): getBondability & getLOLability control which bonds are active in the view for Bonds V1
+          // ... getClaimability is the analogue for claiming bonds
+          if (bond.getBondability(networkId) || bond.getLOLability(networkId)) {
+            dispatch(calcBondDetails({ bond, value: "", provider: loadProvider, networkID: networkId }));
+          }
         });
         dispatch(getAllBonds({ provider: loadProvider, networkID: networkId, address }));
       }

--- a/src/slices/BondSliceV2.ts
+++ b/src/slices/BondSliceV2.ts
@@ -313,8 +313,8 @@ export const getAllBonds = createAsyncThunk(
 
     for (let i = 0; i < liveBondIndexes.length; i++) {
       const bondIndex = +liveBondIndexes[i];
-      const bond: IBondV2Core = await liveBondPromises[i];
       try {
+        const bond: IBondV2Core = await liveBondPromises[i];
         const bondMetadata: IBondV2Meta = await liveBondMetadataPromises[i];
         const bondTerms: IBondV2Terms = await liveBondTermsPromises[i];
         const finalBond = await processBond(bond, bondMetadata, bondTerms, bondIndex, provider, networkID, dispatch);
@@ -324,7 +324,7 @@ export const getAllBonds = createAsyncThunk(
           dispatch(getTokenBalance({ provider, networkID, address, value: finalBond.quoteToken }));
         }
       } catch (e) {
-        console.log("getAllBonds Error for index: ", bondIndex, ", bond: ", bond);
+        console.log("getAllBonds Error for Bond Index: ", bondIndex);
         console.log(e);
       }
     }

--- a/src/slices/BondSliceV2.ts
+++ b/src/slices/BondSliceV2.ts
@@ -314,13 +314,18 @@ export const getAllBonds = createAsyncThunk(
     for (let i = 0; i < liveBondIndexes.length; i++) {
       const bondIndex = +liveBondIndexes[i];
       const bond: IBondV2Core = await liveBondPromises[i];
-      const bondMetadata: IBondV2Meta = await liveBondMetadataPromises[i];
-      const bondTerms: IBondV2Terms = await liveBondTermsPromises[i];
-      const finalBond = await processBond(bond, bondMetadata, bondTerms, bondIndex, provider, networkID, dispatch);
-      liveBonds.push(finalBond);
+      try {
+        const bondMetadata: IBondV2Meta = await liveBondMetadataPromises[i];
+        const bondTerms: IBondV2Terms = await liveBondTermsPromises[i];
+        const finalBond = await processBond(bond, bondMetadata, bondTerms, bondIndex, provider, networkID, dispatch);
+        liveBonds.push(finalBond);
 
-      if (address) {
-        dispatch(getTokenBalance({ provider, networkID, address, value: finalBond.quoteToken }));
+        if (address) {
+          dispatch(getTokenBalance({ provider, networkID, address, value: finalBond.quoteToken }));
+        }
+      } catch (e) {
+        console.log("getAllBonds Error for index: ", bondIndex, ", bond: ", bond);
+        console.log(e);
       }
     }
     return liveBonds;


### PR DESCRIPTION
1. in BondSliceV2 when a given bond contract call fails (on the backend), catch & return the other bonds
2. exclude bondsV1 from AppSlice contract calls unless isBondable || isLOLable

eliminates these contract call errors on rinkeby, also catches BondsV2 Rinkeby Index #9 which has a marketPrice error (prob because we initialized that one incorrectly during testing)
![image](https://user-images.githubusercontent.com/80423742/150012771-5be75f28-e364-4389-be34-ecd68f188855.png)
