### PR TITLE
Firefox Sidebar Styling

### DIFF
--- a/src/themes/dark.js
+++ b/src/themes/dark.js
@@ -104,9 +104,6 @@ export const dark = responsiveFontSizes(
           paper: {
             backgroundColor: darkTheme.paperBg,
             zIndex: 7,
-            "@supports not ((-webkit-backdrop-filter: none) or (backdrop-filter: none))": {
-              backgroundColor: "rgba(54, 56, 64, 0.98)",
-            },
           },
         },
         MuiSelect: {

--- a/src/themes/light.js
+++ b/src/themes/light.js
@@ -116,9 +116,6 @@ export const light = responsiveFontSizes(
           paper: {
             backgroundColor: lightTheme.backdropBg,
             zIndex: 7,
-            "@supports not ((-webkit-backdrop-filter: none) or (backdrop-filter: none))": {
-              backgroundColor: "rgba(255, 255, 255, 0.98)",
-            },
           },
         },
         MuiBackdrop: {


### PR DESCRIPTION
There were conditional set to apply an additional layer of background color over an already globally set background color for firefox browsers. This skewed the sidebar menu opacity significantly darker. Removing this brings alignment to what users already see in other browsers.
# Before:
<img src="https://user-images.githubusercontent.com/95196612/150595717-d7c988f6-583d-43e7-9791-902cc1942508.png" height="600"><img src="https://user-images.githubusercontent.com/95196612/150595731-fb28a9bb-a394-4774-8e7d-603d7c71faad.png" height="600">
# After:
<img src="https://user-images.githubusercontent.com/95196612/150595782-26c34c28-79fe-4a58-aeb0-66293c2785ab.png" height="600"><img src="https://user-images.githubusercontent.com/95196612/150595803-4648e00f-7a7d-4da1-98ca-e7161bdf6f80.png" height="600">

