### PR TITLE
fix unwrap issue

### DIFF
--- a/src/views/Wrap/Wrap.tsx
+++ b/src/views/Wrap/Wrap.tsx
@@ -87,7 +87,8 @@ const Wrap: React.FC = () => {
     return 0;
   }, [unwrapGohmAllowance, wrapSohmAllowance, assetTo, assetFrom, sohmBalance, gohmBalance]);
 
-  const isAllowanceDataLoading = currentAction === "Unwrap from";
+  // @ts-ignore
+  const isAllowanceDataLoading = currentAction === "Unwrap";
   // const convertedQuantity = 0;
   const convertedQuantity = useMemo(() => {
     if (assetFrom === "sOHM") {


### PR DESCRIPTION
I initially migrated the wrap function to a TypeScript component. In doing so I introduced a bug which has been logged today under issues. TypeScript was initially complaining about this line of code, so I changed it to satisfy the compiler, in doing so it introduced the bug shown in - https://github.com/OlympusDAO/olympus-frontend/issues/1320

I've reverted this change and just added an @ts-ignore comment to keep the compiler happy.

Reproduced the bug on Rinkeby and tested the fix working on Rinkeby.