### PR TITLE
Ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ cache
 .vscode
 
 src/typechain
+
+# We use Yarn - prevent this file from being committed to avoid confusion
+package-lock.json


### PR DESCRIPTION
Prevent this irrelevant file from being committed. It being present could lead people to assume that we use npm (instead of yarn), and we would then have a parallel lock file that could cause problems.