### PR TITLE
Adding Rinkeby Contracts for FRAX and DAI to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,19 +66,25 @@ To run the tests:
 
 ## Rinkeby Testing
 
-**Rinkeby faucet for sOHM:**
-[Lives here](https://rinkeby.etherscan.io/address/0x800B3d87b77361F0D1d903246cA1F51b5acb43c9#writeContract), to retrieve test sOHM click `Connect to Web3` and use function #3: `dripSOHM`. After connecting to web3, click `Write` to execute and 10 sOHM will automatically be transferred to your connected wallet.
+### sOHM Faucet
+- [0x800B3d87b77361F0D1d903246cA1F51b5acb43c9](https://rinkeby.etherscan.io/address/0x800B3d87b77361F0D1d903246cA1F51b5acb43c9#writeContract)
+- to retrieve test sOHM click `Connect to Web3` and use function #3: `dripSOHM`. 
+- After connecting to web3, click `Write` to execute and 10 sOHM will automatically be transferred to your connected wallet.
 
 Note: The faucet is limited to one transfer per wallet every 6500 blocks (~1 day)
 
-**Rinkeby faucet for WETH:**
+### wETH Faucet
 [Wrap rinkeby eth on rinkeby uniswap](https://app.uniswap.org/#/swap)
 
-**Rinkeby faucets for LUSD, FRAX & DAI can be taken from rinkeby etherscan:**
+### DAI Faucets
+- [0xb2180448f8945c8cc8ae9809e67d6bd27d8b2f2c](https://rinkeby.etherscan.io/address/0xb2180448f8945c8cc8ae9809e67d6bd27d8b2f2c#writeContract)
+- [0x5ed8bd53b0c3fa3deabd345430b1a3a6a4e8bd7c](https://rinkeby.etherscan.io/address/0x5ed8bd53b0c3fa3deabd345430b1a3a6a4e8bd7c#writeContract)
+-  use the `mint` function. You can use the number helper for 10^18 & then add four more zeros for 10,000 units of whichever reserve you are minting.
 
-1. Go to `src/helpers/AllBonds.ts`
-2. Then copy the rinkeby `reserveAddress` for the applicable bond & navigate to that contract on rinkeby etherscan.
-3. On Rinkeby etherscan use the `mint` function. You can use the number helper for 10^18 & then add four more zeros for 10,000 units of whichever reserve you are minting.
+### FRAX Faucet
+- [0x2f7249cb599139e560f0c81c269ab9b04799e453](https://rinkeby.etherscan.io/address/0x2f7249cb599139e560f0c81c269ab9b04799e453#writeContract)
+-  use the `mint` function. You can use the number helper for 10^18 & then add four more zeros for 10,000 units of whichever reserve you are minting.
+
 
 ## Avax Fuji Testnet
 


### PR DESCRIPTION
Adding Rinkeby Contracts to Readme for FRAX and DAI / minting instructions