### PR TITLE
handling paper on paper case where we dont want a transparent bg

### DIFF
--- a/src/themes/dark.js
+++ b/src/themes/dark.js
@@ -120,6 +120,9 @@ export const dark = responsiveFontSizes(
             "&.ohm-modal": {
               backgroundColor: darkTheme.modalBg,
             },
+            "&.MuiPaper-root.tooltip-container": {
+              backgroundColor: darkTheme.paperBg,
+            },
             "&.ohm-menu": {
               backgroundColor: darkTheme.menuBg,
               backdropFilter: "blur(33px)",

--- a/src/themes/light.js
+++ b/src/themes/light.js
@@ -98,6 +98,9 @@ export const light = responsiveFontSizes(
             "&.ohm-card": {
               backgroundColor: lightTheme.paperBg,
             },
+            "&.MuiPaper-root.tooltip-container": {
+              backgroundColor: lightTheme.paperBg,
+            },
             "&.ohm-modal": {
               backgroundColor: lightTheme.modalBg,
             },


### PR DESCRIPTION
Component-Library defaults a child paper element to a transparent background, since 99% of the time we would not want to layer our backgrounds.
![image](https://user-images.githubusercontent.com/95196612/151271841-abe75f0f-da25-4515-bb81-3c85abb05b2d.png)
![image](https://user-images.githubusercontent.com/95196612/151271854-c1ab04a3-1b80-4a09-848d-8313d3cc2bc2.png)
 
There is a case where sometimes a tooltip, specifically treasury dashboard tooltips, are rendered as a child and not a sibling. This theme update handles that case where we'd want to display the paper background.
```jsx
<Paper>
   Parent Paper
  <Paper>ChildPaper</Paper>
<Paper>
```

