### PR TITLE
fix: manifest 401 error in dev console

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@
       content="Olympus utilizes Treasury Reserves to enable long-term price consistency and scarcity within an infinite supply system" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
 
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" crossorigin="use-credentials" />
     <title>OlympusDAO</title>
   </head>
 


### PR DESCRIPTION
In dev mode, Chrome shows 401 error in console. See attachment.
Solution is to explicitly set cors attribute for manifest reference.

Context of the fix:
- https://medium.com/@aurelien.delogu/401-error-on-a-webmanifest-file-cb9e3678b9f3
- https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin#example_webmanifest_with_credentials

![Screen Shot 2022-01-31 at 4 50 11 PM](https://user-images.githubusercontent.com/2234901/151889283-79d7d5d6-b64d-478f-a17a-b9c2477cf1dd.png)


Signed-off-by: ivelin <ivelin@ambianic.ai>