### PR TITLE
Add SSH key management to GitPod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,11 @@
 tasks:
-  - before: rm -rf ~/.ssh; mkdir -p /workspace/.ssh; ln -sf /workspace.ssh ~/.ssh
+  - name: Shell
+    before: echo "Setting up SSH environment"; rm -rf ~/.ssh; mkdir -p /workspace/.ssh; ln -sf /workspace.ssh ~/.ssh
     # The ~/.ssh directory will be removed between workspace runs
     # We store it on /workspace/ instead and link it
     # We also ensure that ssh-agent is added
     # Your own keys will need to be added
-    init: eval $(ssh-agent -s)
+    command: eval $(ssh-agent -s)
   - name: App
     init: |
       # bring in secret access tokens from gitpod user dashboard

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,11 +1,4 @@
 tasks:
-  - name: Shell
-    before: echo "Setting up SSH environment"; rm -rf ~/.ssh; mkdir -p /workspace/.ssh; ln -sf /workspace/.ssh ~/.ssh
-    # The ~/.ssh directory will be removed between workspace runs
-    # We store it on /workspace/ instead and link it
-    # We also ensure that ssh-agent is added
-    # Your own keys will need to be added through ssh-add or ~/.ssh/config
-    command: eval $(ssh-agent -s)
   - name: App
     init: |
       # bring in secret access tokens from gitpod user dashboard
@@ -30,6 +23,18 @@ tasks:
       yarn test --clearCache
       yarn test:unit
     openMode: split-right
+  - name: Shell
+    # The ~/.ssh directory will be removed between workspace runs
+    # We store it on /workspace/ instead and link it
+    # We also ensure that ssh-agent is added
+    # Your own keys will need to be added through ssh-add or ~/.ssh/config
+    before: |
+      echo "Setting up SSH environment"
+      rm -rf ~/.ssh
+      mkdir -p /workspace/.ssh
+      ln -sf /workspace/.ssh ~/.ssh
+    command: eval $(ssh-agent -s)
+    openMode: tab-after
 ports:
   - port: 3000
     onOpen: open-preview

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,6 @@
 tasks:
   - name: Shell
-    before: echo "Setting up SSH environment"; rm -rf ~/.ssh; mkdir -p /workspace/.ssh; ln -sf /workspace.ssh ~/.ssh
+    before: echo "Setting up SSH environment"; rm -rf ~/.ssh; mkdir -p /workspace/.ssh; ln -sf /workspace/.ssh ~/.ssh
     # The ~/.ssh directory will be removed between workspace runs
     # We store it on /workspace/ instead and link it
     # We also ensure that ssh-agent is added

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,7 +4,7 @@ tasks:
     # The ~/.ssh directory will be removed between workspace runs
     # We store it on /workspace/ instead and link it
     # We also ensure that ssh-agent is added
-    # Your own keys will need to be added
+    # Your own keys will need to be added through ssh-add or ~/.ssh/config
     command: eval $(ssh-agent -s)
   - name: App
     init: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,10 @@
 tasks:
+  - before: rm -rf ~/.ssh; mkdir -p /workspace/.ssh; ln -sf /workspace.ssh ~/.ssh
+    # The ~/.ssh directory will be removed between workspace runs
+    # We store it on /workspace/ instead and link it
+    # We also ensure that ssh-agent is added
+    # Your own keys will need to be added
+    init: eval $(ssh-agent -s)
   - name: App
     init: |
       # bring in secret access tokens from gitpod user dashboard

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -43,3 +43,5 @@ vscode:
   extensions:
     - dbaeumer.vscode-eslint
     - esbenp.prettier-vscode
+    - mhutchie.git-graph
+    - bmuskalla.vscode-tldr


### PR DESCRIPTION
This persists SSH keys between runs in a GitPod workspace, as suggested here: https://github.com/gitpod-io/gitpod/issues/8006#issuecomment-1029210923

It also runs ssh-agent.