### PR TITLE
move this one component back to muipaper

### DIFF
--- a/src/components/GiveProject/ProjectCard.tsx
+++ b/src/components/GiveProject/ProjectCard.tsx
@@ -5,6 +5,7 @@ import {
   Grid,
   LinearProgress,
   Link,
+  Paper as MuiPaper,
   SvgIcon,
   Tooltip,
   Typography,
@@ -669,7 +670,7 @@ export default function ProjectCard({ project, mode }: ProjectDetailsProps) {
                     paddingLeft: "1rem",
                   }}
                 >
-                  <Paper className="project-sidebar">
+                  <MuiPaper className="project-sidebar">
                     <Grid container className="project-intro" justifyContent="space-between">
                       <Grid item className="project-title">
                         <Link href={"#/give"}>
@@ -716,9 +717,9 @@ export default function ProjectCard({ project, mode }: ProjectDetailsProps) {
                         {renderCountdownDetailed()}
                       </Grid>
                     </Grid>
-                  </Paper>
+                  </MuiPaper>
                   {isUserDonating ? (
-                    <Paper className="project-sidebar">
+                    <MuiPaper className="project-sidebar">
                       <div className="project-sidebar-header">
                         <Typography variant="h5">
                           <strong>
@@ -760,7 +761,7 @@ export default function ProjectCard({ project, mode }: ProjectDetailsProps) {
                           </PrimaryButton>
                         </div>
                       </div>
-                    </Paper>
+                    </MuiPaper>
                   ) : (
                     <></>
                   )}


### PR DESCRIPTION
hey @0xJem! I would recommend moving this back to the MuiPaper component. I know it doesnt sound ideal, but
there's a lot going on here that's not really standard to the rest of our paper implementation so it's a little bit of a square peg in a round hole, and we're not really gaining much by moving to component-library paper since we're still applying/overriding additional styles. 

We make some assumptions with our paper component that are causing issues here. In large part because we've got this Give page with a Box wrapping a Grid container wrapping a paper component which then also includes its own grid container. Because of this and flex-box behavior the `flex-wrap: wrap` style causes complications with your highest level grid here. This is a default style with MuiPaper, but the multilayer containers are what's causing the extra spacing at the bottom of the cell with flex-wrap

We can revisit additional flexibility with our paper component to support cases like this, but because everything else is relatively standardized, it'd potentially mean having to refactor all of our other views using component-library paper to make this work.

LMK if this helps (or doesn't :) ) 