### PR TITLE
Optimize lint-staged pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,8 @@
   },
   "lint-staged": {
     "!(src/locales)src/**/*.{ts,tsx,js,jsx}": [
-      "yarn lint --fix"
+      "eslint --fix",
+      "prettier --write"
     ]
   }
 }


### PR DESCRIPTION
Lint staged pre-commit hook takes for execution too much time, because it fixes all files in the project.

In lint-staged docs there is example how it works https://github.com/okonet/lint-staged#packagejson-example
Lint-staged is designed to run linters against only staged files, so it shouldn't be used for linting all files