### PR TITLE
Improve code coverage reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "coverageReporters": [
       "text",
       "json-summary",
-      "text-summary"
+      "text-summary",
+      "lcov"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
Adds `lcov` as a jest reporter, which enables VSCode extensions (like coverage gutters) to give line-by-line coverage in the editor.