### PR TITLE
fix centering of give-info on mobile

### DIFF
--- a/src/views/Give/Give.scss
+++ b/src/views/Give/Give.scss
@@ -451,6 +451,7 @@
 
   .give-info {
     width: 315px;
+    margin: auto;
 
     .give-info-deposit-box {
       margin-right: 0px;
@@ -546,7 +547,7 @@
 
   .give-info {
     width: 220px;
-    margin: auto; 
+    margin: auto;
 
     .give-info-deposit-box {
       margin-right: 0px;

--- a/src/views/Give/Give.scss
+++ b/src/views/Give/Give.scss
@@ -546,6 +546,7 @@
 
   .give-info {
     width: 220px;
+    margin: auto; 
 
     .give-info-deposit-box {
       margin-right: 0px;


### PR DESCRIPTION
before:
_mobile screen_
<img width="212" alt="image" src="https://user-images.githubusercontent.com/80423742/158252452-76b671c6-a1b4-4cd1-b251-86fd69ef5372.png">
_tablet_
<img width="330" alt="image" src="https://user-images.githubusercontent.com/80423742/158252643-0d44f425-16b7-459f-b063-0d972699dd62.png">


after:
_mobile_
<img width="210" alt="image" src="https://user-images.githubusercontent.com/80423742/158252496-ba6c345d-0419-40b4-99c0-586895779174.png">
_tablet_
<img width="329" alt="image" src="https://user-images.githubusercontent.com/80423742/158253144-8b67a22a-9746-4ada-894c-708a96f24d4d.png">
