### PR TITLE
add --silent flag to suppress warnings in ci logs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run unit tests
         uses: ArtiomTr/jest-coverage-report-action@v2.0.5
         with:
-          test-script: yarn test:unit
+          test-script: yarn test:unit --silent
           skip-step: install
           package-manager: yarn
       - name: Prepare coverage badges


### PR DESCRIPTION
Our jest logs have a ton of warnings... figure we can suppress them for now & make it easier to follow the errors.