### PR TITLE
Fix bond list padding on side navbar

### DIFF
--- a/src/components/Sidebar/NavContent.tsx
+++ b/src/components/Sidebar/NavContent.tsx
@@ -126,7 +126,7 @@ const NavContent: React.VFC = () => {
 const Bonds: React.VFC = () => {
   const bonds = useLiveBonds().data;
 
-  if (!bonds) return null;
+  if (!bonds || bonds.length === 0) return null;
 
   return (
     <Box ml="26px" mt="16px" mb="12px">


### PR DESCRIPTION
Fixes a UI issue in the side navbar where when there are no active bonds, an empty list is rendered with enough padding to create an awkward amount of spacing between links