### PR TITLE
Show successful claimable bonds when query fails

### DIFF
--- a/src/views/Bond/components/ClaimBonds/hooks/useBondNotes.ts
+++ b/src/views/Bond/components/ClaimBonds/hooks/useBondNotes.ts
@@ -44,7 +44,7 @@ export const fetchBondNotes = async (networkId: NetworkId.MAINNET | NetworkId.TE
 
   const ids = await contract.indexesFor(address).then(ids => ids.map(id => id.toString()));
 
-  return Promise.all(
+  const promises = await Promise.allSettled(
     ids.map(async id => {
       const note = await contract.notes(address, id);
 
@@ -61,4 +61,8 @@ export const fetchBondNotes = async (networkId: NetworkId.MAINNET | NetworkId.TE
       };
     }),
   );
+
+  return promises
+    .filter(({ status }) => status === "fulfilled")
+    .map(promise => (promise as PromiseFulfilledResult<BondNote>).value);
 };


### PR DESCRIPTION
Fixes an issue with the claim bonds list where if any single query failed while fetching the bond data, no claimable bonds would be rendered in the list. Now, it will still render the rows that were successful and only hide the ones that failed.