### PR TITLE
move to percentage based skeleton width on Farm Pool Table

### DIFF
--- a/src/__tests__/__snapshots__/App.unit.test.jsx.snap
+++ b/src/__tests__/__snapshots__/App.unit.test.jsx.snap
@@ -1479,7 +1479,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -1492,7 +1492,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -1676,7 +1676,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -1689,7 +1689,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -1847,7 +1847,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -1860,7 +1860,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -2082,7 +2082,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -2095,7 +2095,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -2317,7 +2317,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -2330,7 +2330,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -2524,7 +2524,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -2537,7 +2537,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -3103,7 +3103,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -3116,7 +3116,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -3321,7 +3321,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -3334,7 +3334,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -4870,7 +4870,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -4883,7 +4883,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -5067,7 +5067,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -5080,7 +5080,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -5238,7 +5238,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -5251,7 +5251,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -5473,7 +5473,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -5486,7 +5486,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -5708,7 +5708,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -5721,7 +5721,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -5915,7 +5915,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -5928,7 +5928,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -6494,7 +6494,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -6507,7 +6507,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -6712,7 +6712,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -6725,7 +6725,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -8261,7 +8261,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -8274,7 +8274,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -8458,7 +8458,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -8471,7 +8471,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -8629,7 +8629,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -8642,7 +8642,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -8864,7 +8864,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -8877,7 +8877,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -9099,7 +9099,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -9112,7 +9112,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -9306,7 +9306,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -9319,7 +9319,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -9885,7 +9885,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -9898,7 +9898,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -10103,7 +10103,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -10116,7 +10116,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>

--- a/src/__tests__/__snapshots__/Root.unit.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Root.unit.test.tsx.snap
@@ -1543,7 +1543,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -1556,7 +1556,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -1740,7 +1740,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -1753,7 +1753,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -1911,7 +1911,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -1924,7 +1924,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -2146,7 +2146,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -2159,7 +2159,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -2381,7 +2381,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -2394,7 +2394,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -2588,7 +2588,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -2601,7 +2601,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -3167,7 +3167,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -3180,7 +3180,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -3385,7 +3385,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>
@@ -3398,7 +3398,7 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root-591 MuiSkeleton-text-592 MuiSkeleton-pulse-595"
-                        style="width: 80px;"
+                        style="width: 100%;"
                       />
                     </p>
                   </td>

--- a/src/views/Stake/__tests__/__snapshots__/Stake.unit.test.tsx.snap
+++ b/src/views/Stake/__tests__/__snapshots__/Stake.unit.test.tsx.snap
@@ -691,7 +691,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -704,7 +704,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -888,7 +888,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -901,7 +901,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1059,7 +1059,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1072,7 +1072,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1294,7 +1294,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1307,7 +1307,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1529,7 +1529,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1542,7 +1542,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1736,7 +1736,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1749,7 +1749,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -2315,7 +2315,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -2328,7 +2328,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -2533,7 +2533,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -2546,7 +2546,7 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -3291,7 +3291,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -3304,7 +3304,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -3488,7 +3488,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -3501,7 +3501,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -3659,7 +3659,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -3672,7 +3672,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -3894,7 +3894,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -3907,7 +3907,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4129,7 +4129,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4142,7 +4142,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4336,7 +4336,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4349,7 +4349,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4915,7 +4915,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4928,7 +4928,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -5133,7 +5133,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -5146,7 +5146,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>

--- a/src/views/Stake/components/ExternalStakePools/ExternalStakePools.tsx
+++ b/src/views/Stake/components/ExternalStakePools/ExternalStakePools.tsx
@@ -131,12 +131,12 @@ const StakePool: React.FC<{ pool: ExternalPool; tvl?: number; apy?: number }> = 
       </TableCell>
       <TableCell>
         <Typography gutterBottom={false} style={{ lineHeight: 1.4 }}>
-          {!props.tvl ? <Skeleton width={80} /> : formatCurrency(props.tvl)}
+          {!props.tvl ? <Skeleton width="100%" /> : formatCurrency(props.tvl)}
         </Typography>
       </TableCell>
       <TableCell>
         <Typography gutterBottom={false} style={{ lineHeight: 1.4 }}>
-          {!props.apy ? <Skeleton width={80} /> : `${formatNumber(props.apy * 100, 2)}%`}
+          {!props.apy ? <Skeleton width="100%" /> : `${formatNumber(props.apy * 100, 2)}%`}
         </Typography>
       </TableCell>
       <TableCell>
@@ -144,7 +144,7 @@ const StakePool: React.FC<{ pool: ExternalPool; tvl?: number; apy?: number }> = 
           {!connected ? (
             ""
           ) : !userBalance ? (
-            <Skeleton width={80} />
+            <Skeleton width="100%" />
           ) : (
             `${userBalance.toString({ decimals: 4, trim: false, format: true })} LP`
           )}

--- a/src/views/V1-Stake/__tests__/__snapshots__/V1-Stake.unit.test.tsx.snap
+++ b/src/views/V1-Stake/__tests__/__snapshots__/V1-Stake.unit.test.tsx.snap
@@ -993,7 +993,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1006,7 +1006,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1190,7 +1190,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1203,7 +1203,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1361,7 +1361,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1374,7 +1374,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1596,7 +1596,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1609,7 +1609,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1831,7 +1831,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -1844,7 +1844,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -2038,7 +2038,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -2051,7 +2051,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -2617,7 +2617,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -2630,7 +2630,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -2835,7 +2835,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -2848,7 +2848,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -3897,7 +3897,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -3910,7 +3910,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -3923,7 +3923,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4099,7 +4099,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4112,7 +4112,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4125,7 +4125,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4275,7 +4275,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4288,7 +4288,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4301,7 +4301,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4515,7 +4515,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4528,7 +4528,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4541,7 +4541,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4755,7 +4755,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4768,7 +4768,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4781,7 +4781,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4967,7 +4967,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4980,7 +4980,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -4993,7 +4993,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -5551,7 +5551,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -5564,7 +5564,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -5577,7 +5577,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -5774,7 +5774,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -5787,7 +5787,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -5800,7 +5800,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -6841,7 +6841,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -6854,7 +6854,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -6867,7 +6867,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -7043,7 +7043,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -7056,7 +7056,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -7069,7 +7069,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -7219,7 +7219,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -7232,7 +7232,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -7245,7 +7245,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -7459,7 +7459,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -7472,7 +7472,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -7485,7 +7485,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -7699,7 +7699,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -7712,7 +7712,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -7725,7 +7725,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -7911,7 +7911,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -7924,7 +7924,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -7937,7 +7937,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -8495,7 +8495,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -8508,7 +8508,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -8521,7 +8521,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -8718,7 +8718,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -8731,7 +8731,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -8744,7 +8744,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -9785,7 +9785,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -9798,7 +9798,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -9811,7 +9811,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -9987,7 +9987,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -10000,7 +10000,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -10013,7 +10013,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -10163,7 +10163,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -10176,7 +10176,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -10189,7 +10189,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -10403,7 +10403,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -10416,7 +10416,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -10429,7 +10429,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -10643,7 +10643,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -10656,7 +10656,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -10669,7 +10669,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -10855,7 +10855,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -10868,7 +10868,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -10881,7 +10881,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -11439,7 +11439,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -11452,7 +11452,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -11465,7 +11465,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -11662,7 +11662,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -11675,7 +11675,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>
@@ -11688,7 +11688,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 80px;"
+                    style="width: 100%;"
                   />
                 </p>
               </td>


### PR DESCRIPTION
Skeleton width is fixed at 80px. This causes overflow when multiple values are loading. See right margin.
<img width="870" alt="image" src="https://user-images.githubusercontent.com/95196612/163622189-9c7302d0-d1fd-4618-87cd-49bbeea853f9.png">

This shifts loading indicators to percentages.
<img width="901" alt="image" src="https://user-images.githubusercontent.com/95196612/163622249-c5678a34-28a5-4f81-a325-0a06bcd45413.png">

