### PR TITLE
Improve decimal big number API

### DIFF
--- a/src/helpers/DecimalBigNumber/DecimalBigNumber.ts
+++ b/src/helpers/DecimalBigNumber/DecimalBigNumber.ts
@@ -83,8 +83,8 @@ export class DecimalBigNumber {
    * Often used when passing this value as
    * an argument to a contract method
    */
-  public toBigNumber(): BigNumber {
-    return this._value;
+  public toBigNumber(decimals?: number): BigNumber {
+    return decimals === undefined ? this._value : new DecimalBigNumber(this.toString(), decimals)._value;
   }
 
   /**
@@ -104,12 +104,12 @@ export class DecimalBigNumber {
    */
   public toString({
     decimals,
-    format = false,
     trim = true,
+    format = false,
   }: {
-    decimals?: number;
     trim?: boolean;
     format?: boolean;
+    decimals?: number;
   } = {}): string {
     let result = formatUnits(this._value, this._decimals);
 

--- a/src/helpers/DecimalBigNumber/DecimalBigNumber.ts
+++ b/src/helpers/DecimalBigNumber/DecimalBigNumber.ts
@@ -142,82 +142,94 @@ export class DecimalBigNumber {
   /**
    * Determines if the two values are equal
    */
-  public eq(value: DecimalBigNumber): boolean {
+  public eq(value: DecimalBigNumber | string): boolean {
+    const valueAsDBN = value instanceof DecimalBigNumber ? value : new DecimalBigNumber(value);
+
     // Normalize decimals to the largest of the two values
-    const decimals = Math.max(value._decimals, this._decimals);
+    const largestDecimalAmount = Math.max(valueAsDBN._decimals, this._decimals);
 
     // Normalize values to the correct decimal amount
-    const _this = new DecimalBigNumber(this.toString(), decimals);
-    const _value = new DecimalBigNumber(value.toString(), decimals);
+    const normalisedThis = new DecimalBigNumber(this.toString(), largestDecimalAmount);
+    const normalisedValue = new DecimalBigNumber(valueAsDBN.toString(), largestDecimalAmount);
 
-    return _this._value.eq(_value._value);
+    return normalisedThis._value.eq(normalisedValue._value);
   }
 
   /**
    * Subtracts this value by the value provided
    */
-  public sub(value: DecimalBigNumber): DecimalBigNumber {
+  public sub(value: DecimalBigNumber | string): DecimalBigNumber {
+    const valueAsDBN = value instanceof DecimalBigNumber ? value : new DecimalBigNumber(value);
+
     // Normalize decimals to the largest of the two values
-    const decimals = Math.max(value._decimals, this._decimals);
+    const largestDecimalAmount = Math.max(valueAsDBN._decimals, this._decimals);
 
     // Normalize values to the correct decimal amount
-    const _this = new DecimalBigNumber(this.toString(), decimals);
-    const _value = new DecimalBigNumber(value.toString(), decimals);
+    const normalisedThis = new DecimalBigNumber(this.toString(), largestDecimalAmount);
+    const normalisedValue = new DecimalBigNumber(valueAsDBN.toString(), largestDecimalAmount);
 
-    return new DecimalBigNumber(_this._value.sub(_value._value), decimals);
+    return new DecimalBigNumber(normalisedThis._value.sub(normalisedValue._value), largestDecimalAmount);
   }
 
   /**
    * Sums this value and the value provided
    */
-  public add(value: DecimalBigNumber): DecimalBigNumber {
+  public add(value: DecimalBigNumber | string): DecimalBigNumber {
+    const valueAsDBN = value instanceof DecimalBigNumber ? value : new DecimalBigNumber(value);
+
     // Normalize decimals to the largest of the two values
-    const decimals = Math.max(value._decimals, this._decimals);
+    const largestDecimalAmount = Math.max(valueAsDBN._decimals, this._decimals);
 
     // Normalize values to the correct decimal amount
-    const _this = new DecimalBigNumber(this.toString(), decimals);
-    const _value = new DecimalBigNumber(value.toString(), decimals);
+    const normalisedThis = new DecimalBigNumber(this.toString(), largestDecimalAmount);
+    const normalisedValue = new DecimalBigNumber(valueAsDBN.toString(), largestDecimalAmount);
 
-    return new DecimalBigNumber(_this._value.add(_value._value), decimals);
+    return new DecimalBigNumber(normalisedThis._value.add(normalisedValue._value), largestDecimalAmount);
   }
 
   /**
    * Determines if this value is greater than the provided value
    */
-  public gt(value: DecimalBigNumber): boolean {
+  public gt(value: DecimalBigNumber | string): boolean {
+    const valueAsDBN = value instanceof DecimalBigNumber ? value : new DecimalBigNumber(value);
+
     // Normalize decimals to the largest of the two values
-    const decimals = Math.max(value._decimals, this._decimals);
+    const largestDecimalAmount = Math.max(valueAsDBN._decimals, this._decimals);
 
     // Normalize values to the correct decimal amount
-    const _this = new DecimalBigNumber(this.toString(), decimals);
-    const _value = new DecimalBigNumber(value.toString(), decimals);
+    const normalisedThis = new DecimalBigNumber(this.toString(), largestDecimalAmount);
+    const normalisedValue = new DecimalBigNumber(valueAsDBN.toString(), largestDecimalAmount);
 
-    return _this._value.gt(_value._value);
+    return normalisedThis._value.gt(normalisedValue._value);
   }
 
   /**
    * Determines if this value is less than the provided value
    */
-  public lt(value: DecimalBigNumber): boolean {
+  public lt(value: DecimalBigNumber | string): boolean {
+    const valueAsDBN = value instanceof DecimalBigNumber ? value : new DecimalBigNumber(value);
+
     // Normalize decimals to the largest of the two values
-    const decimals = Math.max(value._decimals, this._decimals);
+    const largestDecimalAmount = Math.max(valueAsDBN._decimals, this._decimals);
 
     // Normalize values to the correct decimal amount
-    const _this = new DecimalBigNumber(this.toString(), decimals);
-    const _value = new DecimalBigNumber(value.toString(), decimals);
+    const normalisedThis = new DecimalBigNumber(this.toString(), largestDecimalAmount);
+    const normalisedValue = new DecimalBigNumber(valueAsDBN.toString(), largestDecimalAmount);
 
-    return _this._value.lt(_value._value);
+    return normalisedThis._value.lt(normalisedValue._value);
   }
 
   /**
    * Multiplies this value by the provided value
    */
-  public mul(value: DecimalBigNumber): DecimalBigNumber {
-    const product = this._value.mul(value._value);
+  public mul(value: DecimalBigNumber | string): DecimalBigNumber {
+    const valueAsDBN = value instanceof DecimalBigNumber ? value : new DecimalBigNumber(value);
+
+    const product = this._value.mul(valueAsDBN._value);
 
     // Multiplying two BigNumbers produces a product with a decimal
     // amount equal to the sum of the decimal amounts of the two input numbers
-    return new DecimalBigNumber(product, this._decimals + value._decimals);
+    return new DecimalBigNumber(product, this._decimals + valueAsDBN._decimals);
   }
 
   /**
@@ -230,8 +242,10 @@ export class DecimalBigNumber {
    *
    * @param decimals The expected decimal amount of the output value
    */
-  public div(value: DecimalBigNumber, decimals?: number): DecimalBigNumber {
-    const _decimals = decimals === undefined ? this._decimals + value._decimals : this._ensurePositive(decimals);
+  public div(value: DecimalBigNumber | string, decimals?: number): DecimalBigNumber {
+    const valueAsDBN = value instanceof DecimalBigNumber ? value : new DecimalBigNumber(value);
+
+    const _decimals = decimals === undefined ? this._decimals + valueAsDBN._decimals : this._ensurePositive(decimals);
 
     // When we divide two BigNumbers, the result will never
     // include any decimal places because BigNumber only deals
@@ -254,9 +268,9 @@ export class DecimalBigNumber {
     // Normalized to the expected decimal amount of the result
     // 4.4
 
-    const _this = new DecimalBigNumber(this.toString(), _decimals + value._decimals);
+    const normalisedThis = new DecimalBigNumber(this.toString(), _decimals + valueAsDBN._decimals);
 
-    const quotient = _this._value.div(value._value);
+    const quotient = normalisedThis._value.div(valueAsDBN._value);
 
     // Return result with the expected output decimal amount
     return new DecimalBigNumber(quotient, _decimals);

--- a/src/helpers/DecimalBigNumber/DecimalBigNumber.ts
+++ b/src/helpers/DecimalBigNumber/DecimalBigNumber.ts
@@ -65,7 +65,7 @@ export class DecimalBigNumber {
 
     const _decimals = _decimalsOrUndefined || "";
 
-    const paddingRequired = Math.max(0, decimals - _decimals.length);
+    const paddingRequired = this._ensurePositive(decimals - _decimals.length);
 
     return integer + "." + _decimals.substring(0, decimals) + "0".repeat(paddingRequired);
   }
@@ -106,7 +106,11 @@ export class DecimalBigNumber {
     decimals,
     format = false,
     trim = true,
-  }: { decimals?: number; trim?: boolean; format?: boolean } = {}): string {
+  }: {
+    decimals?: number;
+    trim?: boolean;
+    format?: boolean;
+  } = {}): string {
     let result = formatUnits(this._value, this._decimals);
 
     // Add thousands separators

--- a/src/helpers/DecimalBigNumber/DecimalBigNumber.unit.test.ts
+++ b/src/helpers/DecimalBigNumber/DecimalBigNumber.unit.test.ts
@@ -158,4 +158,9 @@ describe("DecimalBigNumber", () => {
 
     expect(new DecimalBigNumber("10").div(new DecimalBigNumber("3"), 10).toString()).toEqual("3.3333333333");
   });
+
+  it("should format toBigNumber to a specified number of decimals", () => {
+    expect(new DecimalBigNumber("10", 10).toBigNumber(1).toString()).toEqual("100");
+    expect(new DecimalBigNumber("10").toBigNumber(4).toString()).toEqual("100000");
+  });
 });

--- a/src/helpers/DecimalBigNumber/DecimalBigNumber.unit.test.ts
+++ b/src/helpers/DecimalBigNumber/DecimalBigNumber.unit.test.ts
@@ -88,26 +88,31 @@ describe("DecimalBigNumber", () => {
 
   it("should add another number correctly", () => {
     expect(new DecimalBigNumber("1.1", 9).add(new DecimalBigNumber("1.2", 18)).toString()).toEqual("2.3");
+    expect(new DecimalBigNumber("1.1").add("1.2").toString()).toEqual("2.3");
     expect(new DecimalBigNumber("-1.1", 9).add(new DecimalBigNumber("-1.2", 18)).toString()).toEqual("-2.3");
   });
 
   it("should subtract another number correctly", () => {
     expect(new DecimalBigNumber("1.2", 9).sub(new DecimalBigNumber("1.1", 18)).toString()).toEqual("0.1");
+    expect(new DecimalBigNumber("1.2").sub("1.1").toString()).toEqual("0.1");
     expect(new DecimalBigNumber("1.1", 9).sub(new DecimalBigNumber("1.2", 18)).toString()).toEqual("-0.1");
   });
 
   it("should compare the magnitude against another number and determine the greater number correctly", () => {
     expect(new DecimalBigNumber("1.1", 9).gt(new DecimalBigNumber("1.2", 18))).toEqual(false);
+    expect(new DecimalBigNumber("1.1").gt("1.2")).toEqual(false);
     expect(new DecimalBigNumber("1.21", 9).gt(new DecimalBigNumber("1.2", 18))).toEqual(true);
   });
 
   it("should compare the magnitude against another number and determine the lesser number correctly", () => {
     expect(new DecimalBigNumber("1.1", 9).lt(new DecimalBigNumber("1.2", 18))).toEqual(true);
+    expect(new DecimalBigNumber("1.1").lt("1.2")).toEqual(true);
     expect(new DecimalBigNumber("1.21", 9).lt(new DecimalBigNumber("1.2", 18))).toEqual(false);
   });
 
   it("should determine if two numbers are equal", () => {
     expect(new DecimalBigNumber("1.1", 9).eq(new DecimalBigNumber("1.1", 9))).toEqual(true);
+    expect(new DecimalBigNumber("1.1").eq("1.1")).toEqual(true);
     expect(new DecimalBigNumber("1.1", 9).eq(new DecimalBigNumber("1.1", 18))).toEqual(true);
     expect(new DecimalBigNumber("1.111111111", 9).eq(new DecimalBigNumber("1.111111111000000000", 18))).toEqual(true);
     expect(new DecimalBigNumber("1.111111111", 9).eq(new DecimalBigNumber("1.111111111111111111", 18))).toEqual(false);
@@ -123,6 +128,7 @@ describe("DecimalBigNumber", () => {
     const index = new DecimalBigNumber("90", 9); // Index of 90
     expect(gohm.mul(index).toString()).toEqual("180");
     expect(index.mul(gohm).toString()).toEqual("180");
+    expect(new DecimalBigNumber("2").mul("90").toString()).toEqual("180");
 
     const decimalNumber = new DecimalBigNumber("20.12", 9);
     const secondDecimalNumber = new DecimalBigNumber("1.12", 9);
@@ -144,6 +150,7 @@ describe("DecimalBigNumber", () => {
     expect(index.div(ohm, 18).toString()).toEqual("0.5");
     expect(index.div(ohm).toString()).toEqual("0.5");
     expect(index.div(ohm, 0).toString()).toEqual("0");
+    expect(new DecimalBigNumber("180").div("90").toString()).toEqual("2");
 
     const decimalNumber = new DecimalBigNumber("2.123", 3);
     const secondDecimalNumber = new DecimalBigNumber("1.1", 1);

--- a/src/hooks/useZapExecute.ts
+++ b/src/hooks/useZapExecute.ts
@@ -60,8 +60,7 @@ export const useZapExecute = () => {
       if (!tokenAddress) throw new Error(t`The tokenAddress parameter must be set`);
 
       const minimumAmountNumber = new DecimalBigNumber(minimumAmount);
-      if (!minimumAmount || !minimumAmountNumber.gt(new DecimalBigNumber("0")))
-        throw new Error(t`Minimum amount must be greater than 0`);
+      if (!minimumAmount || !minimumAmountNumber.gt("0")) throw new Error(t`Minimum amount must be greater than 0`);
 
       if (!isSupportedChain(networkId)) {
         dispatch(error(t`Zaps are only available on Ethereum Mainnet. Please switch networks.`));

--- a/src/views/Bond/components/BondModal/components/BondInputArea/hooks/usePurchaseBond.ts
+++ b/src/views/Bond/components/BondModal/components/BondInputArea/hooks/usePurchaseBond.ts
@@ -37,10 +37,9 @@ export const usePurchaseBond = (bond: Bond) => {
       const parsedAmount = new DecimalBigNumber(amount, bond.quoteToken.decimals);
       const parsedSlippage = new DecimalBigNumber(slippage, 18);
 
-      if (!parsedAmount.gt(new DecimalBigNumber("0"))) throw new Error(t`Please enter a number greater than 0`);
+      if (!parsedAmount.gt("0")) throw new Error(t`Please enter a number greater than 0`);
 
-      if (!parsedSlippage.gt(new DecimalBigNumber("0")))
-        throw new Error(t`Please enter a slippage amount greater than 0`);
+      if (!parsedSlippage.gt("0")) throw new Error(t`Please enter a slippage amount greater than 0`);
 
       if (!balance) throw new Error(t`Please refresh your page and try again`);
 
@@ -66,7 +65,7 @@ export const usePurchaseBond = (bond: Bond) => {
       if (networkId !== networks.MAINNET)
         throw new Error(t`Please switch to the Ethereum network to purchase this bond`);
 
-      const slippageAsPercent = parsedSlippage.div(new DecimalBigNumber("100")).add(new DecimalBigNumber("1"));
+      const slippageAsPercent = parsedSlippage.div("100").add("1");
       const maxPrice = bond.price.inBaseToken.mul(slippageAsPercent);
 
       const signer = provider.getSigner();
@@ -85,7 +84,7 @@ export const usePurchaseBond = (bond: Bond) => {
         .deposit(
           bond.id,
           parsedAmount.toBigNumber(),
-          new DecimalBigNumber(maxPrice.toString(), bond.baseToken.decimals).toBigNumber(),
+          maxPrice.toBigNumber(bond.baseToken.decimals),
           recipientAddress,
           referrer,
         );

--- a/src/views/Bond/hooks/useBond.ts
+++ b/src/views/Bond/hooks/useBond.ts
@@ -156,8 +156,7 @@ export const fetchBond = async ({ id, isInverseBond, networkId }: UseBondOptions
    * Bonds are sold out if either there is no capacity left,
    * or the maximum has been paid out for a specific interval.
    */
-  const ONE = new DecimalBigNumber("1");
-  const isSoldOut = ONE.gt(capacityInBaseToken) || ONE.gt(maxPayoutInBaseToken);
+  const isSoldOut = capacityInBaseToken.lt("1") || maxPayoutInBaseToken.lt("1");
 
   return {
     id,

--- a/src/views/Stake/components/StakeArea/components/StakeInputArea/hooks/useStakeToken.ts
+++ b/src/views/Stake/components/StakeArea/components/StakeInputArea/hooks/useStakeToken.ts
@@ -24,7 +24,7 @@ export const useStakeToken = (toToken: "sOHM" | "gOHM") => {
 
       const _amount = new DecimalBigNumber(amount, 9);
 
-      if (!_amount.gt(new DecimalBigNumber("0", 9))) throw new Error(t`Please enter a number greater than 0`);
+      if (!_amount.gt("0")) throw new Error(t`Please enter a number greater than 0`);
 
       if (!balance) throw new Error(t`Please refresh your page and try again`);
 

--- a/src/views/Stake/components/StakeArea/components/StakeInputArea/hooks/useUnstakeToken.ts
+++ b/src/views/Stake/components/StakeArea/components/StakeInputArea/hooks/useUnstakeToken.ts
@@ -26,7 +26,7 @@ export const useUnstakeToken = (fromToken: "sOHM" | "gOHM") => {
 
       const _amount = new DecimalBigNumber(amount, fromToken === "gOHM" ? 18 : 9);
 
-      if (!_amount.gt(new DecimalBigNumber("0", 9))) throw new Error(t`Please enter a number greater than 0`);
+      if (!_amount.gt("0")) throw new Error(t`Please enter a number greater than 0`);
 
       if (!balance) throw new Error(t`Please refresh your page and try again`);
 

--- a/src/views/Wrap/components/MigrateInputArea/hooks/useMigrateWsohm.tsx
+++ b/src/views/Wrap/components/MigrateInputArea/hooks/useMigrateWsohm.tsx
@@ -24,7 +24,7 @@ export const useMigrateWsohm = () => {
 
       const _amount = new DecimalBigNumber(amount, 18);
 
-      if (!_amount.gt(new DecimalBigNumber("0", 18))) throw new Error(t`Please enter a number greater than 0`);
+      if (!_amount.gt("0")) throw new Error(t`Please enter a number greater than 0`);
 
       if (!contract || (networkId !== networks.AVALANCHE && networkId !== networks.ARBITRUM))
         throw new Error(t`Please switch to the Abritrum or Avalanche networks to migrate`);

--- a/src/views/Wrap/components/WrapInputArea/hooks/useUnwrapGohm.tsx
+++ b/src/views/Wrap/components/WrapInputArea/hooks/useUnwrapGohm.tsx
@@ -24,7 +24,7 @@ export const useUnwrapGohm = () => {
 
       const _amount = new DecimalBigNumber(amount, 18);
 
-      if (!_amount.gt(new DecimalBigNumber("0", 18))) throw new Error(t`Please enter a number greater than 0`);
+      if (!_amount.gt("0")) throw new Error(t`Please enter a number greater than 0`);
 
       if (!balance) throw new Error(t`Please refresh your page and try again`);
 

--- a/src/views/Wrap/components/WrapInputArea/hooks/useWrapSohm.tsx
+++ b/src/views/Wrap/components/WrapInputArea/hooks/useWrapSohm.tsx
@@ -24,7 +24,7 @@ export const useWrapSohm = () => {
 
       const _amount = new DecimalBigNumber(amount, 9);
 
-      if (!_amount.gt(new DecimalBigNumber("0", 9))) throw new Error(t`Please enter a number greater than 0`);
+      if (!_amount.gt("0")) throw new Error(t`Please enter a number greater than 0`);
 
       if (!balance) throw new Error(t`Please refresh your page and try again`);
 


### PR DESCRIPTION
Adds two improvements to DecimalBigNumber:

1. When performing calculations, you can use a `string` as a shorthand input
2. `toBigNumber` now has an optional argument to specify decimals of the return value