### PR TITLE
only render migration notification if old assets are detected

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -282,6 +282,14 @@ function App() {
     if (isSidebarExpanded) handleSidebarClose();
   }, [location]);
 
+  const MigrationNotification = () => {
+    return hasDust ? (
+      <MigrationModalSingle open={migrationModalOpen} handleClose={migModalClose} />
+    ) : (
+      <MigrationModal open={migrationModalOpen} handleClose={migModalClose} />
+    );
+  };
+
   return (
     <ThemeProvider theme={themeMode}>
       <MultifarmProvider
@@ -355,11 +363,7 @@ function App() {
             </Routes>
           </div>
         </div>
-        {hasDust ? (
-          <MigrationModalSingle open={migrationModalOpen} handleClose={migModalClose} />
-        ) : (
-          <MigrationModal open={migrationModalOpen} handleClose={migModalClose} />
-        )}
+        {oldAssetsDetected && <MigrationNotification />}
       </MultifarmProvider>
     </ThemeProvider>
   );

--- a/src/__tests__/__snapshots__/App.unit.test.jsx.snap
+++ b/src/__tests__/__snapshots__/App.unit.test.jsx.snap
@@ -9,14 +9,14 @@ exports[`<App/> should not render a connection error message when user wallet is
       <div />
     </div>
     <header
-      class="MuiPaper-root MuiAppBar-root MuiAppBar-positionSticky MuiAppBar-colorPrimary makeStyles-appBar-538 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAppBar-root MuiAppBar-positionSticky MuiAppBar-colorPrimary makeStyles-appBar-518 MuiPaper-elevation0"
     >
       <div
         class="MuiToolbar-root MuiToolbar-regular dapp-topbar"
       >
         <button
           aria-label="open drawer"
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-menuButton-539 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-menuButton-519 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
           id="hamburger"
           tabindex="0"
           type="button"
@@ -35,7 +35,7 @@ exports[`<App/> should not render a connection error message when user wallet is
           </span>
         </button>
         <div
-          class="MuiBox-root MuiBox-root-540"
+          class="MuiBox-root MuiBox-root-520"
         >
           <a
             href="#/wallet"
@@ -90,7 +90,7 @@ exports[`<App/> should not render a connection error message when user wallet is
           </button>
           <button
             aria-describedby="locales-popper"
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-toggleButton-542 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-toggleButton-522 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
             tabindex="0"
             title="Change locale"
             type="button"
@@ -137,7 +137,7 @@ exports[`<App/> should not render a connection error message when user wallet is
       </div>
     </header>
     <nav
-      class="makeStyles-drawer-416"
+      class="makeStyles-drawer-400"
     >
       <div
         class="sidebar"
@@ -153,13 +153,13 @@ exports[`<App/> should not render a connection error message when user wallet is
               class="MuiPaper-root dapp-sidebar MuiPaper-elevation0 MuiPaper-rounded"
             >
               <div
-                class="MuiBox-root MuiBox-root-546 dapp-sidebar-inner"
+                class="MuiBox-root MuiBox-root-526 dapp-sidebar-inner"
               >
                 <div
                   class="dapp-menu-top"
                 >
                   <div
-                    class="MuiBox-root MuiBox-root-547 branding-header"
+                    class="MuiBox-root MuiBox-root-527 branding-header"
                   >
                     <a
                       class="MuiTypography-root MuiLink-root MuiLink-underlineNone MuiTypography-colorPrimary"
@@ -185,17 +185,17 @@ exports[`<App/> should not render a connection error message when user wallet is
                       id="navbarNav"
                     >
                       <div
-                        class="makeStyles-root-548 makeStyles-root-550 nav-item-container"
+                        class="makeStyles-root-528 makeStyles-root-530 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/dashboard"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-551 link-container"
+                            class="MuiBox-root MuiBox-root-531 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-552 makeStyles-title-549 title"
+                              class="MuiBox-root MuiBox-root-532 makeStyles-title-529 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -214,10 +214,10 @@ exports[`<App/> should not render a connection error message when user wallet is
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-548 makeStyles-root-553 nav-item-container"
+                        class="makeStyles-root-528 makeStyles-root-533 nav-item-container"
                       >
                         <div
-                          class="MuiPaper-root MuiAccordion-root makeStyles-root-554 undefined Mui-expanded MuiPaper-elevation0"
+                          class="MuiPaper-root MuiAccordion-root makeStyles-root-534 undefined Mui-expanded MuiPaper-elevation0"
                         >
                           <div
                             aria-disabled="false"
@@ -234,10 +234,10 @@ exports[`<App/> should not render a connection error message when user wallet is
                                 href="#/bonds"
                               >
                                 <div
-                                  class="MuiBox-root MuiBox-root-555 link-container"
+                                  class="MuiBox-root MuiBox-root-535 link-container"
                                 >
                                   <div
-                                    class="MuiBox-root MuiBox-root-556 makeStyles-title-549 title"
+                                    class="MuiBox-root MuiBox-root-536 makeStyles-title-529 title"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -300,7 +300,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                         </div>
                       </div>
                       <div
-                        class="makeStyles-root-548 makeStyles-root-557 nav-item-container"
+                        class="makeStyles-root-528 makeStyles-root-537 nav-item-container"
                       >
                         <a
                           aria-current="page"
@@ -308,10 +308,10 @@ exports[`<App/> should not render a connection error message when user wallet is
                           href="#/stake"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-558 link-container"
+                            class="MuiBox-root MuiBox-root-538 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-559 makeStyles-title-549 title"
+                              class="MuiBox-root MuiBox-root-539 makeStyles-title-529 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -330,17 +330,17 @@ exports[`<App/> should not render a connection error message when user wallet is
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-548 makeStyles-root-560 nav-item-container"
+                        class="makeStyles-root-528 makeStyles-root-540 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/zap"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-561 link-container"
+                            class="MuiBox-root MuiBox-root-541 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-562 makeStyles-title-549 title"
+                              class="MuiBox-root MuiBox-root-542 makeStyles-title-529 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -359,17 +359,17 @@ exports[`<App/> should not render a connection error message when user wallet is
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-548 makeStyles-root-563 nav-item-container"
+                        class="makeStyles-root-528 makeStyles-root-543 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/give"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-564 link-container"
+                            class="MuiBox-root MuiBox-root-544 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-565 makeStyles-title-549 title"
+                              class="MuiBox-root MuiBox-root-545 makeStyles-title-529 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -388,17 +388,17 @@ exports[`<App/> should not render a connection error message when user wallet is
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-548 makeStyles-root-566 nav-item-container"
+                        class="makeStyles-root-528 makeStyles-root-546 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/wrap"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-567 link-container"
+                            class="MuiBox-root MuiBox-root-547 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-568 makeStyles-title-549 title"
+                              class="MuiBox-root MuiBox-root-548 makeStyles-title-529 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -417,7 +417,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-548 makeStyles-root-569 nav-item-container"
+                        class="makeStyles-root-528 makeStyles-root-549 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -425,10 +425,10 @@ exports[`<App/> should not render a connection error message when user wallet is
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-570 link-container"
+                            class="MuiBox-root MuiBox-root-550 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-571 makeStyles-title-549 title"
+                              class="MuiBox-root MuiBox-root-551 makeStyles-title-529 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -457,14 +457,14 @@ exports[`<App/> should not render a connection error message when user wallet is
                         </a>
                       </div>
                       <div
-                        class="MuiBox-root MuiBox-root-572 menu-divider"
+                        class="MuiBox-root MuiBox-root-552 menu-divider"
                       >
                         <hr
                           class="MuiDivider-root"
                         />
                       </div>
                       <div
-                        class="makeStyles-root-548 makeStyles-root-573 nav-item-container"
+                        class="makeStyles-root-528 makeStyles-root-553 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -472,10 +472,10 @@ exports[`<App/> should not render a connection error message when user wallet is
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-574 link-container"
+                            class="MuiBox-root MuiBox-root-554 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-575 makeStyles-title-549 title"
+                              class="MuiBox-root MuiBox-root-555 makeStyles-title-529 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -504,14 +504,14 @@ exports[`<App/> should not render a connection error message when user wallet is
                         </a>
                       </div>
                       <div
-                        class="MuiBox-root MuiBox-root-576 menu-divider"
+                        class="MuiBox-root MuiBox-root-556 menu-divider"
                       >
                         <hr
                           class="MuiDivider-root"
                         />
                       </div>
                       <div
-                        class="makeStyles-root-548 makeStyles-root-577 nav-item-container"
+                        class="makeStyles-root-528 makeStyles-root-557 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -519,10 +519,10 @@ exports[`<App/> should not render a connection error message when user wallet is
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-578 link-container"
+                            class="MuiBox-root MuiBox-root-558 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-579 makeStyles-title-549 title"
+                              class="MuiBox-root MuiBox-root-559 makeStyles-title-529 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -551,7 +551,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-548 makeStyles-root-580 nav-item-container"
+                        class="makeStyles-root-528 makeStyles-root-560 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -559,10 +559,10 @@ exports[`<App/> should not render a connection error message when user wallet is
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-581 link-container"
+                            class="MuiBox-root MuiBox-root-561 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-582 makeStyles-title-549 title"
+                              class="MuiBox-root MuiBox-root-562 makeStyles-title-529 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -591,7 +591,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-548 makeStyles-root-583 nav-item-container"
+                        class="makeStyles-root-528 makeStyles-root-563 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -599,10 +599,10 @@ exports[`<App/> should not render a connection error message when user wallet is
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-584 link-container"
+                            class="MuiBox-root MuiBox-root-564 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-585 makeStyles-title-549 title"
+                              class="MuiBox-root MuiBox-root-565 makeStyles-title-529 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -631,7 +631,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-548 makeStyles-root-586 nav-item-container"
+                        class="makeStyles-root-528 makeStyles-root-566 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -639,10 +639,10 @@ exports[`<App/> should not render a connection error message when user wallet is
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-587 link-container"
+                            class="MuiBox-root MuiBox-root-567 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-588 makeStyles-title-549 title"
+                              class="MuiBox-root MuiBox-root-568 makeStyles-title-529 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -671,7 +671,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-548 makeStyles-root-589 nav-item-container"
+                        class="makeStyles-root-528 makeStyles-root-569 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -679,10 +679,10 @@ exports[`<App/> should not render a connection error message when user wallet is
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-590 link-container"
+                            class="MuiBox-root MuiBox-root-570 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-591 makeStyles-title-549 title"
+                              class="MuiBox-root MuiBox-root-571 makeStyles-title-529 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -714,7 +714,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   </div>
                 </div>
                 <div
-                  class="MuiBox-root MuiBox-root-592"
+                  class="MuiBox-root MuiBox-root-572"
                 >
                   <a
                     class="MuiTypography-root MuiLink-root MuiLink-underlineNone MuiTypography-colorPrimary"
@@ -723,7 +723,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-545 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-525 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -739,7 +739,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-545 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-525 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -755,7 +755,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-545 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-525 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -771,7 +771,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-545 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-525 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -788,13 +788,13 @@ exports[`<App/> should not render a connection error message when user wallet is
       </div>
     </nav>
     <div
-      class="makeStyles-content-417 false"
+      class="makeStyles-content-401 false"
     >
       <div
         id="stake-view"
       >
         <div
-          class="MuiPaper-root makeStyles-root-593 makeStyles-root-594  MuiPaper-elevation0 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-root-573 makeStyles-root-574  MuiPaper-elevation0 MuiPaper-rounded"
           style="transform: none; webkit-transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
         >
           <div
@@ -804,10 +804,10 @@ exports[`<App/> should not render a connection error message when user wallet is
               class="MuiGrid-root card-header MuiGrid-item"
             >
               <div
-                class="MuiBox-root MuiBox-root-595"
+                class="MuiBox-root MuiBox-root-575"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-596"
+                  class="MuiBox-root MuiBox-root-576"
                 >
                   <h5
                     class="MuiTypography-root header-text MuiTypography-h5"
@@ -820,10 +820,10 @@ exports[`<App/> should not render a connection error message when user wallet is
                 />
               </div>
               <div
-                class="MuiBox-root MuiBox-root-597"
+                class="MuiBox-root MuiBox-root-577"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-598 rebase-timer"
+                  class="MuiBox-root MuiBox-root-578 rebase-timer"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body2"
@@ -840,13 +840,13 @@ exports[`<App/> should not render a connection error message when user wallet is
               class="MuiGrid-root MuiGrid-item"
             >
               <div
-                class="MuiBox-root MuiBox-root-599"
+                class="MuiBox-root MuiBox-root-579"
               >
                 <div
                   class="MuiGrid-root"
                 >
                   <div
-                    class="MuiBox-root MuiBox-root-600"
+                    class="MuiBox-root MuiBox-root-580"
                   >
                     <div
                       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-flex-end"
@@ -855,10 +855,10 @@ exports[`<App/> should not render a connection error message when user wallet is
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
                       >
                         <div
-                          class="makeStyles-root-601 stake-apy"
+                          class="makeStyles-root-581 stake-apy"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-602"
+                            class="MuiBox-root MuiBox-root-582"
                           >
                             <h5
                               class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
@@ -881,10 +881,10 @@ exports[`<App/> should not render a connection error message when user wallet is
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
                       >
                         <div
-                          class="makeStyles-root-601 stake-tvl"
+                          class="makeStyles-root-581 stake-tvl"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-603"
+                            class="MuiBox-root MuiBox-root-583"
                           >
                             <h5
                               class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
@@ -907,21 +907,21 @@ exports[`<App/> should not render a connection error message when user wallet is
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
                       >
                         <div
-                          class="makeStyles-root-601 stake-index"
+                          class="makeStyles-root-581 stake-index"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-604"
+                            class="MuiBox-root MuiBox-root-584"
                           >
                             <h5
                               class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
                             >
                               Current Index
                               <div
-                                class="MuiBox-root MuiBox-root-605"
+                                class="MuiBox-root MuiBox-root-585"
                                 style="font-size: 16px;"
                               >
                                 <div
-                                  class="MuiBox-root MuiBox-root-606"
+                                  class="MuiBox-root MuiBox-root-586"
                                   style="display: inline-flex; justify-content: center; align-self: center;"
                                 >
                                   <svg
@@ -955,13 +955,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                 </div>
               </div>
               <div
-                class="MuiBox-root MuiBox-root-607"
+                class="MuiBox-root MuiBox-root-587"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-608"
+                  class="MuiBox-root MuiBox-root-588"
                 >
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-root-609 makeStyles-root-610 undefined MuiButton-containedPrimary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-root-589 makeStyles-root-590 undefined MuiButton-containedPrimary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
                     style="font-size: 1.2857rem;"
                     tabindex="0"
                     type="button"
@@ -983,7 +983,7 @@ exports[`<App/> should not render a connection error message when user wallet is
           </div>
         </div>
         <div
-          class="MuiPaper-root makeStyles-root-593 makeStyles-root-615  MuiPaper-elevation0 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-root-573 makeStyles-root-595  MuiPaper-elevation0 MuiPaper-rounded"
           style="transform: none; webkit-transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
         >
           <div
@@ -993,10 +993,10 @@ exports[`<App/> should not render a connection error message when user wallet is
               class="MuiGrid-root card-header MuiGrid-item"
             >
               <div
-                class="MuiBox-root MuiBox-root-616"
+                class="MuiBox-root MuiBox-root-596"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-617"
+                  class="MuiBox-root MuiBox-root-597"
                 >
                   <h5
                     class="MuiTypography-root header-text MuiTypography-h5"
@@ -1016,7 +1016,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                 class="MuiTable-root"
               >
                 <thead
-                  class="MuiTableHead-root makeStyles-stakePoolHeaderText-612"
+                  class="MuiTableHead-root makeStyles-stakePoolHeaderText-592"
                 >
                   <tr
                     class="MuiTableRow-root MuiTableRow-head"
@@ -1052,11 +1052,11 @@ exports[`<App/> should not render a connection error message when user wallet is
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-618"
+                      class="MuiBox-root MuiBox-root-598"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-619"
+                        class="MuiBox-root MuiBox-root-599"
                       >
                         <svg
                           aria-hidden="true"
@@ -1509,7 +1509,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-609 makeStyles-root-621 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-589 makeStyles-root-601 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://app.sushi.com/farm?filter=2x"
                       tabindex="0"
                       target="_blank"
@@ -1545,11 +1545,11 @@ exports[`<App/> should not render a connection error message when user wallet is
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-622"
+                      class="MuiBox-root MuiBox-root-602"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-623"
+                        class="MuiBox-root MuiBox-root-603"
                       >
                         <svg
                           aria-hidden="true"
@@ -1706,7 +1706,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-609 makeStyles-root-624 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-589 makeStyles-root-604 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://app.sushi.com/farm?filter=2x"
                       tabindex="0"
                       target="_blank"
@@ -1742,11 +1742,11 @@ exports[`<App/> should not render a connection error message when user wallet is
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-625"
+                      class="MuiBox-root MuiBox-root-605"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-626"
+                        class="MuiBox-root MuiBox-root-606"
                       >
                         <svg
                           aria-hidden="true"
@@ -1877,7 +1877,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-609 makeStyles-root-627 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-589 makeStyles-root-607 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://traderjoexyz.com/farm/0xB674f93952F02F2538214D4572Aa47F262e990Ff-0x188bED1968b795d5c9022F6a0bb5931Ac4c18F00"
                       tabindex="0"
                       target="_blank"
@@ -1913,11 +1913,11 @@ exports[`<App/> should not render a connection error message when user wallet is
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-628"
+                      class="MuiBox-root MuiBox-root-608"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-629"
+                        class="MuiBox-root MuiBox-root-609"
                       >
                         <svg
                           aria-hidden="true"
@@ -2112,7 +2112,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-609 makeStyles-root-630 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-589 makeStyles-root-610 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://app.spiritswap.finance/#/farms/allfarms"
                       tabindex="0"
                       target="_blank"
@@ -2148,11 +2148,11 @@ exports[`<App/> should not render a connection error message when user wallet is
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-631"
+                      class="MuiBox-root MuiBox-root-611"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-632"
+                        class="MuiBox-root MuiBox-root-612"
                       >
                         <svg
                           aria-hidden="true"
@@ -2347,7 +2347,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-609 makeStyles-root-633 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-589 makeStyles-root-613 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://beets.fi/#/pool/0xf7bf0f161d3240488807ffa23894452246049916000200000000000000000198"
                       tabindex="0"
                       target="_blank"
@@ -2383,11 +2383,11 @@ exports[`<App/> should not render a connection error message when user wallet is
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-634"
+                      class="MuiBox-root MuiBox-root-614"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-635"
+                        class="MuiBox-root MuiBox-root-615"
                       >
                         <svg
                           aria-hidden="true"
@@ -2554,7 +2554,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-609 makeStyles-root-636 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-589 makeStyles-root-616 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://zipswap.fi/#/farm/0x3f6da9334142477718bE2ecC3577d1A28dceAAe1"
                       tabindex="0"
                       target="_blank"
@@ -2590,11 +2590,11 @@ exports[`<App/> should not render a connection error message when user wallet is
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-637"
+                      class="MuiBox-root MuiBox-root-617"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-638"
+                        class="MuiBox-root MuiBox-root-618"
                       >
                         <svg
                           aria-hidden="true"
@@ -3133,7 +3133,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-609 makeStyles-root-639 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-589 makeStyles-root-619 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://jonesdao.io/farms"
                       tabindex="0"
                       target="_blank"
@@ -3169,11 +3169,11 @@ exports[`<App/> should not render a connection error message when user wallet is
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-640"
+                      class="MuiBox-root MuiBox-root-620"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-641"
+                        class="MuiBox-root MuiBox-root-621"
                       >
                         <svg
                           aria-hidden="true"
@@ -3351,7 +3351,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-609 makeStyles-root-642 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-589 makeStyles-root-622 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://app.balancer.fi/#/pool/0xc45d42f801105e861e86658648e3678ad7aa70f900010000000000000000011e"
                       tabindex="0"
                       target="_blank"
@@ -3387,11 +3387,11 @@ exports[`<App/> should not render a connection error message when user wallet is
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-643"
+                      class="MuiBox-root MuiBox-root-623"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-644"
+                        class="MuiBox-root MuiBox-root-624"
                       >
                         <svg
                           aria-hidden="true"
@@ -3585,7 +3585,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-609 makeStyles-root-645 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-589 makeStyles-root-625 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://oolongswap.com/#/farm/lp"
                       tabindex="0"
                       target="_blank"
@@ -3621,7 +3621,6 @@ exports[`<App/> should not render a connection error message when user wallet is
       </div>
     </div>
   </div>
-  <div />
 </div>
 `;
 
@@ -3634,14 +3633,14 @@ exports[`<App/> should not render an error message when user wallet is connected
       <div />
     </div>
     <header
-      class="MuiPaper-root MuiAppBar-root MuiAppBar-positionSticky MuiAppBar-colorPrimary makeStyles-appBar-304 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAppBar-root MuiAppBar-positionSticky MuiAppBar-colorPrimary makeStyles-appBar-292 MuiPaper-elevation0"
     >
       <div
         class="MuiToolbar-root MuiToolbar-regular dapp-topbar"
       >
         <button
           aria-label="open drawer"
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-menuButton-305 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-menuButton-293 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
           id="hamburger"
           tabindex="0"
           type="button"
@@ -3660,7 +3659,7 @@ exports[`<App/> should not render an error message when user wallet is connected
           </span>
         </button>
         <div
-          class="MuiBox-root MuiBox-root-306"
+          class="MuiBox-root MuiBox-root-294"
         >
           <a
             href="#/wallet"
@@ -3715,7 +3714,7 @@ exports[`<App/> should not render an error message when user wallet is connected
           </button>
           <button
             aria-describedby="locales-popper"
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-toggleButton-308 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-toggleButton-296 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
             tabindex="0"
             title="Change locale"
             type="button"
@@ -3762,7 +3761,7 @@ exports[`<App/> should not render an error message when user wallet is connected
       </div>
     </header>
     <nav
-      class="makeStyles-drawer-182"
+      class="makeStyles-drawer-174"
     >
       <div
         class="sidebar"
@@ -3778,13 +3777,13 @@ exports[`<App/> should not render an error message when user wallet is connected
               class="MuiPaper-root dapp-sidebar MuiPaper-elevation0 MuiPaper-rounded"
             >
               <div
-                class="MuiBox-root MuiBox-root-312 dapp-sidebar-inner"
+                class="MuiBox-root MuiBox-root-300 dapp-sidebar-inner"
               >
                 <div
                   class="dapp-menu-top"
                 >
                   <div
-                    class="MuiBox-root MuiBox-root-313 branding-header"
+                    class="MuiBox-root MuiBox-root-301 branding-header"
                   >
                     <a
                       class="MuiTypography-root MuiLink-root MuiLink-underlineNone MuiTypography-colorPrimary"
@@ -3810,17 +3809,17 @@ exports[`<App/> should not render an error message when user wallet is connected
                       id="navbarNav"
                     >
                       <div
-                        class="makeStyles-root-314 makeStyles-root-316 nav-item-container"
+                        class="makeStyles-root-302 makeStyles-root-304 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/dashboard"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-317 link-container"
+                            class="MuiBox-root MuiBox-root-305 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-318 makeStyles-title-315 title"
+                              class="MuiBox-root MuiBox-root-306 makeStyles-title-303 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -3839,10 +3838,10 @@ exports[`<App/> should not render an error message when user wallet is connected
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-314 makeStyles-root-319 nav-item-container"
+                        class="makeStyles-root-302 makeStyles-root-307 nav-item-container"
                       >
                         <div
-                          class="MuiPaper-root MuiAccordion-root makeStyles-root-320 undefined Mui-expanded MuiPaper-elevation0"
+                          class="MuiPaper-root MuiAccordion-root makeStyles-root-308 undefined Mui-expanded MuiPaper-elevation0"
                         >
                           <div
                             aria-disabled="false"
@@ -3859,10 +3858,10 @@ exports[`<App/> should not render an error message when user wallet is connected
                                 href="#/bonds"
                               >
                                 <div
-                                  class="MuiBox-root MuiBox-root-321 link-container"
+                                  class="MuiBox-root MuiBox-root-309 link-container"
                                 >
                                   <div
-                                    class="MuiBox-root MuiBox-root-322 makeStyles-title-315 title"
+                                    class="MuiBox-root MuiBox-root-310 makeStyles-title-303 title"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -3925,7 +3924,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                         </div>
                       </div>
                       <div
-                        class="makeStyles-root-314 makeStyles-root-323 nav-item-container"
+                        class="makeStyles-root-302 makeStyles-root-311 nav-item-container"
                       >
                         <a
                           aria-current="page"
@@ -3933,10 +3932,10 @@ exports[`<App/> should not render an error message when user wallet is connected
                           href="#/stake"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-324 link-container"
+                            class="MuiBox-root MuiBox-root-312 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-325 makeStyles-title-315 title"
+                              class="MuiBox-root MuiBox-root-313 makeStyles-title-303 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -3955,17 +3954,17 @@ exports[`<App/> should not render an error message when user wallet is connected
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-314 makeStyles-root-326 nav-item-container"
+                        class="makeStyles-root-302 makeStyles-root-314 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/zap"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-327 link-container"
+                            class="MuiBox-root MuiBox-root-315 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-328 makeStyles-title-315 title"
+                              class="MuiBox-root MuiBox-root-316 makeStyles-title-303 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -3984,17 +3983,17 @@ exports[`<App/> should not render an error message when user wallet is connected
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-314 makeStyles-root-329 nav-item-container"
+                        class="makeStyles-root-302 makeStyles-root-317 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/give"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-330 link-container"
+                            class="MuiBox-root MuiBox-root-318 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-331 makeStyles-title-315 title"
+                              class="MuiBox-root MuiBox-root-319 makeStyles-title-303 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4013,17 +4012,17 @@ exports[`<App/> should not render an error message when user wallet is connected
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-314 makeStyles-root-332 nav-item-container"
+                        class="makeStyles-root-302 makeStyles-root-320 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/wrap"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-333 link-container"
+                            class="MuiBox-root MuiBox-root-321 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-334 makeStyles-title-315 title"
+                              class="MuiBox-root MuiBox-root-322 makeStyles-title-303 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4042,7 +4041,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-314 makeStyles-root-335 nav-item-container"
+                        class="makeStyles-root-302 makeStyles-root-323 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -4050,10 +4049,10 @@ exports[`<App/> should not render an error message when user wallet is connected
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-336 link-container"
+                            class="MuiBox-root MuiBox-root-324 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-337 makeStyles-title-315 title"
+                              class="MuiBox-root MuiBox-root-325 makeStyles-title-303 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4082,14 +4081,14 @@ exports[`<App/> should not render an error message when user wallet is connected
                         </a>
                       </div>
                       <div
-                        class="MuiBox-root MuiBox-root-338 menu-divider"
+                        class="MuiBox-root MuiBox-root-326 menu-divider"
                       >
                         <hr
                           class="MuiDivider-root"
                         />
                       </div>
                       <div
-                        class="makeStyles-root-314 makeStyles-root-339 nav-item-container"
+                        class="makeStyles-root-302 makeStyles-root-327 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -4097,10 +4096,10 @@ exports[`<App/> should not render an error message when user wallet is connected
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-340 link-container"
+                            class="MuiBox-root MuiBox-root-328 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-341 makeStyles-title-315 title"
+                              class="MuiBox-root MuiBox-root-329 makeStyles-title-303 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4129,14 +4128,14 @@ exports[`<App/> should not render an error message when user wallet is connected
                         </a>
                       </div>
                       <div
-                        class="MuiBox-root MuiBox-root-342 menu-divider"
+                        class="MuiBox-root MuiBox-root-330 menu-divider"
                       >
                         <hr
                           class="MuiDivider-root"
                         />
                       </div>
                       <div
-                        class="makeStyles-root-314 makeStyles-root-343 nav-item-container"
+                        class="makeStyles-root-302 makeStyles-root-331 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -4144,10 +4143,10 @@ exports[`<App/> should not render an error message when user wallet is connected
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-344 link-container"
+                            class="MuiBox-root MuiBox-root-332 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-345 makeStyles-title-315 title"
+                              class="MuiBox-root MuiBox-root-333 makeStyles-title-303 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4176,7 +4175,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-314 makeStyles-root-346 nav-item-container"
+                        class="makeStyles-root-302 makeStyles-root-334 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -4184,10 +4183,10 @@ exports[`<App/> should not render an error message when user wallet is connected
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-347 link-container"
+                            class="MuiBox-root MuiBox-root-335 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-348 makeStyles-title-315 title"
+                              class="MuiBox-root MuiBox-root-336 makeStyles-title-303 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4216,7 +4215,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-314 makeStyles-root-349 nav-item-container"
+                        class="makeStyles-root-302 makeStyles-root-337 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -4224,10 +4223,10 @@ exports[`<App/> should not render an error message when user wallet is connected
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-350 link-container"
+                            class="MuiBox-root MuiBox-root-338 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-351 makeStyles-title-315 title"
+                              class="MuiBox-root MuiBox-root-339 makeStyles-title-303 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4256,7 +4255,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-314 makeStyles-root-352 nav-item-container"
+                        class="makeStyles-root-302 makeStyles-root-340 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -4264,10 +4263,10 @@ exports[`<App/> should not render an error message when user wallet is connected
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-353 link-container"
+                            class="MuiBox-root MuiBox-root-341 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-354 makeStyles-title-315 title"
+                              class="MuiBox-root MuiBox-root-342 makeStyles-title-303 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4296,7 +4295,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-314 makeStyles-root-355 nav-item-container"
+                        class="makeStyles-root-302 makeStyles-root-343 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -4304,10 +4303,10 @@ exports[`<App/> should not render an error message when user wallet is connected
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-356 link-container"
+                            class="MuiBox-root MuiBox-root-344 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-357 makeStyles-title-315 title"
+                              class="MuiBox-root MuiBox-root-345 makeStyles-title-303 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -4339,7 +4338,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   </div>
                 </div>
                 <div
-                  class="MuiBox-root MuiBox-root-358"
+                  class="MuiBox-root MuiBox-root-346"
                 >
                   <a
                     class="MuiTypography-root MuiLink-root MuiLink-underlineNone MuiTypography-colorPrimary"
@@ -4348,7 +4347,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-311 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-299 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -4364,7 +4363,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-311 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-299 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -4380,7 +4379,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-311 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-299 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -4396,7 +4395,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-311 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-299 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -4413,13 +4412,13 @@ exports[`<App/> should not render an error message when user wallet is connected
       </div>
     </nav>
     <div
-      class="makeStyles-content-183 false"
+      class="makeStyles-content-175 false"
     >
       <div
         id="stake-view"
       >
         <div
-          class="MuiPaper-root makeStyles-root-359 makeStyles-root-360  MuiPaper-elevation0 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-root-347 makeStyles-root-348  MuiPaper-elevation0 MuiPaper-rounded"
           style="transform: none; webkit-transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
         >
           <div
@@ -4429,10 +4428,10 @@ exports[`<App/> should not render an error message when user wallet is connected
               class="MuiGrid-root card-header MuiGrid-item"
             >
               <div
-                class="MuiBox-root MuiBox-root-361"
+                class="MuiBox-root MuiBox-root-349"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-362"
+                  class="MuiBox-root MuiBox-root-350"
                 >
                   <h5
                     class="MuiTypography-root header-text MuiTypography-h5"
@@ -4445,10 +4444,10 @@ exports[`<App/> should not render an error message when user wallet is connected
                 />
               </div>
               <div
-                class="MuiBox-root MuiBox-root-363"
+                class="MuiBox-root MuiBox-root-351"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-364 rebase-timer"
+                  class="MuiBox-root MuiBox-root-352 rebase-timer"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body2"
@@ -4465,13 +4464,13 @@ exports[`<App/> should not render an error message when user wallet is connected
               class="MuiGrid-root MuiGrid-item"
             >
               <div
-                class="MuiBox-root MuiBox-root-365"
+                class="MuiBox-root MuiBox-root-353"
               >
                 <div
                   class="MuiGrid-root"
                 >
                   <div
-                    class="MuiBox-root MuiBox-root-366"
+                    class="MuiBox-root MuiBox-root-354"
                   >
                     <div
                       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-flex-end"
@@ -4480,10 +4479,10 @@ exports[`<App/> should not render an error message when user wallet is connected
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
                       >
                         <div
-                          class="makeStyles-root-367 stake-apy"
+                          class="makeStyles-root-355 stake-apy"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-368"
+                            class="MuiBox-root MuiBox-root-356"
                           >
                             <h5
                               class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
@@ -4506,10 +4505,10 @@ exports[`<App/> should not render an error message when user wallet is connected
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
                       >
                         <div
-                          class="makeStyles-root-367 stake-tvl"
+                          class="makeStyles-root-355 stake-tvl"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-369"
+                            class="MuiBox-root MuiBox-root-357"
                           >
                             <h5
                               class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
@@ -4532,21 +4531,21 @@ exports[`<App/> should not render an error message when user wallet is connected
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
                       >
                         <div
-                          class="makeStyles-root-367 stake-index"
+                          class="makeStyles-root-355 stake-index"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-370"
+                            class="MuiBox-root MuiBox-root-358"
                           >
                             <h5
                               class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
                             >
                               Current Index
                               <div
-                                class="MuiBox-root MuiBox-root-371"
+                                class="MuiBox-root MuiBox-root-359"
                                 style="font-size: 16px;"
                               >
                                 <div
-                                  class="MuiBox-root MuiBox-root-372"
+                                  class="MuiBox-root MuiBox-root-360"
                                   style="display: inline-flex; justify-content: center; align-self: center;"
                                 >
                                   <svg
@@ -4580,13 +4579,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                 </div>
               </div>
               <div
-                class="MuiBox-root MuiBox-root-373"
+                class="MuiBox-root MuiBox-root-361"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-374"
+                  class="MuiBox-root MuiBox-root-362"
                 >
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-root-375 makeStyles-root-376 undefined MuiButton-containedPrimary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-root-363 makeStyles-root-364 undefined MuiButton-containedPrimary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
                     style="font-size: 1.2857rem;"
                     tabindex="0"
                     type="button"
@@ -4608,7 +4607,7 @@ exports[`<App/> should not render an error message when user wallet is connected
           </div>
         </div>
         <div
-          class="MuiPaper-root makeStyles-root-359 makeStyles-root-381  MuiPaper-elevation0 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-root-347 makeStyles-root-369  MuiPaper-elevation0 MuiPaper-rounded"
           style="transform: none; webkit-transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
         >
           <div
@@ -4618,10 +4617,10 @@ exports[`<App/> should not render an error message when user wallet is connected
               class="MuiGrid-root card-header MuiGrid-item"
             >
               <div
-                class="MuiBox-root MuiBox-root-382"
+                class="MuiBox-root MuiBox-root-370"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-383"
+                  class="MuiBox-root MuiBox-root-371"
                 >
                   <h5
                     class="MuiTypography-root header-text MuiTypography-h5"
@@ -4641,7 +4640,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                 class="MuiTable-root"
               >
                 <thead
-                  class="MuiTableHead-root makeStyles-stakePoolHeaderText-378"
+                  class="MuiTableHead-root makeStyles-stakePoolHeaderText-366"
                 >
                   <tr
                     class="MuiTableRow-root MuiTableRow-head"
@@ -4677,11 +4676,11 @@ exports[`<App/> should not render an error message when user wallet is connected
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-384"
+                      class="MuiBox-root MuiBox-root-372"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-385"
+                        class="MuiBox-root MuiBox-root-373"
                       >
                         <svg
                           aria-hidden="true"
@@ -5134,7 +5133,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-375 makeStyles-root-387 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-363 makeStyles-root-375 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://app.sushi.com/farm?filter=2x"
                       tabindex="0"
                       target="_blank"
@@ -5145,6 +5144,844 @@ exports[`<App/> should not render an error message when user wallet is connected
                         Stake on
                          
                         Sushi
+                        <span
+                          class="MuiButton-endIcon MuiButton-iconSizeSmall"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                            focusable="false"
+                            viewBox="0 0 20 20"
+                          >
+                            <path
+                              d="M4.297 17.445h9.539c1.523 0 2.305-.78 2.305-2.28v-9.58c0-1.507-.782-2.288-2.305-2.288h-9.54c-1.523 0-2.304.773-2.304 2.289v9.578c0 1.508.781 2.281 2.305 2.281Zm.016-.968c-.875 0-1.352-.461-1.352-1.368V5.633c0-.899.477-1.367 1.352-1.367h9.5c.867 0 1.359.468 1.359 1.367v9.476c0 .907-.492 1.368-1.36 1.368h-9.5Zm7.296-4.235c.266 0 .438-.195.438-.476V7.867c0-.344-.188-.492-.492-.492H7.64c-.29 0-.47.172-.47.438 0 .265.188.445.477.445H9.53l1.133-.078-1.055.992-3.382 3.383a.476.476 0 0 0-.149.328c0 .273.18.453.453.453a.47.47 0 0 0 .344-.149L10.25 9.82l.984-1.047-.078 1.282v1.718c0 .29.18.47.453.47Z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </a>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root MuiBox-root-376"
+                      style="white-space: nowrap;"
+                    >
+                      <div
+                        class="MuiBox-root MuiBox-root-377"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                          focusable="false"
+                          style="z-index: 1;"
+                          viewBox="0 0 32 32"
+                        >
+                          <defs>
+                            <lineargradient
+                              gradientTransform="matrix(0.177778, 0, 0, 0.177778, 1.777779, 1.777779)"
+                              gradientUnits="userSpaceOnUse"
+                              id="paint0_linear_359"
+                              x1="80"
+                              x2="80"
+                              y1="-84"
+                              y2="256"
+                            >
+                              <stop
+                                offset="0.1949"
+                                stop-color="#708B96"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#F7FBE7"
+                              />
+                            </lineargradient>
+                          </defs>
+                          <path
+                            d="M 1.778 16 C 1.778 8.145 8.145 1.778 16 1.778 C 23.855 1.778 30.222 8.145 30.222 16 C 30.222 23.855 23.855 30.222 16 30.222 C 8.145 30.222 1.778 23.855 1.778 16 Z"
+                            fill="#fff"
+                          />
+                          <rect
+                            fill="#fff"
+                            height="12.516"
+                            width="12.516"
+                            x="9.742"
+                            y="9.771"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M 14.635 22.286 L 14.635 19.916 C 12.852 19.355 11.563 17.725 11.563 15.801 C 11.563 13.413 13.549 11.477 16 11.477 C 18.451 11.477 20.437 13.413 20.437 15.801 C 20.437 17.725 19.148 19.355 17.365 19.916 L 17.365 21.658 L 17.365 22.258 L 17.365 22.286 L 22.258 22.286 L 22.258 20.523 L 19.842 20.523 C 21.295 19.421 22.229 17.709 22.229 15.787 C 22.229 12.464 19.44 9.771 16 9.771 C 12.56 9.771 9.771 12.464 9.771 15.787 C 9.771 17.709 10.705 19.421 12.158 20.523 L 9.742 20.523 L 9.742 22.286 Z"
+                            fill="#708b96"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            d="M 16 28.444 C 9.127 28.444 3.556 22.873 3.556 16 L 0 16 C 0 24.837 7.163 32 16 32 Z M 28.444 16 C 28.444 22.873 22.873 28.444 16 28.444 L 16 32 C 24.837 32 32 24.837 32 16 Z M 16 3.556 C 22.873 3.556 28.444 9.127 28.444 16 L 32 16 C 32 7.163 24.837 0 16 0 Z M 16 0 C 7.163 0 0 7.163 0 16 L 3.556 16 C 3.556 9.127 9.127 3.556 16 3.556 Z"
+                            fill="url(#paint0_linear_359)"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                          focusable="false"
+                          style="margin-left: -6px; z-index: 1;"
+                          viewBox="0 0 32 32"
+                        >
+                          <circle
+                            cx="16"
+                            cy="16"
+                            fill="#fff"
+                            r="15"
+                            stroke="url(#wETH_svg__a)"
+                            stroke-width="2"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M16.25 20.976 10 17.349 16.25 26V26l6.253-8.65-6.253 3.626Z"
+                            fill="#708B96"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="m16.25 6 6.248 10.186-6.248-2.793L10 16.186 16.25 6Zm0 7.395L10 16.185l6.25 3.629 6.248-3.628-6.248-2.791Z"
+                            fill="#424242"
+                            fill-rule="evenodd"
+                          />
+                          <defs>
+                            <lineargradient
+                              gradientUnits="userSpaceOnUse"
+                              id="wETH_svg__a"
+                              x1="16"
+                              x2="16"
+                              y1="0"
+                              y2="32"
+                            >
+                              <stop
+                                stop-color="#444243"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#708B96"
+                              />
+                            </lineargradient>
+                          </defs>
+                        </svg>
+                      </div>
+                      <p
+                        class="MuiTypography-root MuiTypography-body1"
+                        style="line-height: 1.4; margin-left: 10px; margin-right: 10px;"
+                      >
+                        gOHM-wETH
+                      </p>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                        focusable="false"
+                        style="font-size: 15px;"
+                        viewBox="0 0 32 32"
+                      >
+                        <path
+                          d="M 24.23 10.528 C 23.645 10.194 22.893 10.194 22.225 10.528 L 17.546 13.285 L 14.371 15.039 L 9.775 17.797 C 9.191 18.131 8.439 18.131 7.77 17.797 L 4.178 15.624 C 3.593 15.29 3.175 14.622 3.175 13.87 L 3.175 9.692 C 3.175 9.024 3.509 8.355 4.178 7.938 L 7.77 5.849 C 8.355 5.515 9.107 5.515 9.775 5.849 L 13.368 8.021 C 13.953 8.355 14.371 9.024 14.371 9.776 L 14.371 12.533 L 17.546 10.695 L 17.546 7.854 C 17.546 7.186 17.211 6.517 16.543 6.1 L 9.859 2.173 C 9.274 1.838 8.522 1.838 7.854 2.173 L 1.003 6.183 C 0.334 6.517 0 7.186 0 7.854 L 0 15.708 C 0 16.376 0.334 17.045 1.003 17.462 L 7.77 21.389 C 8.355 21.724 9.107 21.724 9.775 21.389 L 14.371 18.716 L 17.546 16.878 L 22.141 14.204 C 22.726 13.87 23.478 13.87 24.146 14.204 L 27.739 16.293 C 28.324 16.627 28.742 17.295 28.742 18.047 L 28.742 22.225 C 28.742 22.893 28.407 23.562 27.739 23.979 L 24.23 26.068 C 23.645 26.402 22.893 26.402 22.225 26.068 L 18.632 23.979 C 18.047 23.645 17.629 22.977 17.629 22.225 L 17.629 19.551 L 14.454 21.389 L 14.454 24.147 C 14.454 24.815 14.789 25.483 15.457 25.901 L 22.225 29.828 C 22.809 30.162 23.561 30.162 24.23 29.828 L 30.997 25.901 C 31.582 25.567 32 24.899 32 24.147 L 32 16.209 C 32 15.541 31.666 14.872 30.997 14.455 L 24.23 10.528 Z"
+                          fill="#8247e5"
+                        />
+                      </svg>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                      style="line-height: 1.4;"
+                    >
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
+                        style="width: 100%;"
+                      />
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                      style="line-height: 1.4;"
+                    >
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
+                        style="width: 100%;"
+                      />
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                      style="line-height: 1.4;"
+                    />
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <a
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-363 makeStyles-root-378 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      href="https://app.sushi.com/farm?filter=2x"
+                      tabindex="0"
+                      target="_blank"
+                    >
+                      <span
+                        class="MuiButton-label"
+                      >
+                        Stake on
+                         
+                        Sushi
+                        <span
+                          class="MuiButton-endIcon MuiButton-iconSizeSmall"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                            focusable="false"
+                            viewBox="0 0 20 20"
+                          >
+                            <path
+                              d="M4.297 17.445h9.539c1.523 0 2.305-.78 2.305-2.28v-9.58c0-1.507-.782-2.288-2.305-2.288h-9.54c-1.523 0-2.304.773-2.304 2.289v9.578c0 1.508.781 2.281 2.305 2.281Zm.016-.968c-.875 0-1.352-.461-1.352-1.368V5.633c0-.899.477-1.367 1.352-1.367h9.5c.867 0 1.359.468 1.359 1.367v9.476c0 .907-.492 1.368-1.36 1.368h-9.5Zm7.296-4.235c.266 0 .438-.195.438-.476V7.867c0-.344-.188-.492-.492-.492H7.64c-.29 0-.47.172-.47.438 0 .265.188.445.477.445H9.53l1.133-.078-1.055.992-3.382 3.383a.476.476 0 0 0-.149.328c0 .273.18.453.453.453a.47.47 0 0 0 .344-.149L10.25 9.82l.984-1.047-.078 1.282v1.718c0 .29.18.47.453.47Z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </a>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root MuiBox-root-379"
+                      style="white-space: nowrap;"
+                    >
+                      <div
+                        class="MuiBox-root MuiBox-root-380"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                          focusable="false"
+                          style="z-index: 1;"
+                          viewBox="0 0 32 32"
+                        >
+                          <defs>
+                            <lineargradient
+                              gradientTransform="matrix(0.177778, 0, 0, 0.177778, 1.777779, 1.777779)"
+                              gradientUnits="userSpaceOnUse"
+                              id="paint0_linear_359"
+                              x1="80"
+                              x2="80"
+                              y1="-84"
+                              y2="256"
+                            >
+                              <stop
+                                offset="0.1949"
+                                stop-color="#708B96"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#F7FBE7"
+                              />
+                            </lineargradient>
+                          </defs>
+                          <path
+                            d="M 1.778 16 C 1.778 8.145 8.145 1.778 16 1.778 C 23.855 1.778 30.222 8.145 30.222 16 C 30.222 23.855 23.855 30.222 16 30.222 C 8.145 30.222 1.778 23.855 1.778 16 Z"
+                            fill="#fff"
+                          />
+                          <rect
+                            fill="#fff"
+                            height="12.516"
+                            width="12.516"
+                            x="9.742"
+                            y="9.771"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M 14.635 22.286 L 14.635 19.916 C 12.852 19.355 11.563 17.725 11.563 15.801 C 11.563 13.413 13.549 11.477 16 11.477 C 18.451 11.477 20.437 13.413 20.437 15.801 C 20.437 17.725 19.148 19.355 17.365 19.916 L 17.365 21.658 L 17.365 22.258 L 17.365 22.286 L 22.258 22.286 L 22.258 20.523 L 19.842 20.523 C 21.295 19.421 22.229 17.709 22.229 15.787 C 22.229 12.464 19.44 9.771 16 9.771 C 12.56 9.771 9.771 12.464 9.771 15.787 C 9.771 17.709 10.705 19.421 12.158 20.523 L 9.742 20.523 L 9.742 22.286 Z"
+                            fill="#708b96"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            d="M 16 28.444 C 9.127 28.444 3.556 22.873 3.556 16 L 0 16 C 0 24.837 7.163 32 16 32 Z M 28.444 16 C 28.444 22.873 22.873 28.444 16 28.444 L 16 32 C 24.837 32 32 24.837 32 16 Z M 16 3.556 C 22.873 3.556 28.444 9.127 28.444 16 L 32 16 C 32 7.163 24.837 0 16 0 Z M 16 0 C 7.163 0 0 7.163 0 16 L 3.556 16 C 3.556 9.127 9.127 3.556 16 3.556 Z"
+                            fill="url(#paint0_linear_359)"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                          focusable="false"
+                          style="margin-left: -6px; z-index: 1;"
+                          viewBox="0 0 32 32"
+                        >
+                          <path
+                            d="M6.104 5.475h19.771v17.981H6.104z"
+                            style="fill: #fff; stroke-width: 0.02130493;"
+                          />
+                          <path
+                            d="M32 16c0 8.837-7.163 16-16 16S0 24.837 0 16 7.163 0 16 0s16 7.163 16 16Zm-20.534 6.367H8.361c-.653 0-.975 0-1.171-.126a.79.79 0 0 1-.358-.617c-.012-.232.15-.515.472-1.08L14.97 7.028c.326-.574.49-.86.7-.967a.791.791 0 0 1 .715 0c.208.106.373.393.7.967L18.66 9.78l.008.014c.353.615.531.927.61 1.255.086.358.086.735 0 1.093-.08.33-.256.644-.614 1.27l-4.027 7.119-.01.018c-.355.62-.535.935-.784 1.172-.271.26-.597.448-.955.555-.326.09-.692.09-1.423.09zm7.842 0h4.449c.656 0 .987 0 1.183-.13a.787.787 0 0 0 .358-.62c.011-.225-.146-.497-.455-1.03l-.033-.055-2.228-3.813-.026-.043c-.313-.53-.471-.797-.674-.9a.783.783 0 0 0-.711 0c-.205.106-.37.385-.696.947l-2.22 3.813-.009.013c-.325.56-.487.841-.476 1.071a.796.796 0 0 0 .358.622c.193.125.523.125 1.18.125z"
+                            style="clip-rule: evenodd; fill: #e84142; fill-rule: evenodd; stroke-width: 0.02130493;"
+                          />
+                        </svg>
+                      </div>
+                      <p
+                        class="MuiTypography-root MuiTypography-body1"
+                        style="line-height: 1.4; margin-left: 10px; margin-right: 10px;"
+                      >
+                        gOHM-AVAX
+                      </p>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                        focusable="false"
+                        style="font-size: 15px;"
+                        viewBox="0 0 32 32"
+                      >
+                        <path
+                          d="M6.104 5.475h19.771v17.981H6.104z"
+                          style="fill: #fff; stroke-width: 0.02130493;"
+                        />
+                        <path
+                          d="M32 16c0 8.837-7.163 16-16 16S0 24.837 0 16 7.163 0 16 0s16 7.163 16 16Zm-20.534 6.367H8.361c-.653 0-.975 0-1.171-.126a.79.79 0 0 1-.358-.617c-.012-.232.15-.515.472-1.08L14.97 7.028c.326-.574.49-.86.7-.967a.791.791 0 0 1 .715 0c.208.106.373.393.7.967L18.66 9.78l.008.014c.353.615.531.927.61 1.255.086.358.086.735 0 1.093-.08.33-.256.644-.614 1.27l-4.027 7.119-.01.018c-.355.62-.535.935-.784 1.172-.271.26-.597.448-.955.555-.326.09-.692.09-1.423.09zm7.842 0h4.449c.656 0 .987 0 1.183-.13a.787.787 0 0 0 .358-.62c.011-.225-.146-.497-.455-1.03l-.033-.055-2.228-3.813-.026-.043c-.313-.53-.471-.797-.674-.9a.783.783 0 0 0-.711 0c-.205.106-.37.385-.696.947l-2.22 3.813-.009.013c-.325.56-.487.841-.476 1.071a.796.796 0 0 0 .358.622c.193.125.523.125 1.18.125z"
+                          style="clip-rule: evenodd; fill: #e84142; fill-rule: evenodd; stroke-width: 0.02130493;"
+                        />
+                      </svg>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                      style="line-height: 1.4;"
+                    >
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
+                        style="width: 100%;"
+                      />
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                      style="line-height: 1.4;"
+                    >
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
+                        style="width: 100%;"
+                      />
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                      style="line-height: 1.4;"
+                    />
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <a
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-363 makeStyles-root-381 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      href="https://traderjoexyz.com/farm/0xB674f93952F02F2538214D4572Aa47F262e990Ff-0x188bED1968b795d5c9022F6a0bb5931Ac4c18F00"
+                      tabindex="0"
+                      target="_blank"
+                    >
+                      <span
+                        class="MuiButton-label"
+                      >
+                        Stake on
+                         
+                        Trader Joe
+                        <span
+                          class="MuiButton-endIcon MuiButton-iconSizeSmall"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                            focusable="false"
+                            viewBox="0 0 20 20"
+                          >
+                            <path
+                              d="M4.297 17.445h9.539c1.523 0 2.305-.78 2.305-2.28v-9.58c0-1.507-.782-2.288-2.305-2.288h-9.54c-1.523 0-2.304.773-2.304 2.289v9.578c0 1.508.781 2.281 2.305 2.281Zm.016-.968c-.875 0-1.352-.461-1.352-1.368V5.633c0-.899.477-1.367 1.352-1.367h9.5c.867 0 1.359.468 1.359 1.367v9.476c0 .907-.492 1.368-1.36 1.368h-9.5Zm7.296-4.235c.266 0 .438-.195.438-.476V7.867c0-.344-.188-.492-.492-.492H7.64c-.29 0-.47.172-.47.438 0 .265.188.445.477.445H9.53l1.133-.078-1.055.992-3.382 3.383a.476.476 0 0 0-.149.328c0 .273.18.453.453.453a.47.47 0 0 0 .344-.149L10.25 9.82l.984-1.047-.078 1.282v1.718c0 .29.18.47.453.47Z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </a>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root MuiBox-root-382"
+                      style="white-space: nowrap;"
+                    >
+                      <div
+                        class="MuiBox-root MuiBox-root-383"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                          focusable="false"
+                          style="z-index: 1;"
+                          viewBox="0 0 32 32"
+                        >
+                          <defs>
+                            <lineargradient
+                              gradientTransform="matrix(0.177778, 0, 0, 0.177778, 1.777779, 1.777779)"
+                              gradientUnits="userSpaceOnUse"
+                              id="paint0_linear_359"
+                              x1="80"
+                              x2="80"
+                              y1="-84"
+                              y2="256"
+                            >
+                              <stop
+                                offset="0.1949"
+                                stop-color="#708B96"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#F7FBE7"
+                              />
+                            </lineargradient>
+                          </defs>
+                          <path
+                            d="M 1.778 16 C 1.778 8.145 8.145 1.778 16 1.778 C 23.855 1.778 30.222 8.145 30.222 16 C 30.222 23.855 23.855 30.222 16 30.222 C 8.145 30.222 1.778 23.855 1.778 16 Z"
+                            fill="#fff"
+                          />
+                          <rect
+                            fill="#fff"
+                            height="12.516"
+                            width="12.516"
+                            x="9.742"
+                            y="9.771"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M 14.635 22.286 L 14.635 19.916 C 12.852 19.355 11.563 17.725 11.563 15.801 C 11.563 13.413 13.549 11.477 16 11.477 C 18.451 11.477 20.437 13.413 20.437 15.801 C 20.437 17.725 19.148 19.355 17.365 19.916 L 17.365 21.658 L 17.365 22.258 L 17.365 22.286 L 22.258 22.286 L 22.258 20.523 L 19.842 20.523 C 21.295 19.421 22.229 17.709 22.229 15.787 C 22.229 12.464 19.44 9.771 16 9.771 C 12.56 9.771 9.771 12.464 9.771 15.787 C 9.771 17.709 10.705 19.421 12.158 20.523 L 9.742 20.523 L 9.742 22.286 Z"
+                            fill="#708b96"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            d="M 16 28.444 C 9.127 28.444 3.556 22.873 3.556 16 L 0 16 C 0 24.837 7.163 32 16 32 Z M 28.444 16 C 28.444 22.873 22.873 28.444 16 28.444 L 16 32 C 24.837 32 32 24.837 32 16 Z M 16 3.556 C 22.873 3.556 28.444 9.127 28.444 16 L 32 16 C 32 7.163 24.837 0 16 0 Z M 16 0 C 7.163 0 0 7.163 0 16 L 3.556 16 C 3.556 9.127 9.127 3.556 16 3.556 Z"
+                            fill="url(#paint0_linear_359)"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                          focusable="false"
+                          style="margin-left: -6px; z-index: 1;"
+                          viewBox="0 0 32 32"
+                        >
+                          <defs>
+                            <style>
+                              .fantom_svg__cls-1{fill:#fff;fill-rule:evenodd}
+                            </style>
+                            <mask
+                              height="20"
+                              id="fantom_svg__mask"
+                              maskUnits="userSpaceOnUse"
+                              width="93.1"
+                              x="10"
+                              y="6"
+                            >
+                              <path
+                                class="fantom_svg__cls-1"
+                                d="M10 6h93.1v20H10Z"
+                                id="fantom_svg__a"
+                              />
+                            </mask>
+                          </defs>
+                          <g
+                            data-name="Layer 2"
+                            id="fantom_svg__Layer_2"
+                          >
+                            <g
+                              data-name="Layer 1"
+                              id="fantom_svg__Layer_1-2"
+                            >
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="16"
+                                style="fill: #13b5ec;"
+                              />
+                              <path
+                                class="fantom_svg__cls-1"
+                                d="m17.2 12.9 3.6-2.1V15Zm3.6 9L16 24.7l-4.8-2.8V17l4.8 2.8 4.8-2.8Zm-9.6-11.1 3.6 2.1-3.6 2.1Zm5.4 3.1 3.6 2.1-3.6 2.1Zm-1.2 4.2L11.8 16l3.6-2.1Zm4.8-8.3L16 12.2l-4.2-2.4L16 7.3ZM10 9.4v13.1l6 3.4 6-3.4V9.4L16 6Z"
+                                style="mask: url(#fantom_svg__mask);"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                      </div>
+                      <p
+                        class="MuiTypography-root MuiTypography-body1"
+                        style="line-height: 1.4; margin-left: 10px; margin-right: 10px;"
+                      >
+                        gOHM-FTM
+                      </p>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                        focusable="false"
+                        style="font-size: 15px;"
+                        viewBox="0 0 32 32"
+                      >
+                        <defs>
+                          <style>
+                            .fantom_svg__cls-1{fill:#fff;fill-rule:evenodd}
+                          </style>
+                          <mask
+                            height="20"
+                            id="fantom_svg__mask"
+                            maskUnits="userSpaceOnUse"
+                            width="93.1"
+                            x="10"
+                            y="6"
+                          >
+                            <path
+                              class="fantom_svg__cls-1"
+                              d="M10 6h93.1v20H10Z"
+                              id="fantom_svg__a"
+                            />
+                          </mask>
+                        </defs>
+                        <g
+                          data-name="Layer 2"
+                          id="fantom_svg__Layer_2"
+                        >
+                          <g
+                            data-name="Layer 1"
+                            id="fantom_svg__Layer_1-2"
+                          >
+                            <circle
+                              cx="16"
+                              cy="16"
+                              r="16"
+                              style="fill: #13b5ec;"
+                            />
+                            <path
+                              class="fantom_svg__cls-1"
+                              d="m17.2 12.9 3.6-2.1V15Zm3.6 9L16 24.7l-4.8-2.8V17l4.8 2.8 4.8-2.8Zm-9.6-11.1 3.6 2.1-3.6 2.1Zm5.4 3.1 3.6 2.1-3.6 2.1Zm-1.2 4.2L11.8 16l3.6-2.1Zm4.8-8.3L16 12.2l-4.2-2.4L16 7.3ZM10 9.4v13.1l6 3.4 6-3.4V9.4L16 6Z"
+                              style="mask: url(#fantom_svg__mask);"
+                            />
+                          </g>
+                        </g>
+                      </svg>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                      style="line-height: 1.4;"
+                    >
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
+                        style="width: 100%;"
+                      />
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                      style="line-height: 1.4;"
+                    >
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
+                        style="width: 100%;"
+                      />
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                      style="line-height: 1.4;"
+                    />
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <a
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-363 makeStyles-root-384 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      href="https://app.spiritswap.finance/#/farms/allfarms"
+                      tabindex="0"
+                      target="_blank"
+                    >
+                      <span
+                        class="MuiButton-label"
+                      >
+                        Stake on
+                         
+                        Spirit
+                        <span
+                          class="MuiButton-endIcon MuiButton-iconSizeSmall"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                            focusable="false"
+                            viewBox="0 0 20 20"
+                          >
+                            <path
+                              d="M4.297 17.445h9.539c1.523 0 2.305-.78 2.305-2.28v-9.58c0-1.507-.782-2.288-2.305-2.288h-9.54c-1.523 0-2.304.773-2.304 2.289v9.578c0 1.508.781 2.281 2.305 2.281Zm.016-.968c-.875 0-1.352-.461-1.352-1.368V5.633c0-.899.477-1.367 1.352-1.367h9.5c.867 0 1.359.468 1.359 1.367v9.476c0 .907-.492 1.368-1.36 1.368h-9.5Zm7.296-4.235c.266 0 .438-.195.438-.476V7.867c0-.344-.188-.492-.492-.492H7.64c-.29 0-.47.172-.47.438 0 .265.188.445.477.445H9.53l1.133-.078-1.055.992-3.382 3.383a.476.476 0 0 0-.149.328c0 .273.18.453.453.453a.47.47 0 0 0 .344-.149L10.25 9.82l.984-1.047-.078 1.282v1.718c0 .29.18.47.453.47Z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </a>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root"
+                >
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <div
+                      class="MuiBox-root MuiBox-root-385"
+                      style="white-space: nowrap;"
+                    >
+                      <div
+                        class="MuiBox-root MuiBox-root-386"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                          focusable="false"
+                          style="z-index: 1;"
+                          viewBox="0 0 32 32"
+                        >
+                          <defs>
+                            <lineargradient
+                              gradientTransform="matrix(0.177778, 0, 0, 0.177778, 1.777779, 1.777779)"
+                              gradientUnits="userSpaceOnUse"
+                              id="paint0_linear_359"
+                              x1="80"
+                              x2="80"
+                              y1="-84"
+                              y2="256"
+                            >
+                              <stop
+                                offset="0.1949"
+                                stop-color="#708B96"
+                              />
+                              <stop
+                                offset="1"
+                                stop-color="#F7FBE7"
+                              />
+                            </lineargradient>
+                          </defs>
+                          <path
+                            d="M 1.778 16 C 1.778 8.145 8.145 1.778 16 1.778 C 23.855 1.778 30.222 8.145 30.222 16 C 30.222 23.855 23.855 30.222 16 30.222 C 8.145 30.222 1.778 23.855 1.778 16 Z"
+                            fill="#fff"
+                          />
+                          <rect
+                            fill="#fff"
+                            height="12.516"
+                            width="12.516"
+                            x="9.742"
+                            y="9.771"
+                          />
+                          <path
+                            clip-rule="evenodd"
+                            d="M 14.635 22.286 L 14.635 19.916 C 12.852 19.355 11.563 17.725 11.563 15.801 C 11.563 13.413 13.549 11.477 16 11.477 C 18.451 11.477 20.437 13.413 20.437 15.801 C 20.437 17.725 19.148 19.355 17.365 19.916 L 17.365 21.658 L 17.365 22.258 L 17.365 22.286 L 22.258 22.286 L 22.258 20.523 L 19.842 20.523 C 21.295 19.421 22.229 17.709 22.229 15.787 C 22.229 12.464 19.44 9.771 16 9.771 C 12.56 9.771 9.771 12.464 9.771 15.787 C 9.771 17.709 10.705 19.421 12.158 20.523 L 9.742 20.523 L 9.742 22.286 Z"
+                            fill="#708b96"
+                            fill-rule="evenodd"
+                          />
+                          <path
+                            d="M 16 28.444 C 9.127 28.444 3.556 22.873 3.556 16 L 0 16 C 0 24.837 7.163 32 16 32 Z M 28.444 16 C 28.444 22.873 22.873 28.444 16 28.444 L 16 32 C 24.837 32 32 24.837 32 16 Z M 16 3.556 C 22.873 3.556 28.444 9.127 28.444 16 L 32 16 C 32 7.163 24.837 0 16 0 Z M 16 0 C 7.163 0 0 7.163 0 16 L 3.556 16 C 3.556 9.127 9.127 3.556 16 3.556 Z"
+                            fill="url(#paint0_linear_359)"
+                          />
+                        </svg>
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                          focusable="false"
+                          style="margin-left: -6px; z-index: 1;"
+                          viewBox="0 0 32 32"
+                        >
+                          <defs>
+                            <style>
+                              .fantom_svg__cls-1{fill:#fff;fill-rule:evenodd}
+                            </style>
+                            <mask
+                              height="20"
+                              id="fantom_svg__mask"
+                              maskUnits="userSpaceOnUse"
+                              width="93.1"
+                              x="10"
+                              y="6"
+                            >
+                              <path
+                                class="fantom_svg__cls-1"
+                                d="M10 6h93.1v20H10Z"
+                                id="fantom_svg__a"
+                              />
+                            </mask>
+                          </defs>
+                          <g
+                            data-name="Layer 2"
+                            id="fantom_svg__Layer_2"
+                          >
+                            <g
+                              data-name="Layer 1"
+                              id="fantom_svg__Layer_1-2"
+                            >
+                              <circle
+                                cx="16"
+                                cy="16"
+                                r="16"
+                                style="fill: #13b5ec;"
+                              />
+                              <path
+                                class="fantom_svg__cls-1"
+                                d="m17.2 12.9 3.6-2.1V15Zm3.6 9L16 24.7l-4.8-2.8V17l4.8 2.8 4.8-2.8Zm-9.6-11.1 3.6 2.1-3.6 2.1Zm5.4 3.1 3.6 2.1-3.6 2.1Zm-1.2 4.2L11.8 16l3.6-2.1Zm4.8-8.3L16 12.2l-4.2-2.4L16 7.3ZM10 9.4v13.1l6 3.4 6-3.4V9.4L16 6Z"
+                                style="mask: url(#fantom_svg__mask);"
+                              />
+                            </g>
+                          </g>
+                        </svg>
+                      </div>
+                      <p
+                        class="MuiTypography-root MuiTypography-body1"
+                        style="line-height: 1.4; margin-left: 10px; margin-right: 10px;"
+                      >
+                        gOHM-wFTM
+                      </p>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
+                        focusable="false"
+                        style="font-size: 15px;"
+                        viewBox="0 0 32 32"
+                      >
+                        <defs>
+                          <style>
+                            .fantom_svg__cls-1{fill:#fff;fill-rule:evenodd}
+                          </style>
+                          <mask
+                            height="20"
+                            id="fantom_svg__mask"
+                            maskUnits="userSpaceOnUse"
+                            width="93.1"
+                            x="10"
+                            y="6"
+                          >
+                            <path
+                              class="fantom_svg__cls-1"
+                              d="M10 6h93.1v20H10Z"
+                              id="fantom_svg__a"
+                            />
+                          </mask>
+                        </defs>
+                        <g
+                          data-name="Layer 2"
+                          id="fantom_svg__Layer_2"
+                        >
+                          <g
+                            data-name="Layer 1"
+                            id="fantom_svg__Layer_1-2"
+                          >
+                            <circle
+                              cx="16"
+                              cy="16"
+                              r="16"
+                              style="fill: #13b5ec;"
+                            />
+                            <path
+                              class="fantom_svg__cls-1"
+                              d="m17.2 12.9 3.6-2.1V15Zm3.6 9L16 24.7l-4.8-2.8V17l4.8 2.8 4.8-2.8Zm-9.6-11.1 3.6 2.1-3.6 2.1Zm5.4 3.1 3.6 2.1-3.6 2.1Zm-1.2 4.2L11.8 16l3.6-2.1Zm4.8-8.3L16 12.2l-4.2-2.4L16 7.3ZM10 9.4v13.1l6 3.4 6-3.4V9.4L16 6Z"
+                              style="mask: url(#fantom_svg__mask);"
+                            />
+                          </g>
+                        </g>
+                      </svg>
+                    </div>
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                      style="line-height: 1.4;"
+                    >
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
+                        style="width: 100%;"
+                      />
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                      style="line-height: 1.4;"
+                    >
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
+                        style="width: 100%;"
+                      />
+                    </p>
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1"
+                      style="line-height: 1.4;"
+                    />
+                  </td>
+                  <td
+                    class="MuiTableCell-root"
+                  >
+                    <a
+                      aria-disabled="false"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-363 makeStyles-root-387 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      href="https://beets.fi/#/pool/0xf7bf0f161d3240488807ffa23894452246049916000200000000000000000198"
+                      tabindex="0"
+                      target="_blank"
+                    >
+                      <span
+                        class="MuiButton-label"
+                      >
+                        Stake on
+                         
+                        Beethoven
                         <span
                           class="MuiButton-endIcon MuiButton-iconSizeSmall"
                         >
@@ -5285,844 +6122,6 @@ exports[`<App/> should not render an error message when user wallet is connected
                         style="font-size: 15px;"
                         viewBox="0 0 32 32"
                       >
-                        <path
-                          d="M 24.23 10.528 C 23.645 10.194 22.893 10.194 22.225 10.528 L 17.546 13.285 L 14.371 15.039 L 9.775 17.797 C 9.191 18.131 8.439 18.131 7.77 17.797 L 4.178 15.624 C 3.593 15.29 3.175 14.622 3.175 13.87 L 3.175 9.692 C 3.175 9.024 3.509 8.355 4.178 7.938 L 7.77 5.849 C 8.355 5.515 9.107 5.515 9.775 5.849 L 13.368 8.021 C 13.953 8.355 14.371 9.024 14.371 9.776 L 14.371 12.533 L 17.546 10.695 L 17.546 7.854 C 17.546 7.186 17.211 6.517 16.543 6.1 L 9.859 2.173 C 9.274 1.838 8.522 1.838 7.854 2.173 L 1.003 6.183 C 0.334 6.517 0 7.186 0 7.854 L 0 15.708 C 0 16.376 0.334 17.045 1.003 17.462 L 7.77 21.389 C 8.355 21.724 9.107 21.724 9.775 21.389 L 14.371 18.716 L 17.546 16.878 L 22.141 14.204 C 22.726 13.87 23.478 13.87 24.146 14.204 L 27.739 16.293 C 28.324 16.627 28.742 17.295 28.742 18.047 L 28.742 22.225 C 28.742 22.893 28.407 23.562 27.739 23.979 L 24.23 26.068 C 23.645 26.402 22.893 26.402 22.225 26.068 L 18.632 23.979 C 18.047 23.645 17.629 22.977 17.629 22.225 L 17.629 19.551 L 14.454 21.389 L 14.454 24.147 C 14.454 24.815 14.789 25.483 15.457 25.901 L 22.225 29.828 C 22.809 30.162 23.561 30.162 24.23 29.828 L 30.997 25.901 C 31.582 25.567 32 24.899 32 24.147 L 32 16.209 C 32 15.541 31.666 14.872 30.997 14.455 L 24.23 10.528 Z"
-                          fill="#8247e5"
-                        />
-                      </svg>
-                    </div>
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    >
-                      <span
-                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
-                      />
-                    </p>
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    >
-                      <span
-                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
-                      />
-                    </p>
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <a
-                      aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-375 makeStyles-root-390 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
-                      href="https://app.sushi.com/farm?filter=2x"
-                      tabindex="0"
-                      target="_blank"
-                    >
-                      <span
-                        class="MuiButton-label"
-                      >
-                        Stake on
-                         
-                        Sushi
-                        <span
-                          class="MuiButton-endIcon MuiButton-iconSizeSmall"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                            focusable="false"
-                            viewBox="0 0 20 20"
-                          >
-                            <path
-                              d="M4.297 17.445h9.539c1.523 0 2.305-.78 2.305-2.28v-9.58c0-1.507-.782-2.288-2.305-2.288h-9.54c-1.523 0-2.304.773-2.304 2.289v9.578c0 1.508.781 2.281 2.305 2.281Zm.016-.968c-.875 0-1.352-.461-1.352-1.368V5.633c0-.899.477-1.367 1.352-1.367h9.5c.867 0 1.359.468 1.359 1.367v9.476c0 .907-.492 1.368-1.36 1.368h-9.5Zm7.296-4.235c.266 0 .438-.195.438-.476V7.867c0-.344-.188-.492-.492-.492H7.64c-.29 0-.47.172-.47.438 0 .265.188.445.477.445H9.53l1.133-.078-1.055.992-3.382 3.383a.476.476 0 0 0-.149.328c0 .273.18.453.453.453a.47.47 0 0 0 .344-.149L10.25 9.82l.984-1.047-.078 1.282v1.718c0 .29.18.47.453.47Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                    </a>
-                  </td>
-                </tr>
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <div
-                      class="MuiBox-root MuiBox-root-391"
-                      style="white-space: nowrap;"
-                    >
-                      <div
-                        class="MuiBox-root MuiBox-root-392"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                          focusable="false"
-                          style="z-index: 1;"
-                          viewBox="0 0 32 32"
-                        >
-                          <defs>
-                            <lineargradient
-                              gradientTransform="matrix(0.177778, 0, 0, 0.177778, 1.777779, 1.777779)"
-                              gradientUnits="userSpaceOnUse"
-                              id="paint0_linear_359"
-                              x1="80"
-                              x2="80"
-                              y1="-84"
-                              y2="256"
-                            >
-                              <stop
-                                offset="0.1949"
-                                stop-color="#708B96"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#F7FBE7"
-                              />
-                            </lineargradient>
-                          </defs>
-                          <path
-                            d="M 1.778 16 C 1.778 8.145 8.145 1.778 16 1.778 C 23.855 1.778 30.222 8.145 30.222 16 C 30.222 23.855 23.855 30.222 16 30.222 C 8.145 30.222 1.778 23.855 1.778 16 Z"
-                            fill="#fff"
-                          />
-                          <rect
-                            fill="#fff"
-                            height="12.516"
-                            width="12.516"
-                            x="9.742"
-                            y="9.771"
-                          />
-                          <path
-                            clip-rule="evenodd"
-                            d="M 14.635 22.286 L 14.635 19.916 C 12.852 19.355 11.563 17.725 11.563 15.801 C 11.563 13.413 13.549 11.477 16 11.477 C 18.451 11.477 20.437 13.413 20.437 15.801 C 20.437 17.725 19.148 19.355 17.365 19.916 L 17.365 21.658 L 17.365 22.258 L 17.365 22.286 L 22.258 22.286 L 22.258 20.523 L 19.842 20.523 C 21.295 19.421 22.229 17.709 22.229 15.787 C 22.229 12.464 19.44 9.771 16 9.771 C 12.56 9.771 9.771 12.464 9.771 15.787 C 9.771 17.709 10.705 19.421 12.158 20.523 L 9.742 20.523 L 9.742 22.286 Z"
-                            fill="#708b96"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            d="M 16 28.444 C 9.127 28.444 3.556 22.873 3.556 16 L 0 16 C 0 24.837 7.163 32 16 32 Z M 28.444 16 C 28.444 22.873 22.873 28.444 16 28.444 L 16 32 C 24.837 32 32 24.837 32 16 Z M 16 3.556 C 22.873 3.556 28.444 9.127 28.444 16 L 32 16 C 32 7.163 24.837 0 16 0 Z M 16 0 C 7.163 0 0 7.163 0 16 L 3.556 16 C 3.556 9.127 9.127 3.556 16 3.556 Z"
-                            fill="url(#paint0_linear_359)"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                          focusable="false"
-                          style="margin-left: -6px; z-index: 1;"
-                          viewBox="0 0 32 32"
-                        >
-                          <path
-                            d="M6.104 5.475h19.771v17.981H6.104z"
-                            style="fill: #fff; stroke-width: 0.02130493;"
-                          />
-                          <path
-                            d="M32 16c0 8.837-7.163 16-16 16S0 24.837 0 16 7.163 0 16 0s16 7.163 16 16Zm-20.534 6.367H8.361c-.653 0-.975 0-1.171-.126a.79.79 0 0 1-.358-.617c-.012-.232.15-.515.472-1.08L14.97 7.028c.326-.574.49-.86.7-.967a.791.791 0 0 1 .715 0c.208.106.373.393.7.967L18.66 9.78l.008.014c.353.615.531.927.61 1.255.086.358.086.735 0 1.093-.08.33-.256.644-.614 1.27l-4.027 7.119-.01.018c-.355.62-.535.935-.784 1.172-.271.26-.597.448-.955.555-.326.09-.692.09-1.423.09zm7.842 0h4.449c.656 0 .987 0 1.183-.13a.787.787 0 0 0 .358-.62c.011-.225-.146-.497-.455-1.03l-.033-.055-2.228-3.813-.026-.043c-.313-.53-.471-.797-.674-.9a.783.783 0 0 0-.711 0c-.205.106-.37.385-.696.947l-2.22 3.813-.009.013c-.325.56-.487.841-.476 1.071a.796.796 0 0 0 .358.622c.193.125.523.125 1.18.125z"
-                            style="clip-rule: evenodd; fill: #e84142; fill-rule: evenodd; stroke-width: 0.02130493;"
-                          />
-                        </svg>
-                      </div>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1"
-                        style="line-height: 1.4; margin-left: 10px; margin-right: 10px;"
-                      >
-                        gOHM-AVAX
-                      </p>
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                        focusable="false"
-                        style="font-size: 15px;"
-                        viewBox="0 0 32 32"
-                      >
-                        <path
-                          d="M6.104 5.475h19.771v17.981H6.104z"
-                          style="fill: #fff; stroke-width: 0.02130493;"
-                        />
-                        <path
-                          d="M32 16c0 8.837-7.163 16-16 16S0 24.837 0 16 7.163 0 16 0s16 7.163 16 16Zm-20.534 6.367H8.361c-.653 0-.975 0-1.171-.126a.79.79 0 0 1-.358-.617c-.012-.232.15-.515.472-1.08L14.97 7.028c.326-.574.49-.86.7-.967a.791.791 0 0 1 .715 0c.208.106.373.393.7.967L18.66 9.78l.008.014c.353.615.531.927.61 1.255.086.358.086.735 0 1.093-.08.33-.256.644-.614 1.27l-4.027 7.119-.01.018c-.355.62-.535.935-.784 1.172-.271.26-.597.448-.955.555-.326.09-.692.09-1.423.09zm7.842 0h4.449c.656 0 .987 0 1.183-.13a.787.787 0 0 0 .358-.62c.011-.225-.146-.497-.455-1.03l-.033-.055-2.228-3.813-.026-.043c-.313-.53-.471-.797-.674-.9a.783.783 0 0 0-.711 0c-.205.106-.37.385-.696.947l-2.22 3.813-.009.013c-.325.56-.487.841-.476 1.071a.796.796 0 0 0 .358.622c.193.125.523.125 1.18.125z"
-                          style="clip-rule: evenodd; fill: #e84142; fill-rule: evenodd; stroke-width: 0.02130493;"
-                        />
-                      </svg>
-                    </div>
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    >
-                      <span
-                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
-                      />
-                    </p>
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    >
-                      <span
-                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
-                      />
-                    </p>
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <a
-                      aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-375 makeStyles-root-393 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
-                      href="https://traderjoexyz.com/farm/0xB674f93952F02F2538214D4572Aa47F262e990Ff-0x188bED1968b795d5c9022F6a0bb5931Ac4c18F00"
-                      tabindex="0"
-                      target="_blank"
-                    >
-                      <span
-                        class="MuiButton-label"
-                      >
-                        Stake on
-                         
-                        Trader Joe
-                        <span
-                          class="MuiButton-endIcon MuiButton-iconSizeSmall"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                            focusable="false"
-                            viewBox="0 0 20 20"
-                          >
-                            <path
-                              d="M4.297 17.445h9.539c1.523 0 2.305-.78 2.305-2.28v-9.58c0-1.507-.782-2.288-2.305-2.288h-9.54c-1.523 0-2.304.773-2.304 2.289v9.578c0 1.508.781 2.281 2.305 2.281Zm.016-.968c-.875 0-1.352-.461-1.352-1.368V5.633c0-.899.477-1.367 1.352-1.367h9.5c.867 0 1.359.468 1.359 1.367v9.476c0 .907-.492 1.368-1.36 1.368h-9.5Zm7.296-4.235c.266 0 .438-.195.438-.476V7.867c0-.344-.188-.492-.492-.492H7.64c-.29 0-.47.172-.47.438 0 .265.188.445.477.445H9.53l1.133-.078-1.055.992-3.382 3.383a.476.476 0 0 0-.149.328c0 .273.18.453.453.453a.47.47 0 0 0 .344-.149L10.25 9.82l.984-1.047-.078 1.282v1.718c0 .29.18.47.453.47Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                    </a>
-                  </td>
-                </tr>
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <div
-                      class="MuiBox-root MuiBox-root-394"
-                      style="white-space: nowrap;"
-                    >
-                      <div
-                        class="MuiBox-root MuiBox-root-395"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                          focusable="false"
-                          style="z-index: 1;"
-                          viewBox="0 0 32 32"
-                        >
-                          <defs>
-                            <lineargradient
-                              gradientTransform="matrix(0.177778, 0, 0, 0.177778, 1.777779, 1.777779)"
-                              gradientUnits="userSpaceOnUse"
-                              id="paint0_linear_359"
-                              x1="80"
-                              x2="80"
-                              y1="-84"
-                              y2="256"
-                            >
-                              <stop
-                                offset="0.1949"
-                                stop-color="#708B96"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#F7FBE7"
-                              />
-                            </lineargradient>
-                          </defs>
-                          <path
-                            d="M 1.778 16 C 1.778 8.145 8.145 1.778 16 1.778 C 23.855 1.778 30.222 8.145 30.222 16 C 30.222 23.855 23.855 30.222 16 30.222 C 8.145 30.222 1.778 23.855 1.778 16 Z"
-                            fill="#fff"
-                          />
-                          <rect
-                            fill="#fff"
-                            height="12.516"
-                            width="12.516"
-                            x="9.742"
-                            y="9.771"
-                          />
-                          <path
-                            clip-rule="evenodd"
-                            d="M 14.635 22.286 L 14.635 19.916 C 12.852 19.355 11.563 17.725 11.563 15.801 C 11.563 13.413 13.549 11.477 16 11.477 C 18.451 11.477 20.437 13.413 20.437 15.801 C 20.437 17.725 19.148 19.355 17.365 19.916 L 17.365 21.658 L 17.365 22.258 L 17.365 22.286 L 22.258 22.286 L 22.258 20.523 L 19.842 20.523 C 21.295 19.421 22.229 17.709 22.229 15.787 C 22.229 12.464 19.44 9.771 16 9.771 C 12.56 9.771 9.771 12.464 9.771 15.787 C 9.771 17.709 10.705 19.421 12.158 20.523 L 9.742 20.523 L 9.742 22.286 Z"
-                            fill="#708b96"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            d="M 16 28.444 C 9.127 28.444 3.556 22.873 3.556 16 L 0 16 C 0 24.837 7.163 32 16 32 Z M 28.444 16 C 28.444 22.873 22.873 28.444 16 28.444 L 16 32 C 24.837 32 32 24.837 32 16 Z M 16 3.556 C 22.873 3.556 28.444 9.127 28.444 16 L 32 16 C 32 7.163 24.837 0 16 0 Z M 16 0 C 7.163 0 0 7.163 0 16 L 3.556 16 C 3.556 9.127 9.127 3.556 16 3.556 Z"
-                            fill="url(#paint0_linear_359)"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                          focusable="false"
-                          style="margin-left: -6px; z-index: 1;"
-                          viewBox="0 0 32 32"
-                        >
-                          <defs>
-                            <style>
-                              .fantom_svg__cls-1{fill:#fff;fill-rule:evenodd}
-                            </style>
-                            <mask
-                              height="20"
-                              id="fantom_svg__mask"
-                              maskUnits="userSpaceOnUse"
-                              width="93.1"
-                              x="10"
-                              y="6"
-                            >
-                              <path
-                                class="fantom_svg__cls-1"
-                                d="M10 6h93.1v20H10Z"
-                                id="fantom_svg__a"
-                              />
-                            </mask>
-                          </defs>
-                          <g
-                            data-name="Layer 2"
-                            id="fantom_svg__Layer_2"
-                          >
-                            <g
-                              data-name="Layer 1"
-                              id="fantom_svg__Layer_1-2"
-                            >
-                              <circle
-                                cx="16"
-                                cy="16"
-                                r="16"
-                                style="fill: #13b5ec;"
-                              />
-                              <path
-                                class="fantom_svg__cls-1"
-                                d="m17.2 12.9 3.6-2.1V15Zm3.6 9L16 24.7l-4.8-2.8V17l4.8 2.8 4.8-2.8Zm-9.6-11.1 3.6 2.1-3.6 2.1Zm5.4 3.1 3.6 2.1-3.6 2.1Zm-1.2 4.2L11.8 16l3.6-2.1Zm4.8-8.3L16 12.2l-4.2-2.4L16 7.3ZM10 9.4v13.1l6 3.4 6-3.4V9.4L16 6Z"
-                                style="mask: url(#fantom_svg__mask);"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                      </div>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1"
-                        style="line-height: 1.4; margin-left: 10px; margin-right: 10px;"
-                      >
-                        gOHM-FTM
-                      </p>
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                        focusable="false"
-                        style="font-size: 15px;"
-                        viewBox="0 0 32 32"
-                      >
-                        <defs>
-                          <style>
-                            .fantom_svg__cls-1{fill:#fff;fill-rule:evenodd}
-                          </style>
-                          <mask
-                            height="20"
-                            id="fantom_svg__mask"
-                            maskUnits="userSpaceOnUse"
-                            width="93.1"
-                            x="10"
-                            y="6"
-                          >
-                            <path
-                              class="fantom_svg__cls-1"
-                              d="M10 6h93.1v20H10Z"
-                              id="fantom_svg__a"
-                            />
-                          </mask>
-                        </defs>
-                        <g
-                          data-name="Layer 2"
-                          id="fantom_svg__Layer_2"
-                        >
-                          <g
-                            data-name="Layer 1"
-                            id="fantom_svg__Layer_1-2"
-                          >
-                            <circle
-                              cx="16"
-                              cy="16"
-                              r="16"
-                              style="fill: #13b5ec;"
-                            />
-                            <path
-                              class="fantom_svg__cls-1"
-                              d="m17.2 12.9 3.6-2.1V15Zm3.6 9L16 24.7l-4.8-2.8V17l4.8 2.8 4.8-2.8Zm-9.6-11.1 3.6 2.1-3.6 2.1Zm5.4 3.1 3.6 2.1-3.6 2.1Zm-1.2 4.2L11.8 16l3.6-2.1Zm4.8-8.3L16 12.2l-4.2-2.4L16 7.3ZM10 9.4v13.1l6 3.4 6-3.4V9.4L16 6Z"
-                              style="mask: url(#fantom_svg__mask);"
-                            />
-                          </g>
-                        </g>
-                      </svg>
-                    </div>
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    >
-                      <span
-                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
-                      />
-                    </p>
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    >
-                      <span
-                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
-                      />
-                    </p>
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <a
-                      aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-375 makeStyles-root-396 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
-                      href="https://app.spiritswap.finance/#/farms/allfarms"
-                      tabindex="0"
-                      target="_blank"
-                    >
-                      <span
-                        class="MuiButton-label"
-                      >
-                        Stake on
-                         
-                        Spirit
-                        <span
-                          class="MuiButton-endIcon MuiButton-iconSizeSmall"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                            focusable="false"
-                            viewBox="0 0 20 20"
-                          >
-                            <path
-                              d="M4.297 17.445h9.539c1.523 0 2.305-.78 2.305-2.28v-9.58c0-1.507-.782-2.288-2.305-2.288h-9.54c-1.523 0-2.304.773-2.304 2.289v9.578c0 1.508.781 2.281 2.305 2.281Zm.016-.968c-.875 0-1.352-.461-1.352-1.368V5.633c0-.899.477-1.367 1.352-1.367h9.5c.867 0 1.359.468 1.359 1.367v9.476c0 .907-.492 1.368-1.36 1.368h-9.5Zm7.296-4.235c.266 0 .438-.195.438-.476V7.867c0-.344-.188-.492-.492-.492H7.64c-.29 0-.47.172-.47.438 0 .265.188.445.477.445H9.53l1.133-.078-1.055.992-3.382 3.383a.476.476 0 0 0-.149.328c0 .273.18.453.453.453a.47.47 0 0 0 .344-.149L10.25 9.82l.984-1.047-.078 1.282v1.718c0 .29.18.47.453.47Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                    </a>
-                  </td>
-                </tr>
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <div
-                      class="MuiBox-root MuiBox-root-397"
-                      style="white-space: nowrap;"
-                    >
-                      <div
-                        class="MuiBox-root MuiBox-root-398"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                          focusable="false"
-                          style="z-index: 1;"
-                          viewBox="0 0 32 32"
-                        >
-                          <defs>
-                            <lineargradient
-                              gradientTransform="matrix(0.177778, 0, 0, 0.177778, 1.777779, 1.777779)"
-                              gradientUnits="userSpaceOnUse"
-                              id="paint0_linear_359"
-                              x1="80"
-                              x2="80"
-                              y1="-84"
-                              y2="256"
-                            >
-                              <stop
-                                offset="0.1949"
-                                stop-color="#708B96"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#F7FBE7"
-                              />
-                            </lineargradient>
-                          </defs>
-                          <path
-                            d="M 1.778 16 C 1.778 8.145 8.145 1.778 16 1.778 C 23.855 1.778 30.222 8.145 30.222 16 C 30.222 23.855 23.855 30.222 16 30.222 C 8.145 30.222 1.778 23.855 1.778 16 Z"
-                            fill="#fff"
-                          />
-                          <rect
-                            fill="#fff"
-                            height="12.516"
-                            width="12.516"
-                            x="9.742"
-                            y="9.771"
-                          />
-                          <path
-                            clip-rule="evenodd"
-                            d="M 14.635 22.286 L 14.635 19.916 C 12.852 19.355 11.563 17.725 11.563 15.801 C 11.563 13.413 13.549 11.477 16 11.477 C 18.451 11.477 20.437 13.413 20.437 15.801 C 20.437 17.725 19.148 19.355 17.365 19.916 L 17.365 21.658 L 17.365 22.258 L 17.365 22.286 L 22.258 22.286 L 22.258 20.523 L 19.842 20.523 C 21.295 19.421 22.229 17.709 22.229 15.787 C 22.229 12.464 19.44 9.771 16 9.771 C 12.56 9.771 9.771 12.464 9.771 15.787 C 9.771 17.709 10.705 19.421 12.158 20.523 L 9.742 20.523 L 9.742 22.286 Z"
-                            fill="#708b96"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            d="M 16 28.444 C 9.127 28.444 3.556 22.873 3.556 16 L 0 16 C 0 24.837 7.163 32 16 32 Z M 28.444 16 C 28.444 22.873 22.873 28.444 16 28.444 L 16 32 C 24.837 32 32 24.837 32 16 Z M 16 3.556 C 22.873 3.556 28.444 9.127 28.444 16 L 32 16 C 32 7.163 24.837 0 16 0 Z M 16 0 C 7.163 0 0 7.163 0 16 L 3.556 16 C 3.556 9.127 9.127 3.556 16 3.556 Z"
-                            fill="url(#paint0_linear_359)"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                          focusable="false"
-                          style="margin-left: -6px; z-index: 1;"
-                          viewBox="0 0 32 32"
-                        >
-                          <defs>
-                            <style>
-                              .fantom_svg__cls-1{fill:#fff;fill-rule:evenodd}
-                            </style>
-                            <mask
-                              height="20"
-                              id="fantom_svg__mask"
-                              maskUnits="userSpaceOnUse"
-                              width="93.1"
-                              x="10"
-                              y="6"
-                            >
-                              <path
-                                class="fantom_svg__cls-1"
-                                d="M10 6h93.1v20H10Z"
-                                id="fantom_svg__a"
-                              />
-                            </mask>
-                          </defs>
-                          <g
-                            data-name="Layer 2"
-                            id="fantom_svg__Layer_2"
-                          >
-                            <g
-                              data-name="Layer 1"
-                              id="fantom_svg__Layer_1-2"
-                            >
-                              <circle
-                                cx="16"
-                                cy="16"
-                                r="16"
-                                style="fill: #13b5ec;"
-                              />
-                              <path
-                                class="fantom_svg__cls-1"
-                                d="m17.2 12.9 3.6-2.1V15Zm3.6 9L16 24.7l-4.8-2.8V17l4.8 2.8 4.8-2.8Zm-9.6-11.1 3.6 2.1-3.6 2.1Zm5.4 3.1 3.6 2.1-3.6 2.1Zm-1.2 4.2L11.8 16l3.6-2.1Zm4.8-8.3L16 12.2l-4.2-2.4L16 7.3ZM10 9.4v13.1l6 3.4 6-3.4V9.4L16 6Z"
-                                style="mask: url(#fantom_svg__mask);"
-                              />
-                            </g>
-                          </g>
-                        </svg>
-                      </div>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1"
-                        style="line-height: 1.4; margin-left: 10px; margin-right: 10px;"
-                      >
-                        gOHM-wFTM
-                      </p>
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                        focusable="false"
-                        style="font-size: 15px;"
-                        viewBox="0 0 32 32"
-                      >
-                        <defs>
-                          <style>
-                            .fantom_svg__cls-1{fill:#fff;fill-rule:evenodd}
-                          </style>
-                          <mask
-                            height="20"
-                            id="fantom_svg__mask"
-                            maskUnits="userSpaceOnUse"
-                            width="93.1"
-                            x="10"
-                            y="6"
-                          >
-                            <path
-                              class="fantom_svg__cls-1"
-                              d="M10 6h93.1v20H10Z"
-                              id="fantom_svg__a"
-                            />
-                          </mask>
-                        </defs>
-                        <g
-                          data-name="Layer 2"
-                          id="fantom_svg__Layer_2"
-                        >
-                          <g
-                            data-name="Layer 1"
-                            id="fantom_svg__Layer_1-2"
-                          >
-                            <circle
-                              cx="16"
-                              cy="16"
-                              r="16"
-                              style="fill: #13b5ec;"
-                            />
-                            <path
-                              class="fantom_svg__cls-1"
-                              d="m17.2 12.9 3.6-2.1V15Zm3.6 9L16 24.7l-4.8-2.8V17l4.8 2.8 4.8-2.8Zm-9.6-11.1 3.6 2.1-3.6 2.1Zm5.4 3.1 3.6 2.1-3.6 2.1Zm-1.2 4.2L11.8 16l3.6-2.1Zm4.8-8.3L16 12.2l-4.2-2.4L16 7.3ZM10 9.4v13.1l6 3.4 6-3.4V9.4L16 6Z"
-                              style="mask: url(#fantom_svg__mask);"
-                            />
-                          </g>
-                        </g>
-                      </svg>
-                    </div>
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    >
-                      <span
-                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
-                      />
-                    </p>
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    >
-                      <span
-                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
-                      />
-                    </p>
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <a
-                      aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-375 makeStyles-root-399 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
-                      href="https://beets.fi/#/pool/0xf7bf0f161d3240488807ffa23894452246049916000200000000000000000198"
-                      tabindex="0"
-                      target="_blank"
-                    >
-                      <span
-                        class="MuiButton-label"
-                      >
-                        Stake on
-                         
-                        Beethoven
-                        <span
-                          class="MuiButton-endIcon MuiButton-iconSizeSmall"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                            focusable="false"
-                            viewBox="0 0 20 20"
-                          >
-                            <path
-                              d="M4.297 17.445h9.539c1.523 0 2.305-.78 2.305-2.28v-9.58c0-1.507-.782-2.288-2.305-2.288h-9.54c-1.523 0-2.304.773-2.304 2.289v9.578c0 1.508.781 2.281 2.305 2.281Zm.016-.968c-.875 0-1.352-.461-1.352-1.368V5.633c0-.899.477-1.367 1.352-1.367h9.5c.867 0 1.359.468 1.359 1.367v9.476c0 .907-.492 1.368-1.36 1.368h-9.5Zm7.296-4.235c.266 0 .438-.195.438-.476V7.867c0-.344-.188-.492-.492-.492H7.64c-.29 0-.47.172-.47.438 0 .265.188.445.477.445H9.53l1.133-.078-1.055.992-3.382 3.383a.476.476 0 0 0-.149.328c0 .273.18.453.453.453a.47.47 0 0 0 .344-.149L10.25 9.82l.984-1.047-.078 1.282v1.718c0 .29.18.47.453.47Z"
-                            />
-                          </svg>
-                        </span>
-                      </span>
-                    </a>
-                  </td>
-                </tr>
-                <tr
-                  class="MuiTableRow-root"
-                >
-                  <td
-                    class="MuiTableCell-root"
-                  >
-                    <div
-                      class="MuiBox-root MuiBox-root-400"
-                      style="white-space: nowrap;"
-                    >
-                      <div
-                        class="MuiBox-root MuiBox-root-401"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                          focusable="false"
-                          style="z-index: 1;"
-                          viewBox="0 0 32 32"
-                        >
-                          <defs>
-                            <lineargradient
-                              gradientTransform="matrix(0.177778, 0, 0, 0.177778, 1.777779, 1.777779)"
-                              gradientUnits="userSpaceOnUse"
-                              id="paint0_linear_359"
-                              x1="80"
-                              x2="80"
-                              y1="-84"
-                              y2="256"
-                            >
-                              <stop
-                                offset="0.1949"
-                                stop-color="#708B96"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#F7FBE7"
-                              />
-                            </lineargradient>
-                          </defs>
-                          <path
-                            d="M 1.778 16 C 1.778 8.145 8.145 1.778 16 1.778 C 23.855 1.778 30.222 8.145 30.222 16 C 30.222 23.855 23.855 30.222 16 30.222 C 8.145 30.222 1.778 23.855 1.778 16 Z"
-                            fill="#fff"
-                          />
-                          <rect
-                            fill="#fff"
-                            height="12.516"
-                            width="12.516"
-                            x="9.742"
-                            y="9.771"
-                          />
-                          <path
-                            clip-rule="evenodd"
-                            d="M 14.635 22.286 L 14.635 19.916 C 12.852 19.355 11.563 17.725 11.563 15.801 C 11.563 13.413 13.549 11.477 16 11.477 C 18.451 11.477 20.437 13.413 20.437 15.801 C 20.437 17.725 19.148 19.355 17.365 19.916 L 17.365 21.658 L 17.365 22.258 L 17.365 22.286 L 22.258 22.286 L 22.258 20.523 L 19.842 20.523 C 21.295 19.421 22.229 17.709 22.229 15.787 C 22.229 12.464 19.44 9.771 16 9.771 C 12.56 9.771 9.771 12.464 9.771 15.787 C 9.771 17.709 10.705 19.421 12.158 20.523 L 9.742 20.523 L 9.742 22.286 Z"
-                            fill="#708b96"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            d="M 16 28.444 C 9.127 28.444 3.556 22.873 3.556 16 L 0 16 C 0 24.837 7.163 32 16 32 Z M 28.444 16 C 28.444 22.873 22.873 28.444 16 28.444 L 16 32 C 24.837 32 32 24.837 32 16 Z M 16 3.556 C 22.873 3.556 28.444 9.127 28.444 16 L 32 16 C 32 7.163 24.837 0 16 0 Z M 16 0 C 7.163 0 0 7.163 0 16 L 3.556 16 C 3.556 9.127 9.127 3.556 16 3.556 Z"
-                            fill="url(#paint0_linear_359)"
-                          />
-                        </svg>
-                        <svg
-                          aria-hidden="true"
-                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                          focusable="false"
-                          style="margin-left: -6px; z-index: 1;"
-                          viewBox="0 0 32 32"
-                        >
-                          <circle
-                            cx="16"
-                            cy="16"
-                            fill="#fff"
-                            r="15"
-                            stroke="url(#wETH_svg__a)"
-                            stroke-width="2"
-                          />
-                          <path
-                            clip-rule="evenodd"
-                            d="M16.25 20.976 10 17.349 16.25 26V26l6.253-8.65-6.253 3.626Z"
-                            fill="#708B96"
-                            fill-rule="evenodd"
-                          />
-                          <path
-                            clip-rule="evenodd"
-                            d="m16.25 6 6.248 10.186-6.248-2.793L10 16.186 16.25 6Zm0 7.395L10 16.185l6.25 3.629 6.248-3.628-6.248-2.791Z"
-                            fill="#424242"
-                            fill-rule="evenodd"
-                          />
-                          <defs>
-                            <lineargradient
-                              gradientUnits="userSpaceOnUse"
-                              id="wETH_svg__a"
-                              x1="16"
-                              x2="16"
-                              y1="0"
-                              y2="32"
-                            >
-                              <stop
-                                stop-color="#444243"
-                              />
-                              <stop
-                                offset="1"
-                                stop-color="#708B96"
-                              />
-                            </lineargradient>
-                          </defs>
-                        </svg>
-                      </div>
-                      <p
-                        class="MuiTypography-root MuiTypography-body1"
-                        style="line-height: 1.4; margin-left: 10px; margin-right: 10px;"
-                      >
-                        gOHM-wETH
-                      </p>
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeLarge"
-                        focusable="false"
-                        style="font-size: 15px;"
-                        viewBox="0 0 32 32"
-                      >
                         <circle
                           cx="16"
                           cy="16"
@@ -6179,7 +6178,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-375 makeStyles-root-402 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-363 makeStyles-root-390 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://zipswap.fi/#/farm/0x3f6da9334142477718bE2ecC3577d1A28dceAAe1"
                       tabindex="0"
                       target="_blank"
@@ -6215,11 +6214,11 @@ exports[`<App/> should not render an error message when user wallet is connected
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-403"
+                      class="MuiBox-root MuiBox-root-391"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-404"
+                        class="MuiBox-root MuiBox-root-392"
                       >
                         <svg
                           aria-hidden="true"
@@ -6758,7 +6757,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-375 makeStyles-root-405 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-363 makeStyles-root-393 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://jonesdao.io/farms"
                       tabindex="0"
                       target="_blank"
@@ -6794,11 +6793,11 @@ exports[`<App/> should not render an error message when user wallet is connected
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-406"
+                      class="MuiBox-root MuiBox-root-394"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-407"
+                        class="MuiBox-root MuiBox-root-395"
                       >
                         <svg
                           aria-hidden="true"
@@ -6976,7 +6975,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-375 makeStyles-root-408 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-363 makeStyles-root-396 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://app.balancer.fi/#/pool/0xc45d42f801105e861e86658648e3678ad7aa70f900010000000000000000011e"
                       tabindex="0"
                       target="_blank"
@@ -7012,11 +7011,11 @@ exports[`<App/> should not render an error message when user wallet is connected
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-409"
+                      class="MuiBox-root MuiBox-root-397"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-410"
+                        class="MuiBox-root MuiBox-root-398"
                       >
                         <svg
                           aria-hidden="true"
@@ -7210,7 +7209,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-375 makeStyles-root-411 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-363 makeStyles-root-399 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://oolongswap.com/#/farm/lp"
                       tabindex="0"
                       target="_blank"
@@ -7246,7 +7245,6 @@ exports[`<App/> should not render an error message when user wallet is connected
       </div>
     </div>
   </div>
-  <div />
 </div>
 `;
 
@@ -7259,14 +7257,14 @@ exports[`<App/> should render an error message when user wallet is connected and
       <div />
     </div>
     <header
-      class="MuiPaper-root MuiAppBar-root MuiAppBar-positionSticky MuiAppBar-colorPrimary makeStyles-appBar-772 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAppBar-root MuiAppBar-positionSticky MuiAppBar-colorPrimary makeStyles-appBar-744 MuiPaper-elevation0"
     >
       <div
         class="MuiToolbar-root MuiToolbar-regular dapp-topbar"
       >
         <button
           aria-label="open drawer"
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-menuButton-773 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-menuButton-745 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
           id="hamburger"
           tabindex="0"
           type="button"
@@ -7285,7 +7283,7 @@ exports[`<App/> should render an error message when user wallet is connected and
           </span>
         </button>
         <div
-          class="MuiBox-root MuiBox-root-774"
+          class="MuiBox-root MuiBox-root-746"
         >
           <a
             href="#/wallet"
@@ -7340,7 +7338,7 @@ exports[`<App/> should render an error message when user wallet is connected and
           </button>
           <button
             aria-describedby="locales-popper"
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-toggleButton-776 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-toggleButton-748 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
             tabindex="0"
             title="Change locale"
             type="button"
@@ -7387,7 +7385,7 @@ exports[`<App/> should render an error message when user wallet is connected and
       </div>
     </header>
     <nav
-      class="makeStyles-drawer-650"
+      class="makeStyles-drawer-626"
     >
       <div
         class="sidebar"
@@ -7403,13 +7401,13 @@ exports[`<App/> should render an error message when user wallet is connected and
               class="MuiPaper-root dapp-sidebar MuiPaper-elevation0 MuiPaper-rounded"
             >
               <div
-                class="MuiBox-root MuiBox-root-780 dapp-sidebar-inner"
+                class="MuiBox-root MuiBox-root-752 dapp-sidebar-inner"
               >
                 <div
                   class="dapp-menu-top"
                 >
                   <div
-                    class="MuiBox-root MuiBox-root-781 branding-header"
+                    class="MuiBox-root MuiBox-root-753 branding-header"
                   >
                     <a
                       class="MuiTypography-root MuiLink-root MuiLink-underlineNone MuiTypography-colorPrimary"
@@ -7435,17 +7433,17 @@ exports[`<App/> should render an error message when user wallet is connected and
                       id="navbarNav"
                     >
                       <div
-                        class="makeStyles-root-782 makeStyles-root-784 nav-item-container"
+                        class="makeStyles-root-754 makeStyles-root-756 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/dashboard"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-785 link-container"
+                            class="MuiBox-root MuiBox-root-757 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-786 makeStyles-title-783 title"
+                              class="MuiBox-root MuiBox-root-758 makeStyles-title-755 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7464,10 +7462,10 @@ exports[`<App/> should render an error message when user wallet is connected and
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-782 makeStyles-root-787 nav-item-container"
+                        class="makeStyles-root-754 makeStyles-root-759 nav-item-container"
                       >
                         <div
-                          class="MuiPaper-root MuiAccordion-root makeStyles-root-788 undefined Mui-expanded MuiPaper-elevation0"
+                          class="MuiPaper-root MuiAccordion-root makeStyles-root-760 undefined Mui-expanded MuiPaper-elevation0"
                         >
                           <div
                             aria-disabled="false"
@@ -7484,10 +7482,10 @@ exports[`<App/> should render an error message when user wallet is connected and
                                 href="#/bonds"
                               >
                                 <div
-                                  class="MuiBox-root MuiBox-root-789 link-container"
+                                  class="MuiBox-root MuiBox-root-761 link-container"
                                 >
                                   <div
-                                    class="MuiBox-root MuiBox-root-790 makeStyles-title-783 title"
+                                    class="MuiBox-root MuiBox-root-762 makeStyles-title-755 title"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -7550,7 +7548,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                         </div>
                       </div>
                       <div
-                        class="makeStyles-root-782 makeStyles-root-791 nav-item-container"
+                        class="makeStyles-root-754 makeStyles-root-763 nav-item-container"
                       >
                         <a
                           aria-current="page"
@@ -7558,10 +7556,10 @@ exports[`<App/> should render an error message when user wallet is connected and
                           href="#/stake"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-792 link-container"
+                            class="MuiBox-root MuiBox-root-764 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-793 makeStyles-title-783 title"
+                              class="MuiBox-root MuiBox-root-765 makeStyles-title-755 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7580,17 +7578,17 @@ exports[`<App/> should render an error message when user wallet is connected and
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-782 makeStyles-root-794 nav-item-container"
+                        class="makeStyles-root-754 makeStyles-root-766 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/zap"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-795 link-container"
+                            class="MuiBox-root MuiBox-root-767 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-796 makeStyles-title-783 title"
+                              class="MuiBox-root MuiBox-root-768 makeStyles-title-755 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7609,17 +7607,17 @@ exports[`<App/> should render an error message when user wallet is connected and
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-782 makeStyles-root-797 nav-item-container"
+                        class="makeStyles-root-754 makeStyles-root-769 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/give"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-798 link-container"
+                            class="MuiBox-root MuiBox-root-770 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-799 makeStyles-title-783 title"
+                              class="MuiBox-root MuiBox-root-771 makeStyles-title-755 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7638,17 +7636,17 @@ exports[`<App/> should render an error message when user wallet is connected and
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-782 makeStyles-root-800 nav-item-container"
+                        class="makeStyles-root-754 makeStyles-root-772 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/wrap"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-801 link-container"
+                            class="MuiBox-root MuiBox-root-773 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-802 makeStyles-title-783 title"
+                              class="MuiBox-root MuiBox-root-774 makeStyles-title-755 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7667,7 +7665,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-782 makeStyles-root-803 nav-item-container"
+                        class="makeStyles-root-754 makeStyles-root-775 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -7675,10 +7673,10 @@ exports[`<App/> should render an error message when user wallet is connected and
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-804 link-container"
+                            class="MuiBox-root MuiBox-root-776 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-805 makeStyles-title-783 title"
+                              class="MuiBox-root MuiBox-root-777 makeStyles-title-755 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7707,14 +7705,14 @@ exports[`<App/> should render an error message when user wallet is connected and
                         </a>
                       </div>
                       <div
-                        class="MuiBox-root MuiBox-root-806 menu-divider"
+                        class="MuiBox-root MuiBox-root-778 menu-divider"
                       >
                         <hr
                           class="MuiDivider-root"
                         />
                       </div>
                       <div
-                        class="makeStyles-root-782 makeStyles-root-807 nav-item-container"
+                        class="makeStyles-root-754 makeStyles-root-779 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -7722,10 +7720,10 @@ exports[`<App/> should render an error message when user wallet is connected and
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-808 link-container"
+                            class="MuiBox-root MuiBox-root-780 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-809 makeStyles-title-783 title"
+                              class="MuiBox-root MuiBox-root-781 makeStyles-title-755 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7754,14 +7752,14 @@ exports[`<App/> should render an error message when user wallet is connected and
                         </a>
                       </div>
                       <div
-                        class="MuiBox-root MuiBox-root-810 menu-divider"
+                        class="MuiBox-root MuiBox-root-782 menu-divider"
                       >
                         <hr
                           class="MuiDivider-root"
                         />
                       </div>
                       <div
-                        class="makeStyles-root-782 makeStyles-root-811 nav-item-container"
+                        class="makeStyles-root-754 makeStyles-root-783 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -7769,10 +7767,10 @@ exports[`<App/> should render an error message when user wallet is connected and
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-812 link-container"
+                            class="MuiBox-root MuiBox-root-784 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-813 makeStyles-title-783 title"
+                              class="MuiBox-root MuiBox-root-785 makeStyles-title-755 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7801,7 +7799,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-782 makeStyles-root-814 nav-item-container"
+                        class="makeStyles-root-754 makeStyles-root-786 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -7809,10 +7807,10 @@ exports[`<App/> should render an error message when user wallet is connected and
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-815 link-container"
+                            class="MuiBox-root MuiBox-root-787 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-816 makeStyles-title-783 title"
+                              class="MuiBox-root MuiBox-root-788 makeStyles-title-755 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7841,7 +7839,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-782 makeStyles-root-817 nav-item-container"
+                        class="makeStyles-root-754 makeStyles-root-789 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -7849,10 +7847,10 @@ exports[`<App/> should render an error message when user wallet is connected and
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-818 link-container"
+                            class="MuiBox-root MuiBox-root-790 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-819 makeStyles-title-783 title"
+                              class="MuiBox-root MuiBox-root-791 makeStyles-title-755 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7881,7 +7879,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-782 makeStyles-root-820 nav-item-container"
+                        class="makeStyles-root-754 makeStyles-root-792 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -7889,10 +7887,10 @@ exports[`<App/> should render an error message when user wallet is connected and
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-821 link-container"
+                            class="MuiBox-root MuiBox-root-793 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-822 makeStyles-title-783 title"
+                              class="MuiBox-root MuiBox-root-794 makeStyles-title-755 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7921,7 +7919,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-782 makeStyles-root-823 nav-item-container"
+                        class="makeStyles-root-754 makeStyles-root-795 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -7929,10 +7927,10 @@ exports[`<App/> should render an error message when user wallet is connected and
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-824 link-container"
+                            class="MuiBox-root MuiBox-root-796 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-825 makeStyles-title-783 title"
+                              class="MuiBox-root MuiBox-root-797 makeStyles-title-755 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -7964,7 +7962,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   </div>
                 </div>
                 <div
-                  class="MuiBox-root MuiBox-root-826"
+                  class="MuiBox-root MuiBox-root-798"
                 >
                   <a
                     class="MuiTypography-root MuiLink-root MuiLink-underlineNone MuiTypography-colorPrimary"
@@ -7973,7 +7971,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-779 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-751 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -7989,7 +7987,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-779 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-751 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -8005,7 +8003,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-779 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-751 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -8021,7 +8019,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-779 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-751 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -8038,13 +8036,13 @@ exports[`<App/> should render an error message when user wallet is connected and
       </div>
     </nav>
     <div
-      class="makeStyles-content-651 false"
+      class="makeStyles-content-627 false"
     >
       <div
         id="stake-view"
       >
         <div
-          class="MuiPaper-root makeStyles-root-827 makeStyles-root-828  MuiPaper-elevation0 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-root-799 makeStyles-root-800  MuiPaper-elevation0 MuiPaper-rounded"
           style="transform: none; webkit-transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
         >
           <div
@@ -8054,10 +8052,10 @@ exports[`<App/> should render an error message when user wallet is connected and
               class="MuiGrid-root card-header MuiGrid-item"
             >
               <div
-                class="MuiBox-root MuiBox-root-829"
+                class="MuiBox-root MuiBox-root-801"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-830"
+                  class="MuiBox-root MuiBox-root-802"
                 >
                   <h5
                     class="MuiTypography-root header-text MuiTypography-h5"
@@ -8070,10 +8068,10 @@ exports[`<App/> should render an error message when user wallet is connected and
                 />
               </div>
               <div
-                class="MuiBox-root MuiBox-root-831"
+                class="MuiBox-root MuiBox-root-803"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-832 rebase-timer"
+                  class="MuiBox-root MuiBox-root-804 rebase-timer"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body2"
@@ -8090,13 +8088,13 @@ exports[`<App/> should render an error message when user wallet is connected and
               class="MuiGrid-root MuiGrid-item"
             >
               <div
-                class="MuiBox-root MuiBox-root-833"
+                class="MuiBox-root MuiBox-root-805"
               >
                 <div
                   class="MuiGrid-root"
                 >
                   <div
-                    class="MuiBox-root MuiBox-root-834"
+                    class="MuiBox-root MuiBox-root-806"
                   >
                     <div
                       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-flex-end"
@@ -8105,10 +8103,10 @@ exports[`<App/> should render an error message when user wallet is connected and
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
                       >
                         <div
-                          class="makeStyles-root-835 stake-apy"
+                          class="makeStyles-root-807 stake-apy"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-836"
+                            class="MuiBox-root MuiBox-root-808"
                           >
                             <h5
                               class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
@@ -8131,10 +8129,10 @@ exports[`<App/> should render an error message when user wallet is connected and
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
                       >
                         <div
-                          class="makeStyles-root-835 stake-tvl"
+                          class="makeStyles-root-807 stake-tvl"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-837"
+                            class="MuiBox-root MuiBox-root-809"
                           >
                             <h5
                               class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
@@ -8157,21 +8155,21 @@ exports[`<App/> should render an error message when user wallet is connected and
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
                       >
                         <div
-                          class="makeStyles-root-835 stake-index"
+                          class="makeStyles-root-807 stake-index"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-838"
+                            class="MuiBox-root MuiBox-root-810"
                           >
                             <h5
                               class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
                             >
                               Current Index
                               <div
-                                class="MuiBox-root MuiBox-root-839"
+                                class="MuiBox-root MuiBox-root-811"
                                 style="font-size: 16px;"
                               >
                                 <div
-                                  class="MuiBox-root MuiBox-root-840"
+                                  class="MuiBox-root MuiBox-root-812"
                                   style="display: inline-flex; justify-content: center; align-self: center;"
                                 >
                                   <svg
@@ -8205,13 +8203,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                 </div>
               </div>
               <div
-                class="MuiBox-root MuiBox-root-841"
+                class="MuiBox-root MuiBox-root-813"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-842"
+                  class="MuiBox-root MuiBox-root-814"
                 >
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-root-843 makeStyles-root-844 undefined MuiButton-containedPrimary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-root-815 makeStyles-root-816 undefined MuiButton-containedPrimary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
                     style="font-size: 1.2857rem;"
                     tabindex="0"
                     type="button"
@@ -8233,7 +8231,7 @@ exports[`<App/> should render an error message when user wallet is connected and
           </div>
         </div>
         <div
-          class="MuiPaper-root makeStyles-root-827 makeStyles-root-849  MuiPaper-elevation0 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-root-799 makeStyles-root-821  MuiPaper-elevation0 MuiPaper-rounded"
           style="transform: none; webkit-transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
         >
           <div
@@ -8243,10 +8241,10 @@ exports[`<App/> should render an error message when user wallet is connected and
               class="MuiGrid-root card-header MuiGrid-item"
             >
               <div
-                class="MuiBox-root MuiBox-root-850"
+                class="MuiBox-root MuiBox-root-822"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-851"
+                  class="MuiBox-root MuiBox-root-823"
                 >
                   <h5
                     class="MuiTypography-root header-text MuiTypography-h5"
@@ -8266,7 +8264,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                 class="MuiTable-root"
               >
                 <thead
-                  class="MuiTableHead-root makeStyles-stakePoolHeaderText-846"
+                  class="MuiTableHead-root makeStyles-stakePoolHeaderText-818"
                 >
                   <tr
                     class="MuiTableRow-root MuiTableRow-head"
@@ -8302,11 +8300,11 @@ exports[`<App/> should render an error message when user wallet is connected and
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-852"
+                      class="MuiBox-root MuiBox-root-824"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-853"
+                        class="MuiBox-root MuiBox-root-825"
                       >
                         <svg
                           aria-hidden="true"
@@ -8759,7 +8757,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-843 makeStyles-root-855 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-815 makeStyles-root-827 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://app.sushi.com/farm?filter=2x"
                       tabindex="0"
                       target="_blank"
@@ -8795,11 +8793,11 @@ exports[`<App/> should render an error message when user wallet is connected and
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-856"
+                      class="MuiBox-root MuiBox-root-828"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-857"
+                        class="MuiBox-root MuiBox-root-829"
                       >
                         <svg
                           aria-hidden="true"
@@ -8956,7 +8954,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-843 makeStyles-root-858 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-815 makeStyles-root-830 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://app.sushi.com/farm?filter=2x"
                       tabindex="0"
                       target="_blank"
@@ -8992,11 +8990,11 @@ exports[`<App/> should render an error message when user wallet is connected and
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-859"
+                      class="MuiBox-root MuiBox-root-831"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-860"
+                        class="MuiBox-root MuiBox-root-832"
                       >
                         <svg
                           aria-hidden="true"
@@ -9127,7 +9125,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-843 makeStyles-root-861 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-815 makeStyles-root-833 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://traderjoexyz.com/farm/0xB674f93952F02F2538214D4572Aa47F262e990Ff-0x188bED1968b795d5c9022F6a0bb5931Ac4c18F00"
                       tabindex="0"
                       target="_blank"
@@ -9163,11 +9161,11 @@ exports[`<App/> should render an error message when user wallet is connected and
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-862"
+                      class="MuiBox-root MuiBox-root-834"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-863"
+                        class="MuiBox-root MuiBox-root-835"
                       >
                         <svg
                           aria-hidden="true"
@@ -9362,7 +9360,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-843 makeStyles-root-864 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-815 makeStyles-root-836 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://app.spiritswap.finance/#/farms/allfarms"
                       tabindex="0"
                       target="_blank"
@@ -9398,11 +9396,11 @@ exports[`<App/> should render an error message when user wallet is connected and
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-865"
+                      class="MuiBox-root MuiBox-root-837"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-866"
+                        class="MuiBox-root MuiBox-root-838"
                       >
                         <svg
                           aria-hidden="true"
@@ -9597,7 +9595,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-843 makeStyles-root-867 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-815 makeStyles-root-839 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://beets.fi/#/pool/0xf7bf0f161d3240488807ffa23894452246049916000200000000000000000198"
                       tabindex="0"
                       target="_blank"
@@ -9633,11 +9631,11 @@ exports[`<App/> should render an error message when user wallet is connected and
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-868"
+                      class="MuiBox-root MuiBox-root-840"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-869"
+                        class="MuiBox-root MuiBox-root-841"
                       >
                         <svg
                           aria-hidden="true"
@@ -9804,7 +9802,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-843 makeStyles-root-870 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-815 makeStyles-root-842 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://zipswap.fi/#/farm/0x3f6da9334142477718bE2ecC3577d1A28dceAAe1"
                       tabindex="0"
                       target="_blank"
@@ -9840,11 +9838,11 @@ exports[`<App/> should render an error message when user wallet is connected and
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-871"
+                      class="MuiBox-root MuiBox-root-843"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-872"
+                        class="MuiBox-root MuiBox-root-844"
                       >
                         <svg
                           aria-hidden="true"
@@ -10383,7 +10381,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-843 makeStyles-root-873 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-815 makeStyles-root-845 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://jonesdao.io/farms"
                       tabindex="0"
                       target="_blank"
@@ -10419,11 +10417,11 @@ exports[`<App/> should render an error message when user wallet is connected and
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-874"
+                      class="MuiBox-root MuiBox-root-846"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-875"
+                        class="MuiBox-root MuiBox-root-847"
                       >
                         <svg
                           aria-hidden="true"
@@ -10601,7 +10599,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-843 makeStyles-root-876 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-815 makeStyles-root-848 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://app.balancer.fi/#/pool/0xc45d42f801105e861e86658648e3678ad7aa70f900010000000000000000011e"
                       tabindex="0"
                       target="_blank"
@@ -10637,11 +10635,11 @@ exports[`<App/> should render an error message when user wallet is connected and
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-877"
+                      class="MuiBox-root MuiBox-root-849"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-878"
+                        class="MuiBox-root MuiBox-root-850"
                       >
                         <svg
                           aria-hidden="true"
@@ -10835,7 +10833,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-843 makeStyles-root-879 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-815 makeStyles-root-851 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://oolongswap.com/#/farm/lp"
                       tabindex="0"
                       target="_blank"
@@ -10871,6 +10869,5 @@ exports[`<App/> should render an error message when user wallet is connected and
       </div>
     </div>
   </div>
-  <div />
 </div>
 `;

--- a/src/__tests__/__snapshots__/Root.unit.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Root.unit.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`<Root/> should render component 1`] = `
               </div>
               Safety Check: Always verify you're on app.olympusdao.finance!
               <div
-                class="makeStyles-root-70"
+                class="makeStyles-root-66"
               >
                 <div
                   aria-valuemax="100"
@@ -73,14 +73,14 @@ exports[`<Root/> should render component 1`] = `
       </div>
     </div>
     <header
-      class="MuiPaper-root MuiAppBar-root MuiAppBar-positionSticky MuiAppBar-colorPrimary makeStyles-appBar-71 MuiPaper-elevation0"
+      class="MuiPaper-root MuiAppBar-root MuiAppBar-positionSticky MuiAppBar-colorPrimary makeStyles-appBar-67 MuiPaper-elevation0"
     >
       <div
         class="MuiToolbar-root MuiToolbar-regular dapp-topbar"
       >
         <button
           aria-label="open drawer"
-          class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-menuButton-72 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-menuButton-68 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
           id="hamburger"
           tabindex="0"
           type="button"
@@ -99,7 +99,7 @@ exports[`<Root/> should render component 1`] = `
           </span>
         </button>
         <div
-          class="MuiBox-root MuiBox-root-73"
+          class="MuiBox-root MuiBox-root-69"
         >
           <a
             href="#/wallet"
@@ -154,7 +154,7 @@ exports[`<Root/> should render component 1`] = `
           </button>
           <button
             aria-describedby="locales-popper"
-            class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-toggleButton-75 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-toggleButton-71 MuiButton-containedSecondary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
             tabindex="0"
             title="Change locale"
             type="button"
@@ -217,13 +217,13 @@ exports[`<Root/> should render component 1`] = `
               class="MuiPaper-root dapp-sidebar MuiPaper-elevation0 MuiPaper-rounded"
             >
               <div
-                class="MuiBox-root MuiBox-root-79 dapp-sidebar-inner"
+                class="MuiBox-root MuiBox-root-75 dapp-sidebar-inner"
               >
                 <div
                   class="dapp-menu-top"
                 >
                   <div
-                    class="MuiBox-root MuiBox-root-80 branding-header"
+                    class="MuiBox-root MuiBox-root-76 branding-header"
                   >
                     <a
                       class="MuiTypography-root MuiLink-root MuiLink-underlineNone MuiTypography-colorPrimary"
@@ -249,17 +249,17 @@ exports[`<Root/> should render component 1`] = `
                       id="navbarNav"
                     >
                       <div
-                        class="makeStyles-root-81 makeStyles-root-83 nav-item-container"
+                        class="makeStyles-root-77 makeStyles-root-79 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/dashboard"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-84 link-container"
+                            class="MuiBox-root MuiBox-root-80 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-85 makeStyles-title-82 title"
+                              class="MuiBox-root MuiBox-root-81 makeStyles-title-78 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -278,10 +278,10 @@ exports[`<Root/> should render component 1`] = `
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-81 makeStyles-root-86 nav-item-container"
+                        class="makeStyles-root-77 makeStyles-root-82 nav-item-container"
                       >
                         <div
-                          class="MuiPaper-root MuiAccordion-root makeStyles-root-87 undefined Mui-expanded MuiPaper-elevation0"
+                          class="MuiPaper-root MuiAccordion-root makeStyles-root-83 undefined Mui-expanded MuiPaper-elevation0"
                         >
                           <div
                             aria-disabled="false"
@@ -298,10 +298,10 @@ exports[`<Root/> should render component 1`] = `
                                 href="#/bonds"
                               >
                                 <div
-                                  class="MuiBox-root MuiBox-root-88 link-container"
+                                  class="MuiBox-root MuiBox-root-84 link-container"
                                 >
                                   <div
-                                    class="MuiBox-root MuiBox-root-89 makeStyles-title-82 title"
+                                    class="MuiBox-root MuiBox-root-85 makeStyles-title-78 title"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -364,7 +364,7 @@ exports[`<Root/> should render component 1`] = `
                         </div>
                       </div>
                       <div
-                        class="makeStyles-root-81 makeStyles-root-90 nav-item-container"
+                        class="makeStyles-root-77 makeStyles-root-86 nav-item-container"
                       >
                         <a
                           aria-current="page"
@@ -372,10 +372,10 @@ exports[`<Root/> should render component 1`] = `
                           href="#/stake"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-91 link-container"
+                            class="MuiBox-root MuiBox-root-87 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-92 makeStyles-title-82 title"
+                              class="MuiBox-root MuiBox-root-88 makeStyles-title-78 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -394,17 +394,17 @@ exports[`<Root/> should render component 1`] = `
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-81 makeStyles-root-93 nav-item-container"
+                        class="makeStyles-root-77 makeStyles-root-89 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/zap"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-94 link-container"
+                            class="MuiBox-root MuiBox-root-90 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-95 makeStyles-title-82 title"
+                              class="MuiBox-root MuiBox-root-91 makeStyles-title-78 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -423,17 +423,17 @@ exports[`<Root/> should render component 1`] = `
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-81 makeStyles-root-96 nav-item-container"
+                        class="makeStyles-root-77 makeStyles-root-92 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/give"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-97 link-container"
+                            class="MuiBox-root MuiBox-root-93 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-98 makeStyles-title-82 title"
+                              class="MuiBox-root MuiBox-root-94 makeStyles-title-78 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -452,17 +452,17 @@ exports[`<Root/> should render component 1`] = `
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-81 makeStyles-root-99 nav-item-container"
+                        class="makeStyles-root-77 makeStyles-root-95 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone button-dapp-menu  MuiTypography-colorPrimary"
                           href="#/wrap"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-100 link-container"
+                            class="MuiBox-root MuiBox-root-96 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-101 makeStyles-title-82 title"
+                              class="MuiBox-root MuiBox-root-97 makeStyles-title-78 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -481,7 +481,7 @@ exports[`<Root/> should render component 1`] = `
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-81 makeStyles-root-102 nav-item-container"
+                        class="makeStyles-root-77 makeStyles-root-98 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -489,10 +489,10 @@ exports[`<Root/> should render component 1`] = `
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-103 link-container"
+                            class="MuiBox-root MuiBox-root-99 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-104 makeStyles-title-82 title"
+                              class="MuiBox-root MuiBox-root-100 makeStyles-title-78 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -521,14 +521,14 @@ exports[`<Root/> should render component 1`] = `
                         </a>
                       </div>
                       <div
-                        class="MuiBox-root MuiBox-root-105 menu-divider"
+                        class="MuiBox-root MuiBox-root-101 menu-divider"
                       >
                         <hr
                           class="MuiDivider-root"
                         />
                       </div>
                       <div
-                        class="makeStyles-root-81 makeStyles-root-106 nav-item-container"
+                        class="makeStyles-root-77 makeStyles-root-102 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -536,10 +536,10 @@ exports[`<Root/> should render component 1`] = `
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-107 link-container"
+                            class="MuiBox-root MuiBox-root-103 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-108 makeStyles-title-82 title"
+                              class="MuiBox-root MuiBox-root-104 makeStyles-title-78 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -568,14 +568,14 @@ exports[`<Root/> should render component 1`] = `
                         </a>
                       </div>
                       <div
-                        class="MuiBox-root MuiBox-root-109 menu-divider"
+                        class="MuiBox-root MuiBox-root-105 menu-divider"
                       >
                         <hr
                           class="MuiDivider-root"
                         />
                       </div>
                       <div
-                        class="makeStyles-root-81 makeStyles-root-110 nav-item-container"
+                        class="makeStyles-root-77 makeStyles-root-106 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -583,10 +583,10 @@ exports[`<Root/> should render component 1`] = `
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-111 link-container"
+                            class="MuiBox-root MuiBox-root-107 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-112 makeStyles-title-82 title"
+                              class="MuiBox-root MuiBox-root-108 makeStyles-title-78 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -615,7 +615,7 @@ exports[`<Root/> should render component 1`] = `
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-81 makeStyles-root-113 nav-item-container"
+                        class="makeStyles-root-77 makeStyles-root-109 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -623,10 +623,10 @@ exports[`<Root/> should render component 1`] = `
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-114 link-container"
+                            class="MuiBox-root MuiBox-root-110 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-115 makeStyles-title-82 title"
+                              class="MuiBox-root MuiBox-root-111 makeStyles-title-78 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -655,7 +655,7 @@ exports[`<Root/> should render component 1`] = `
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-81 makeStyles-root-116 nav-item-container"
+                        class="makeStyles-root-77 makeStyles-root-112 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -663,10 +663,10 @@ exports[`<Root/> should render component 1`] = `
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-117 link-container"
+                            class="MuiBox-root MuiBox-root-113 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-118 makeStyles-title-82 title"
+                              class="MuiBox-root MuiBox-root-114 makeStyles-title-78 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -695,7 +695,7 @@ exports[`<Root/> should render component 1`] = `
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-81 makeStyles-root-119 nav-item-container"
+                        class="makeStyles-root-77 makeStyles-root-115 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -703,10 +703,10 @@ exports[`<Root/> should render component 1`] = `
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-120 link-container"
+                            class="MuiBox-root MuiBox-root-116 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-121 makeStyles-title-82 title"
+                              class="MuiBox-root MuiBox-root-117 makeStyles-title-78 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -735,7 +735,7 @@ exports[`<Root/> should render component 1`] = `
                         </a>
                       </div>
                       <div
-                        class="makeStyles-root-81 makeStyles-root-122 nav-item-container"
+                        class="makeStyles-root-77 makeStyles-root-118 nav-item-container"
                       >
                         <a
                           class="MuiTypography-root MuiLink-root MuiLink-underlineNone external-site-link  MuiTypography-colorPrimary"
@@ -743,10 +743,10 @@ exports[`<Root/> should render component 1`] = `
                           target="_blank"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-123 link-container"
+                            class="MuiBox-root MuiBox-root-119 link-container"
                           >
                             <div
-                              class="MuiBox-root MuiBox-root-124 makeStyles-title-82 title"
+                              class="MuiBox-root MuiBox-root-120 makeStyles-title-78 title"
                             >
                               <svg
                                 aria-hidden="true"
@@ -778,7 +778,7 @@ exports[`<Root/> should render component 1`] = `
                   </div>
                 </div>
                 <div
-                  class="MuiBox-root MuiBox-root-125"
+                  class="MuiBox-root MuiBox-root-121"
                 >
                   <a
                     class="MuiTypography-root MuiLink-root MuiLink-underlineNone MuiTypography-colorPrimary"
@@ -787,7 +787,7 @@ exports[`<Root/> should render component 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-78 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-74 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -803,7 +803,7 @@ exports[`<Root/> should render component 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-78 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-74 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -819,7 +819,7 @@ exports[`<Root/> should render component 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-78 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-74 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -835,7 +835,7 @@ exports[`<Root/> should render component 1`] = `
                   >
                     <svg
                       aria-hidden="true"
-                      class="MuiSvgIcon-root makeStyles-gray-78 MuiSvgIcon-fontSizeSmall"
+                      class="MuiSvgIcon-root makeStyles-gray-74 MuiSvgIcon-fontSizeSmall"
                       focusable="false"
                       viewBox="0 0 20 20"
                     >
@@ -858,7 +858,7 @@ exports[`<Root/> should render component 1`] = `
         id="stake-view"
       >
         <div
-          class="MuiPaper-root makeStyles-root-126 makeStyles-root-127  MuiPaper-elevation0 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-root-122 makeStyles-root-123  MuiPaper-elevation0 MuiPaper-rounded"
           style="transform: none; webkit-transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
         >
           <div
@@ -868,10 +868,10 @@ exports[`<Root/> should render component 1`] = `
               class="MuiGrid-root card-header MuiGrid-item"
             >
               <div
-                class="MuiBox-root MuiBox-root-128"
+                class="MuiBox-root MuiBox-root-124"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-129"
+                  class="MuiBox-root MuiBox-root-125"
                 >
                   <h5
                     class="MuiTypography-root header-text MuiTypography-h5"
@@ -884,10 +884,10 @@ exports[`<Root/> should render component 1`] = `
                 />
               </div>
               <div
-                class="MuiBox-root MuiBox-root-130"
+                class="MuiBox-root MuiBox-root-126"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-131 rebase-timer"
+                  class="MuiBox-root MuiBox-root-127 rebase-timer"
                 >
                   <p
                     class="MuiTypography-root MuiTypography-body2"
@@ -904,13 +904,13 @@ exports[`<Root/> should render component 1`] = `
               class="MuiGrid-root MuiGrid-item"
             >
               <div
-                class="MuiBox-root MuiBox-root-132"
+                class="MuiBox-root MuiBox-root-128"
               >
                 <div
                   class="MuiGrid-root"
                 >
                   <div
-                    class="MuiBox-root MuiBox-root-133"
+                    class="MuiBox-root MuiBox-root-129"
                   >
                     <div
                       class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-align-items-xs-flex-end"
@@ -919,10 +919,10 @@ exports[`<Root/> should render component 1`] = `
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
                       >
                         <div
-                          class="makeStyles-root-134 stake-apy"
+                          class="makeStyles-root-130 stake-apy"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-135"
+                            class="MuiBox-root MuiBox-root-131"
                           >
                             <h5
                               class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
@@ -945,10 +945,10 @@ exports[`<Root/> should render component 1`] = `
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
                       >
                         <div
-                          class="makeStyles-root-134 stake-tvl"
+                          class="makeStyles-root-130 stake-tvl"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-136"
+                            class="MuiBox-root MuiBox-root-132"
                           >
                             <h5
                               class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
@@ -971,21 +971,21 @@ exports[`<Root/> should render component 1`] = `
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
                       >
                         <div
-                          class="makeStyles-root-134 stake-index"
+                          class="makeStyles-root-130 stake-index"
                         >
                           <div
-                            class="MuiBox-root MuiBox-root-137"
+                            class="MuiBox-root MuiBox-root-133"
                           >
                             <h5
                               class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
                             >
                               Current Index
                               <div
-                                class="MuiBox-root MuiBox-root-138"
+                                class="MuiBox-root MuiBox-root-134"
                                 style="font-size: 16px;"
                               >
                                 <div
-                                  class="MuiBox-root MuiBox-root-139"
+                                  class="MuiBox-root MuiBox-root-135"
                                   style="display: inline-flex; justify-content: center; align-self: center;"
                                 >
                                   <svg
@@ -1019,13 +1019,13 @@ exports[`<Root/> should render component 1`] = `
                 </div>
               </div>
               <div
-                class="MuiBox-root MuiBox-root-140"
+                class="MuiBox-root MuiBox-root-136"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-141"
+                  class="MuiBox-root MuiBox-root-137"
                 >
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-root-142 makeStyles-root-143 undefined MuiButton-containedPrimary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained makeStyles-root-138 makeStyles-root-139 undefined MuiButton-containedPrimary MuiButton-containedSizeLarge MuiButton-sizeLarge MuiButton-disableElevation"
                     style="font-size: 1.2857rem;"
                     tabindex="0"
                     type="button"
@@ -1047,7 +1047,7 @@ exports[`<Root/> should render component 1`] = `
           </div>
         </div>
         <div
-          class="MuiPaper-root makeStyles-root-126 makeStyles-root-148  MuiPaper-elevation0 MuiPaper-rounded"
+          class="MuiPaper-root makeStyles-root-122 makeStyles-root-144  MuiPaper-elevation0 MuiPaper-rounded"
           style="transform: none; webkit-transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
         >
           <div
@@ -1057,10 +1057,10 @@ exports[`<Root/> should render component 1`] = `
               class="MuiGrid-root card-header MuiGrid-item"
             >
               <div
-                class="MuiBox-root MuiBox-root-149"
+                class="MuiBox-root MuiBox-root-145"
               >
                 <div
-                  class="MuiBox-root MuiBox-root-150"
+                  class="MuiBox-root MuiBox-root-146"
                 >
                   <h5
                     class="MuiTypography-root header-text MuiTypography-h5"
@@ -1080,7 +1080,7 @@ exports[`<Root/> should render component 1`] = `
                 class="MuiTable-root"
               >
                 <thead
-                  class="MuiTableHead-root makeStyles-stakePoolHeaderText-145"
+                  class="MuiTableHead-root makeStyles-stakePoolHeaderText-141"
                 >
                   <tr
                     class="MuiTableRow-root MuiTableRow-head"
@@ -1116,11 +1116,11 @@ exports[`<Root/> should render component 1`] = `
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-151"
+                      class="MuiBox-root MuiBox-root-147"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-152"
+                        class="MuiBox-root MuiBox-root-148"
                       >
                         <svg
                           aria-hidden="true"
@@ -1573,7 +1573,7 @@ exports[`<Root/> should render component 1`] = `
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-142 makeStyles-root-154 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-138 makeStyles-root-150 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://app.sushi.com/farm?filter=2x"
                       tabindex="0"
                       target="_blank"
@@ -1609,11 +1609,11 @@ exports[`<Root/> should render component 1`] = `
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-155"
+                      class="MuiBox-root MuiBox-root-151"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-156"
+                        class="MuiBox-root MuiBox-root-152"
                       >
                         <svg
                           aria-hidden="true"
@@ -1770,7 +1770,7 @@ exports[`<Root/> should render component 1`] = `
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-142 makeStyles-root-157 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-138 makeStyles-root-153 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://app.sushi.com/farm?filter=2x"
                       tabindex="0"
                       target="_blank"
@@ -1806,11 +1806,11 @@ exports[`<Root/> should render component 1`] = `
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-158"
+                      class="MuiBox-root MuiBox-root-154"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-159"
+                        class="MuiBox-root MuiBox-root-155"
                       >
                         <svg
                           aria-hidden="true"
@@ -1941,7 +1941,7 @@ exports[`<Root/> should render component 1`] = `
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-142 makeStyles-root-160 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-138 makeStyles-root-156 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://traderjoexyz.com/farm/0xB674f93952F02F2538214D4572Aa47F262e990Ff-0x188bED1968b795d5c9022F6a0bb5931Ac4c18F00"
                       tabindex="0"
                       target="_blank"
@@ -1977,11 +1977,11 @@ exports[`<Root/> should render component 1`] = `
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-161"
+                      class="MuiBox-root MuiBox-root-157"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-162"
+                        class="MuiBox-root MuiBox-root-158"
                       >
                         <svg
                           aria-hidden="true"
@@ -2176,7 +2176,7 @@ exports[`<Root/> should render component 1`] = `
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-142 makeStyles-root-163 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-138 makeStyles-root-159 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://app.spiritswap.finance/#/farms/allfarms"
                       tabindex="0"
                       target="_blank"
@@ -2212,11 +2212,11 @@ exports[`<Root/> should render component 1`] = `
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-164"
+                      class="MuiBox-root MuiBox-root-160"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-165"
+                        class="MuiBox-root MuiBox-root-161"
                       >
                         <svg
                           aria-hidden="true"
@@ -2411,7 +2411,7 @@ exports[`<Root/> should render component 1`] = `
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-142 makeStyles-root-166 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-138 makeStyles-root-162 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://beets.fi/#/pool/0xf7bf0f161d3240488807ffa23894452246049916000200000000000000000198"
                       tabindex="0"
                       target="_blank"
@@ -2447,11 +2447,11 @@ exports[`<Root/> should render component 1`] = `
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-167"
+                      class="MuiBox-root MuiBox-root-163"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-168"
+                        class="MuiBox-root MuiBox-root-164"
                       >
                         <svg
                           aria-hidden="true"
@@ -2618,7 +2618,7 @@ exports[`<Root/> should render component 1`] = `
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-142 makeStyles-root-169 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-138 makeStyles-root-165 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://zipswap.fi/#/farm/0x3f6da9334142477718bE2ecC3577d1A28dceAAe1"
                       tabindex="0"
                       target="_blank"
@@ -2654,11 +2654,11 @@ exports[`<Root/> should render component 1`] = `
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-170"
+                      class="MuiBox-root MuiBox-root-166"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-171"
+                        class="MuiBox-root MuiBox-root-167"
                       >
                         <svg
                           aria-hidden="true"
@@ -3197,7 +3197,7 @@ exports[`<Root/> should render component 1`] = `
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-142 makeStyles-root-172 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-138 makeStyles-root-168 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://jonesdao.io/farms"
                       tabindex="0"
                       target="_blank"
@@ -3233,11 +3233,11 @@ exports[`<Root/> should render component 1`] = `
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-173"
+                      class="MuiBox-root MuiBox-root-169"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-174"
+                        class="MuiBox-root MuiBox-root-170"
                       >
                         <svg
                           aria-hidden="true"
@@ -3415,7 +3415,7 @@ exports[`<Root/> should render component 1`] = `
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-142 makeStyles-root-175 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-138 makeStyles-root-171 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://app.balancer.fi/#/pool/0xc45d42f801105e861e86658648e3678ad7aa70f900010000000000000000011e"
                       tabindex="0"
                       target="_blank"
@@ -3451,11 +3451,11 @@ exports[`<Root/> should render component 1`] = `
                     class="MuiTableCell-root"
                   >
                     <div
-                      class="MuiBox-root MuiBox-root-176"
+                      class="MuiBox-root MuiBox-root-172"
                       style="white-space: nowrap;"
                     >
                       <div
-                        class="MuiBox-root MuiBox-root-177"
+                        class="MuiBox-root MuiBox-root-173"
                       >
                         <svg
                           aria-hidden="true"
@@ -3649,7 +3649,7 @@ exports[`<Root/> should render component 1`] = `
                   >
                     <a
                       aria-disabled="false"
-                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-142 makeStyles-root-178 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
+                      class="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-root-138 makeStyles-root-174 undefined MuiButton-outlinedSecondary MuiButton-outlinedSizeSmall MuiButton-sizeSmall MuiButton-disableElevation MuiButton-fullWidth"
                       href="https://oolongswap.com/#/farm/lp"
                       tabindex="0"
                       target="_blank"
@@ -3685,6 +3685,5 @@ exports[`<Root/> should render component 1`] = `
       </div>
     </div>
   </div>
-  <div />
 </div>
 `;


### PR DESCRIPTION
Previously we were rendering Migration components regardless of if user had v1 balances.
if hasDust was true it returned MigrationModalSingle, if hasDust was false it returned MigrationModal.

 UseEffect hook is used in MigrationModal component to display an 'All approvals complete. You may now migrate.` under the condition that all approvals were complete and the user had v2 balances.. 

This is incorrect logic, as we shouldn't attempt to render the migration component unless we detect v1 balances. 

Fix first checks for old account balances. Then if they have old balances, use the previous logic. 
