### PR TITLE
Fix stake pools table

### DIFF
--- a/src/__tests__/__snapshots__/App.unit.test.jsx.snap
+++ b/src/__tests__/__snapshots__/App.unit.test.jsx.snap
@@ -1014,6 +1014,7 @@ exports[`<App/> should not render a connection error message when user wallet is
             >
               <table
                 class="MuiTable-root"
+                style="table-layout: fixed;"
               >
                 <thead
                   class="MuiTableHead-root makeStyles-stakePoolHeaderText-592"
@@ -1022,27 +1023,26 @@ exports[`<App/> should not render a connection error message when user wallet is
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter"
+                      class="MuiTableCell-root MuiTableCell-head"
                       scope="col"
+                      style="width: 250px; padding: 8px 0px;"
                     >
                       Asset
                     </th>
                     <th
                       class="MuiTableCell-root MuiTableCell-head"
                       scope="col"
+                      style="width: 150px; padding: 8px 0px;"
                     >
                       TVL
                     </th>
                     <th
                       class="MuiTableCell-root MuiTableCell-head"
                       scope="col"
+                      style="width: 150px; padding: 8px 0px;"
                     >
                       APY
                     </th>
-                    <th
-                      class="MuiTableCell-root MuiTableCell-head"
-                      scope="col"
-                    />
                   </tr>
                 </thead>
                 <tr
@@ -1050,6 +1050,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-598"
@@ -1472,6 +1473,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1479,12 +1481,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1492,20 +1495,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -1543,6 +1539,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-602"
@@ -1669,6 +1666,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1676,12 +1674,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1689,20 +1688,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -1740,6 +1732,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-605"
@@ -1840,6 +1833,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1847,12 +1841,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1860,20 +1855,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -1911,6 +1899,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-608"
@@ -2075,6 +2064,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2082,12 +2072,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2095,20 +2086,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -2146,6 +2130,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-611"
@@ -2310,6 +2295,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2317,12 +2303,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2330,20 +2317,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -2381,6 +2361,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-614"
@@ -2517,6 +2498,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2524,12 +2506,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2537,20 +2520,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -2588,6 +2564,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-617"
@@ -3096,6 +3073,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -3103,12 +3081,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -3116,20 +3095,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -3167,6 +3139,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-620"
@@ -3314,6 +3287,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -3321,12 +3295,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -3334,20 +3309,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -3385,6 +3353,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-623"
@@ -3548,6 +3517,7 @@ exports[`<App/> should not render a connection error message when user wallet is
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -3555,12 +3525,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -3568,20 +3539,13 @@ exports[`<App/> should not render a connection error message when user wallet is
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -4638,6 +4602,7 @@ exports[`<App/> should not render an error message when user wallet is connected
             >
               <table
                 class="MuiTable-root"
+                style="table-layout: fixed;"
               >
                 <thead
                   class="MuiTableHead-root makeStyles-stakePoolHeaderText-366"
@@ -4646,27 +4611,26 @@ exports[`<App/> should not render an error message when user wallet is connected
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter"
+                      class="MuiTableCell-root MuiTableCell-head"
                       scope="col"
+                      style="width: 250px; padding: 8px 0px;"
                     >
                       Asset
                     </th>
                     <th
                       class="MuiTableCell-root MuiTableCell-head"
                       scope="col"
+                      style="width: 150px; padding: 8px 0px;"
                     >
                       TVL
                     </th>
                     <th
                       class="MuiTableCell-root MuiTableCell-head"
                       scope="col"
+                      style="width: 150px; padding: 8px 0px;"
                     >
                       APY
                     </th>
-                    <th
-                      class="MuiTableCell-root MuiTableCell-head"
-                      scope="col"
-                    />
                   </tr>
                 </thead>
                 <tr
@@ -4674,6 +4638,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-372"
@@ -5096,6 +5061,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -5103,12 +5069,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -5116,20 +5083,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -5167,6 +5127,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-376"
@@ -5293,6 +5254,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -5300,12 +5262,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -5313,20 +5276,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -5364,6 +5320,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-379"
@@ -5464,6 +5421,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -5471,12 +5429,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -5484,20 +5443,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -5535,6 +5487,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-382"
@@ -5699,6 +5652,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -5706,12 +5660,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -5719,20 +5674,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -5770,6 +5718,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-385"
@@ -5934,6 +5883,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -5941,12 +5891,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -5954,20 +5905,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -6005,6 +5949,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-388"
@@ -6141,6 +6086,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -6148,12 +6094,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -6161,20 +6108,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -6212,6 +6152,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-391"
@@ -6720,6 +6661,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -6727,12 +6669,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -6740,20 +6683,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -6791,6 +6727,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-394"
@@ -6938,6 +6875,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -6945,12 +6883,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -6958,20 +6897,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -7009,6 +6941,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-397"
@@ -7172,6 +7105,7 @@ exports[`<App/> should not render an error message when user wallet is connected
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -7179,12 +7113,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -7192,20 +7127,13 @@ exports[`<App/> should not render an error message when user wallet is connected
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -8262,6 +8190,7 @@ exports[`<App/> should render an error message when user wallet is connected and
             >
               <table
                 class="MuiTable-root"
+                style="table-layout: fixed;"
               >
                 <thead
                   class="MuiTableHead-root makeStyles-stakePoolHeaderText-818"
@@ -8270,27 +8199,26 @@ exports[`<App/> should render an error message when user wallet is connected and
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter"
+                      class="MuiTableCell-root MuiTableCell-head"
                       scope="col"
+                      style="width: 250px; padding: 8px 0px;"
                     >
                       Asset
                     </th>
                     <th
                       class="MuiTableCell-root MuiTableCell-head"
                       scope="col"
+                      style="width: 150px; padding: 8px 0px;"
                     >
                       TVL
                     </th>
                     <th
                       class="MuiTableCell-root MuiTableCell-head"
                       scope="col"
+                      style="width: 150px; padding: 8px 0px;"
                     >
                       APY
                     </th>
-                    <th
-                      class="MuiTableCell-root MuiTableCell-head"
-                      scope="col"
-                    />
                   </tr>
                 </thead>
                 <tr
@@ -8298,6 +8226,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-824"
@@ -8720,6 +8649,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -8727,12 +8657,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -8740,20 +8671,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -8791,6 +8715,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-828"
@@ -8917,6 +8842,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -8924,12 +8850,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -8937,20 +8864,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -8988,6 +8908,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-831"
@@ -9088,6 +9009,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -9095,12 +9017,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -9108,20 +9031,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -9159,6 +9075,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-834"
@@ -9323,6 +9240,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -9330,12 +9248,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -9343,20 +9262,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -9394,6 +9306,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-837"
@@ -9558,6 +9471,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -9565,12 +9479,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -9578,20 +9493,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -9629,6 +9537,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-840"
@@ -9765,6 +9674,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -9772,12 +9682,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -9785,20 +9696,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -9836,6 +9740,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-843"
@@ -10344,6 +10249,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -10351,12 +10257,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -10364,20 +10271,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -10415,6 +10315,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-846"
@@ -10562,6 +10463,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -10569,12 +10471,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -10582,20 +10485,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -10633,6 +10529,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-849"
@@ -10796,6 +10693,7 @@ exports[`<App/> should render an error message when user wallet is connected and
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -10803,12 +10701,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -10816,20 +10715,13 @@ exports[`<App/> should render an error message when user wallet is connected and
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"

--- a/src/__tests__/__snapshots__/Root.unit.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Root.unit.test.tsx.snap
@@ -1078,6 +1078,7 @@ exports[`<Root/> should render component 1`] = `
             >
               <table
                 class="MuiTable-root"
+                style="table-layout: fixed;"
               >
                 <thead
                   class="MuiTableHead-root makeStyles-stakePoolHeaderText-141"
@@ -1086,27 +1087,26 @@ exports[`<Root/> should render component 1`] = `
                     class="MuiTableRow-root MuiTableRow-head"
                   >
                     <th
-                      class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter"
+                      class="MuiTableCell-root MuiTableCell-head"
                       scope="col"
+                      style="width: 250px; padding: 8px 0px;"
                     >
                       Asset
                     </th>
                     <th
                       class="MuiTableCell-root MuiTableCell-head"
                       scope="col"
+                      style="width: 150px; padding: 8px 0px;"
                     >
                       TVL
                     </th>
                     <th
                       class="MuiTableCell-root MuiTableCell-head"
                       scope="col"
+                      style="width: 150px; padding: 8px 0px;"
                     >
                       APY
                     </th>
-                    <th
-                      class="MuiTableCell-root MuiTableCell-head"
-                      scope="col"
-                    />
                   </tr>
                 </thead>
                 <tr
@@ -1114,6 +1114,7 @@ exports[`<Root/> should render component 1`] = `
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-147"
@@ -1536,6 +1537,7 @@ exports[`<Root/> should render component 1`] = `
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1543,12 +1545,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1556,20 +1559,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -1607,6 +1603,7 @@ exports[`<Root/> should render component 1`] = `
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-151"
@@ -1733,6 +1730,7 @@ exports[`<Root/> should render component 1`] = `
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1740,12 +1738,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1753,20 +1752,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -1804,6 +1796,7 @@ exports[`<Root/> should render component 1`] = `
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-154"
@@ -1904,6 +1897,7 @@ exports[`<Root/> should render component 1`] = `
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1911,12 +1905,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -1924,20 +1919,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -1975,6 +1963,7 @@ exports[`<Root/> should render component 1`] = `
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-157"
@@ -2139,6 +2128,7 @@ exports[`<Root/> should render component 1`] = `
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2146,12 +2136,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2159,20 +2150,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -2210,6 +2194,7 @@ exports[`<Root/> should render component 1`] = `
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-160"
@@ -2374,6 +2359,7 @@ exports[`<Root/> should render component 1`] = `
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2381,12 +2367,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2394,20 +2381,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -2445,6 +2425,7 @@ exports[`<Root/> should render component 1`] = `
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-163"
@@ -2581,6 +2562,7 @@ exports[`<Root/> should render component 1`] = `
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2588,12 +2570,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -2601,20 +2584,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -2652,6 +2628,7 @@ exports[`<Root/> should render component 1`] = `
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-166"
@@ -3160,6 +3137,7 @@ exports[`<Root/> should render component 1`] = `
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -3167,12 +3145,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -3180,20 +3159,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -3231,6 +3203,7 @@ exports[`<Root/> should render component 1`] = `
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-169"
@@ -3378,6 +3351,7 @@ exports[`<Root/> should render component 1`] = `
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -3385,12 +3359,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -3398,20 +3373,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"
@@ -3449,6 +3417,7 @@ exports[`<Root/> should render component 1`] = `
                 >
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <div
                       class="MuiBox-root MuiBox-root-172"
@@ -3612,6 +3581,7 @@ exports[`<Root/> should render component 1`] = `
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -3619,12 +3589,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <p
                       class="MuiTypography-root MuiTypography-body1"
@@ -3632,20 +3603,13 @@ exports[`<Root/> should render component 1`] = `
                     >
                       <span
                         class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                        style="width: 100%;"
+                        style="width: 60px;"
                       />
                     </p>
                   </td>
                   <td
                     class="MuiTableCell-root"
-                  >
-                    <p
-                      class="MuiTypography-root MuiTypography-body1"
-                      style="line-height: 1.4;"
-                    />
-                  </td>
-                  <td
-                    class="MuiTableCell-root"
+                    style="padding: 8px 0px;"
                   >
                     <a
                       aria-disabled="false"

--- a/src/views/Stake/Stake.tsx
+++ b/src/views/Stake/Stake.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { useWeb3Context } from "src/hooks";
 import { usePathForNetwork } from "src/hooks/usePathForNetwork";
 
-import ExternalStakePools from "./components/ExternalStakePools/ExternalStakePools";
+import { ExternalStakePools } from "./components/ExternalStakePools/ExternalStakePools";
 import { StakeArea } from "./components/StakeArea/StakeArea";
 
 const Stake: React.FC = () => {

--- a/src/views/Stake/__tests__/__snapshots__/Stake.unit.test.tsx.snap
+++ b/src/views/Stake/__tests__/__snapshots__/Stake.unit.test.tsx.snap
@@ -226,6 +226,7 @@ exports[`<Stake/> should render component 1`] = `
         >
           <table
             class="MuiTable-root"
+            style="table-layout: fixed;"
           >
             <thead
               class="MuiTableHead-root makeStyles-stakePoolHeaderText-21"
@@ -234,27 +235,26 @@ exports[`<Stake/> should render component 1`] = `
                 class="MuiTableRow-root MuiTableRow-head"
               >
                 <th
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter"
+                  class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 250px; padding: 8px 0px;"
                 >
                   Asset
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 150px; padding: 8px 0px;"
                 >
                   TVL
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 150px; padding: 8px 0px;"
                 >
                   APY
                 </th>
-                <th
-                  class="MuiTableCell-root MuiTableCell-head"
-                  scope="col"
-                />
               </tr>
             </thead>
             <tr
@@ -262,6 +262,7 @@ exports[`<Stake/> should render component 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-27"
@@ -684,6 +685,7 @@ exports[`<Stake/> should render component 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -691,12 +693,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -704,20 +707,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -755,6 +751,7 @@ exports[`<Stake/> should render component 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-31"
@@ -881,6 +878,7 @@ exports[`<Stake/> should render component 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -888,12 +886,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -901,20 +900,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -952,6 +944,7 @@ exports[`<Stake/> should render component 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-34"
@@ -1052,6 +1045,7 @@ exports[`<Stake/> should render component 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1059,12 +1053,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1072,20 +1067,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -1123,6 +1111,7 @@ exports[`<Stake/> should render component 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-37"
@@ -1287,6 +1276,7 @@ exports[`<Stake/> should render component 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1294,12 +1284,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1307,20 +1298,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -1358,6 +1342,7 @@ exports[`<Stake/> should render component 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-40"
@@ -1522,6 +1507,7 @@ exports[`<Stake/> should render component 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1529,12 +1515,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1542,20 +1529,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -1593,6 +1573,7 @@ exports[`<Stake/> should render component 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-43"
@@ -1729,6 +1710,7 @@ exports[`<Stake/> should render component 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1736,12 +1718,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1749,20 +1732,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -1800,6 +1776,7 @@ exports[`<Stake/> should render component 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-46"
@@ -2308,6 +2285,7 @@ exports[`<Stake/> should render component 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -2315,12 +2293,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -2328,20 +2307,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -2379,6 +2351,7 @@ exports[`<Stake/> should render component 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-49"
@@ -2526,6 +2499,7 @@ exports[`<Stake/> should render component 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -2533,12 +2507,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -2546,20 +2521,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -2597,6 +2565,7 @@ exports[`<Stake/> should render component 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-52"
@@ -2760,6 +2729,7 @@ exports[`<Stake/> should render component 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -2767,12 +2737,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -2780,20 +2751,13 @@ exports[`<Stake/> should render component 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -3060,6 +3024,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
         >
           <table
             class="MuiTable-root"
+            style="table-layout: fixed;"
           >
             <thead
               class="MuiTableHead-root makeStyles-stakePoolHeaderText-75"
@@ -3068,27 +3033,26 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 class="MuiTableRow-root MuiTableRow-head"
               >
                 <th
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter"
+                  class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 250px; padding: 8px 0px;"
                 >
                   Asset
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 150px; padding: 8px 0px;"
                 >
                   TVL
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 150px; padding: 8px 0px;"
                 >
                   APY
                 </th>
-                <th
-                  class="MuiTableCell-root MuiTableCell-head"
-                  scope="col"
-                />
               </tr>
             </thead>
             <tr
@@ -3096,6 +3060,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-81"
@@ -3518,6 +3483,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -3525,12 +3491,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -3538,20 +3505,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -3589,6 +3549,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-85"
@@ -3715,6 +3676,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -3722,12 +3684,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -3735,20 +3698,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -3786,6 +3742,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-88"
@@ -3886,6 +3843,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -3893,12 +3851,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -3906,20 +3865,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -3957,6 +3909,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-91"
@@ -4121,6 +4074,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4128,12 +4082,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4141,20 +4096,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -4192,6 +4140,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-94"
@@ -4356,6 +4305,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4363,12 +4313,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4376,20 +4327,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -4427,6 +4371,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-97"
@@ -4563,6 +4508,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4570,12 +4516,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4583,20 +4530,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -4634,6 +4574,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-100"
@@ -5142,6 +5083,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -5149,12 +5091,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -5162,20 +5105,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -5213,6 +5149,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-103"
@@ -5360,6 +5297,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -5367,12 +5305,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -5380,20 +5319,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -5431,6 +5363,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-106"
@@ -5594,6 +5527,7 @@ exports[`<Stake/> should render correct staking headers 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -5601,12 +5535,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -5614,20 +5549,13 @@ exports[`<Stake/> should render correct staking headers 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"

--- a/src/views/Stake/components/ExternalStakePools/ExternalStakePools.tsx
+++ b/src/views/Stake/components/ExternalStakePools/ExternalStakePools.tsx
@@ -54,36 +54,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const AllPools = (props: { isSmallScreen: boolean }) => (
-  <>
-    {sushiPools.map(pool => (
-      <SushiPools pool={pool} isSmallScreen={props.isSmallScreen} />
-    ))}
-    {joePools.map(pool => (
-      <JoePools pool={pool} isSmallScreen={props.isSmallScreen} />
-    ))}
-    {spiritPools.map(pool => (
-      <SpiritPools pool={pool} isSmallScreen={props.isSmallScreen} />
-    ))}
-    {beetsPools.map(pool => (
-      <BeetsPools pool={pool} isSmallScreen={props.isSmallScreen} />
-    ))}
-    {zipPools.map(pool => (
-      <ZipPools pool={pool} isSmallScreen={props.isSmallScreen} />
-    ))}
-    {jonesPools.map(pool => (
-      <JonesPools pool={pool} isSmallScreen={props.isSmallScreen} />
-    ))}
-    {balancerPools.map(pool => (
-      <BalancerPools pool={pool} isSmallScreen={props.isSmallScreen} />
-    ))}
-    {bobaPools.map(pool => (
-      <BobaPools pool={pool} isSmallScreen={props.isSmallScreen} />
-    ))}
-  </>
-);
-
-const ExternalStakePools = () => {
+export const ExternalStakePools = () => {
   const styles = useStyles();
   const { connected } = useWeb3Context();
   const isSmallScreen = useMediaQuery("(max-width: 705px)");
@@ -116,6 +87,35 @@ const ExternalStakePools = () => {
     </Zoom>
   );
 };
+
+const AllPools = (props: { isSmallScreen: boolean }) => (
+  <>
+    {sushiPools.map(pool => (
+      <SushiPools pool={pool} isSmallScreen={props.isSmallScreen} />
+    ))}
+    {joePools.map(pool => (
+      <JoePools pool={pool} isSmallScreen={props.isSmallScreen} />
+    ))}
+    {spiritPools.map(pool => (
+      <SpiritPools pool={pool} isSmallScreen={props.isSmallScreen} />
+    ))}
+    {beetsPools.map(pool => (
+      <BeetsPools pool={pool} isSmallScreen={props.isSmallScreen} />
+    ))}
+    {zipPools.map(pool => (
+      <ZipPools pool={pool} isSmallScreen={props.isSmallScreen} />
+    ))}
+    {jonesPools.map(pool => (
+      <JonesPools pool={pool} isSmallScreen={props.isSmallScreen} />
+    ))}
+    {balancerPools.map(pool => (
+      <BalancerPools pool={pool} isSmallScreen={props.isSmallScreen} />
+    ))}
+    {bobaPools.map(pool => (
+      <BobaPools pool={pool} isSmallScreen={props.isSmallScreen} />
+    ))}
+  </>
+);
 
 const StakePool: React.FC<{ pool: ExternalPool; tvl?: number; apy?: number }> = props => {
   const { connected } = useWeb3Context();
@@ -282,5 +282,3 @@ const BobaPools: React.FC<{ pool: ExternalPool; isSmallScreen: boolean }> = prop
     <StakePool pool={props.pool} tvl={totalValueLocked} apy={apy} />
   );
 };
-
-export default ExternalStakePools;

--- a/src/views/Stake/components/ExternalStakePools/ExternalStakePools.tsx
+++ b/src/views/Stake/components/ExternalStakePools/ExternalStakePools.tsx
@@ -65,21 +65,25 @@ export const ExternalStakePools = () => {
         <AllPools isSmallScreen={isSmallScreen} />
       ) : (
         <Paper headerText={t`Farm Pool`}>
-          <Table>
+          <Table style={{ tableLayout: "fixed" }}>
             <TableHead className={styles.stakePoolHeaderText}>
               <TableRow>
-                <TableCell align="center">
+                <TableCell style={{ width: "250px", padding: "8px 0" }}>
                   <Trans>Asset</Trans>
                 </TableCell>
-                <TableCell>
+
+                <TableCell style={{ width: connected ? "100px" : "150px", padding: "8px 0" }}>
                   <Trans>TVL</Trans>
                 </TableCell>
-                <TableCell>
+
+                <TableCell style={{ width: connected ? "100px" : "150px", padding: "8px 0" }}>
                   <Trans>APY</Trans>
                 </TableCell>
-                <TableCell>{connected ? t`Balance` : ""}</TableCell>
+
+                {connected && <TableCell style={{ width: "100px", padding: "8px 0" }}>{t`Balance`}</TableCell>}
               </TableRow>
             </TableHead>
+
             <AllPools isSmallScreen={isSmallScreen} />
           </Table>
         </Paper>
@@ -125,7 +129,7 @@ const StakePool: React.FC<{ pool: ExternalPool; tvl?: number; apy?: number }> = 
 
   return (
     <TableRow>
-      <TableCell>
+      <TableCell style={{ padding: "8px 0" }}>
         <Box display="flex" flexDirection="row" alignItems="center" style={{ whiteSpace: "nowrap" }}>
           <TokenStack tokens={props.pool.icons} />
           <Typography gutterBottom={false} style={{ lineHeight: 1.4, marginLeft: "10px", marginRight: "10px" }}>
@@ -134,28 +138,32 @@ const StakePool: React.FC<{ pool: ExternalPool; tvl?: number; apy?: number }> = 
           <Token name={NetworkId[props.pool.networkID] as OHMTokenProps["name"]} style={{ fontSize: "15px" }} />
         </Box>
       </TableCell>
-      <TableCell>
+
+      <TableCell style={{ padding: "8px 0" }}>
         <Typography gutterBottom={false} style={{ lineHeight: 1.4 }}>
-          {!props.tvl ? <Skeleton width="100%" /> : formatCurrency(props.tvl)}
+          {!props.tvl ? <Skeleton width={60} /> : formatCurrency(props.tvl)}
         </Typography>
       </TableCell>
-      <TableCell>
+
+      <TableCell style={{ padding: "8px 0" }}>
         <Typography gutterBottom={false} style={{ lineHeight: 1.4 }}>
-          {!props.apy ? <Skeleton width="100%" /> : `${formatNumber(props.apy * 100, 2)}%`}
+          {!props.apy ? <Skeleton width={60} /> : `${formatNumber(props.apy * 100, 2)}%`}
         </Typography>
       </TableCell>
-      <TableCell>
-        <Typography gutterBottom={false} style={{ lineHeight: 1.4 }}>
-          {!connected ? (
-            ""
-          ) : !userBalance ? (
-            <Skeleton width="100%" />
-          ) : (
-            `${userBalance.toString({ decimals: 4, trim: false, format: true })} LP`
-          )}
-        </Typography>
-      </TableCell>
-      <TableCell>
+
+      {connected && (
+        <TableCell style={{ padding: "8px 0" }}>
+          <Typography gutterBottom={false} style={{ lineHeight: 1.4 }}>
+            {!userBalance ? (
+              <Skeleton width={60} />
+            ) : (
+              `${userBalance.toString({ decimals: 4, trim: false, format: true })} LP`
+            )}
+          </Typography>
+        </TableCell>
+      )}
+
+      <TableCell style={{ padding: "8px 0" }}>
         <SecondaryButton size="small" target="_blank" href={props.pool.href} fullWidth>
           {t`Stake on`} {props.pool.stakeOn}
         </SecondaryButton>

--- a/src/views/V1-Stake/V1-Stake.jsx
+++ b/src/views/V1-Stake/V1-Stake.jsx
@@ -36,7 +36,7 @@ import { useGohmBalance, useSohmBalance } from "../../hooks/useBalance";
 import { useTestableNetworks } from "../../hooks/useTestableNetworks";
 import { error } from "../../slices/MessagesSlice";
 import { changeApproval, changeStake } from "../../slices/StakeThunk";
-import ExternalStakePools from "../Stake/components/ExternalStakePools/ExternalStakePools";
+import { ExternalStakePools } from "../Stake/components/ExternalStakePools/ExternalStakePools";
 import RebaseTimer from "../Stake/components/StakeArea/components/RebaseTimer/RebaseTimer";
 
 function V1Stake({ oldAssetsDetected, setMigrationModalOpen }) {

--- a/src/views/V1-Stake/__tests__/__snapshots__/V1-Stake.unit.test.tsx.snap
+++ b/src/views/V1-Stake/__tests__/__snapshots__/V1-Stake.unit.test.tsx.snap
@@ -528,6 +528,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
         >
           <table
             class="MuiTable-root"
+            style="table-layout: fixed;"
           >
             <thead
               class="MuiTableHead-root makeStyles-stakePoolHeaderText-32"
@@ -536,27 +537,26 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 class="MuiTableRow-root MuiTableRow-head"
               >
                 <th
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter"
+                  class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 250px; padding: 8px 0px;"
                 >
                   Asset
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 150px; padding: 8px 0px;"
                 >
                   TVL
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 150px; padding: 8px 0px;"
                 >
                   APY
                 </th>
-                <th
-                  class="MuiTableCell-root MuiTableCell-head"
-                  scope="col"
-                />
               </tr>
             </thead>
             <tr
@@ -564,6 +564,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-38"
@@ -986,6 +987,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -993,12 +995,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1006,20 +1009,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -1057,6 +1053,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-44"
@@ -1183,6 +1180,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1190,12 +1188,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1203,20 +1202,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -1254,6 +1246,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-47"
@@ -1354,6 +1347,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1361,12 +1355,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1374,20 +1369,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -1425,6 +1413,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-50"
@@ -1589,6 +1578,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1596,12 +1586,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1609,20 +1600,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -1660,6 +1644,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-53"
@@ -1824,6 +1809,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1831,12 +1817,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -1844,20 +1831,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -1895,6 +1875,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-56"
@@ -2031,6 +2012,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -2038,12 +2020,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -2051,20 +2034,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -2102,6 +2078,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-59"
@@ -2610,6 +2587,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -2617,12 +2595,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -2630,20 +2609,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -2681,6 +2653,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-62"
@@ -2828,6 +2801,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -2835,12 +2809,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -2848,20 +2823,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -2899,6 +2867,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-65"
@@ -3062,6 +3031,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -3069,12 +3039,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -3082,20 +3053,13 @@ exports[`<Stake/> should render component. not connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
-              >
-                <p
-                  class="MuiTypography-root MuiTypography-body1"
-                  style="line-height: 1.4;"
-                />
-              </td>
-              <td
-                class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -3664,6 +3628,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
         >
           <table
             class="MuiTable-root"
+            style="table-layout: fixed;"
           >
             <thead
               class="MuiTableHead-root makeStyles-stakePoolHeaderText-99"
@@ -3672,26 +3637,30 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 class="MuiTableRow-root MuiTableRow-head"
               >
                 <th
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter"
+                  class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 250px; padding: 8px 0px;"
                 >
                   Asset
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 100px; padding: 8px 0px;"
                 >
                   TVL
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 100px; padding: 8px 0px;"
                 >
                   APY
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 100px; padding: 8px 0px;"
                 >
                   Balance
                 </th>
@@ -3702,6 +3671,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-105"
@@ -4124,6 +4094,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4131,12 +4102,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4144,12 +4116,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4157,12 +4130,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -4200,6 +4174,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-111"
@@ -4326,6 +4301,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4333,12 +4309,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4346,12 +4323,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4359,12 +4337,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -4402,6 +4381,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-114"
@@ -4502,6 +4482,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4509,12 +4490,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4522,12 +4504,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4535,12 +4518,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -4578,6 +4562,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-117"
@@ -4742,6 +4727,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4749,12 +4735,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4762,12 +4749,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4775,12 +4763,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -4818,6 +4807,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-120"
@@ -4982,6 +4972,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -4989,12 +4980,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -5002,12 +4994,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -5015,12 +5008,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -5058,6 +5052,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-123"
@@ -5194,6 +5189,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -5201,12 +5197,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -5214,12 +5211,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -5227,12 +5225,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -5270,6 +5269,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-126"
@@ -5778,6 +5778,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -5785,12 +5786,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -5798,12 +5800,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -5811,12 +5814,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -5854,6 +5858,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-129"
@@ -6001,6 +6006,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -6008,12 +6014,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -6021,12 +6028,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -6034,12 +6042,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -6077,6 +6086,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-132"
@@ -6240,6 +6250,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -6247,12 +6258,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -6260,12 +6272,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -6273,12 +6286,13 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -6847,6 +6861,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
         >
           <table
             class="MuiTable-root"
+            style="table-layout: fixed;"
           >
             <thead
               class="MuiTableHead-root makeStyles-stakePoolHeaderText-166"
@@ -6855,26 +6870,30 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 class="MuiTableRow-root MuiTableRow-head"
               >
                 <th
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter"
+                  class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 250px; padding: 8px 0px;"
                 >
                   Asset
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 100px; padding: 8px 0px;"
                 >
                   TVL
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 100px; padding: 8px 0px;"
                 >
                   APY
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 100px; padding: 8px 0px;"
                 >
                   Balance
                 </th>
@@ -6885,6 +6904,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-172"
@@ -7307,6 +7327,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -7314,12 +7335,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -7327,12 +7349,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -7340,12 +7363,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -7383,6 +7407,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-178"
@@ -7509,6 +7534,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -7516,12 +7542,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -7529,12 +7556,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -7542,12 +7570,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -7585,6 +7614,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-181"
@@ -7685,6 +7715,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -7692,12 +7723,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -7705,12 +7737,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -7718,12 +7751,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -7761,6 +7795,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-184"
@@ -7925,6 +7960,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -7932,12 +7968,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -7945,12 +7982,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -7958,12 +7996,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -8001,6 +8040,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-187"
@@ -8165,6 +8205,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -8172,12 +8213,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -8185,12 +8227,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -8198,12 +8241,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -8241,6 +8285,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-190"
@@ -8377,6 +8422,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -8384,12 +8430,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -8397,12 +8444,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -8410,12 +8458,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -8453,6 +8502,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-193"
@@ -8961,6 +9011,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -8968,12 +9019,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -8981,12 +9033,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -8994,12 +9047,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -9037,6 +9091,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-196"
@@ -9184,6 +9239,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -9191,12 +9247,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -9204,12 +9261,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -9217,12 +9275,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -9260,6 +9319,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-199"
@@ -9423,6 +9483,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -9430,12 +9491,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -9443,12 +9505,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -9456,12 +9519,13 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -10030,6 +10094,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
         >
           <table
             class="MuiTable-root"
+            style="table-layout: fixed;"
           >
             <thead
               class="MuiTableHead-root makeStyles-stakePoolHeaderText-233"
@@ -10038,26 +10103,30 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 class="MuiTableRow-root MuiTableRow-head"
               >
                 <th
-                  class="MuiTableCell-root MuiTableCell-head MuiTableCell-alignCenter"
+                  class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 250px; padding: 8px 0px;"
                 >
                   Asset
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 100px; padding: 8px 0px;"
                 >
                   TVL
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 100px; padding: 8px 0px;"
                 >
                   APY
                 </th>
                 <th
                   class="MuiTableCell-root MuiTableCell-head"
                   scope="col"
+                  style="width: 100px; padding: 8px 0px;"
                 >
                   Balance
                 </th>
@@ -10068,6 +10137,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-239"
@@ -10490,6 +10560,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -10497,12 +10568,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -10510,12 +10582,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -10523,12 +10596,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -10566,6 +10640,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-245"
@@ -10692,6 +10767,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -10699,12 +10775,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -10712,12 +10789,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -10725,12 +10803,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -10768,6 +10847,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-248"
@@ -10868,6 +10948,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -10875,12 +10956,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -10888,12 +10970,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -10901,12 +10984,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -10944,6 +11028,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-251"
@@ -11108,6 +11193,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -11115,12 +11201,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -11128,12 +11215,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -11141,12 +11229,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -11184,6 +11273,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-254"
@@ -11348,6 +11438,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -11355,12 +11446,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -11368,12 +11460,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -11381,12 +11474,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -11424,6 +11518,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-257"
@@ -11560,6 +11655,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -11567,12 +11663,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -11580,12 +11677,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -11593,12 +11691,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -11636,6 +11735,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-260"
@@ -12144,6 +12244,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -12151,12 +12252,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -12164,12 +12266,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -12177,12 +12280,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -12220,6 +12324,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-263"
@@ -12367,6 +12472,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -12374,12 +12480,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -12387,12 +12494,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -12400,12 +12508,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"
@@ -12443,6 +12552,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
             >
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <div
                   class="MuiBox-root MuiBox-root-266"
@@ -12606,6 +12716,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -12613,12 +12724,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -12626,12 +12738,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <p
                   class="MuiTypography-root MuiTypography-body1"
@@ -12639,12 +12752,13 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                 >
                   <span
                     class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse"
-                    style="width: 100%;"
+                    style="width: 60px;"
                   />
                 </p>
               </td>
               <td
                 class="MuiTableCell-root"
+                style="padding: 8px 0px;"
               >
                 <a
                   aria-disabled="false"


### PR DESCRIPTION
- Improves left alignment of info
- Fixes width for LP balance so that it takes up only 1 line
- Matches the look of this table with the tables on the Bond view

New

![SCR-20220509-bsh](https://user-images.githubusercontent.com/15123145/167318541-3d34d407-62e2-481d-8dcb-c0eb760f2940.png)

Old

![SCR-20220509-bsm](https://user-images.githubusercontent.com/15123145/167318548-83fad9f7-2eaa-4003-bc5a-eb27d8a18093.png)

