### PR TITLE
Move wallet address to connect button

### DIFF
--- a/src/components/Sidebar/NavContent.tsx
+++ b/src/components/Sidebar/NavContent.tsx
@@ -11,7 +11,6 @@ import { BondDiscount } from "src/views/Bond/components/BondDiscount";
 import { useLiveBonds } from "src/views/Bond/hooks/useLiveBonds";
 
 import { ReactComponent as OlympusIcon } from "../../assets/icons/olympus-nav-header.svg";
-import WalletAddressEns from "../TopBar/Wallet/WalletAddressEns";
 
 const useStyles = makeStyles(theme => ({
   gray: {
@@ -37,8 +36,6 @@ const NavContent: React.VFC = () => {
                 style={{ minWidth: "151px", minHeight: "98px", width: "151px" }}
               />
             </Link>
-
-            <WalletAddressEns />
           </Box>
 
           <div className="dapp-menu-links">

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -12,6 +12,7 @@ import { useWeb3Context } from "src/hooks";
 import { ReactComponent as MenuIcon } from "../../assets/icons/hamburger.svg";
 import { locales, selectLocale } from "../../locales";
 import ThemeSwitcher from "./ThemeSwitch";
+import WalletAddressEns from "./Wallet/WalletAddressEns";
 
 const useStyles = makeStyles(theme => ({
   appBar: {
@@ -62,7 +63,7 @@ function TopBar({ theme, toggleTheme, handleDrawerToggle }: TopBarProps) {
           <Link to={"/wallet"} state={{ prevPath: location.pathname }} style={{ marginRight: "0px" }}>
             <Button variant="contained" color="secondary">
               <SvgIcon component={WalletIcon} style={{ marginRight: "9px" }} />
-              <Typography>{connected ? t`Wallet` : t`Connect`}</Typography>
+              <Typography>{connected ? <WalletAddressEns /> : t`Connect`}</Typography>
             </Button>
           </Link>
           <ThemeSwitcher theme={theme} toggleTheme={toggleTheme} />

--- a/src/components/TopBar/Wallet/WalletAddressEns.tsx
+++ b/src/components/TopBar/Wallet/WalletAddressEns.tsx
@@ -1,4 +1,3 @@
-import { Link } from "@material-ui/core";
 import { shorten } from "src/helpers";
 import { useWeb3Context } from "src/hooks";
 import { useEns } from "src/hooks/useENS";
@@ -9,13 +8,5 @@ export default function WalletAddressEns() {
 
   if (!address) return null;
 
-  return (
-    <div className="wallet-link">
-      {ens?.avatar && <img className="avatar" src={ens.avatar} alt={address} />}
-
-      <Link href={`https://etherscan.io/address/${address}`} target="_blank">
-        {ens?.name || shorten(address)}
-      </Link>
-    </div>
-  );
+  return <>{ens || shorten(address)}</>;
 }

--- a/src/hooks/useENS.ts
+++ b/src/hooks/useENS.ts
@@ -1,30 +1,16 @@
 import { useQuery } from "react-query";
-import { queryAssertion } from "src/helpers/react-query/queryAssertion";
 import { nonNullable } from "src/helpers/types/nonNullable";
+import { NetworkId } from "src/networkDetails";
 
 import { useWeb3Context } from ".";
-import { useTestableNetworks } from "./useTestableNetworks";
 
 export const ensQueryKey = (address?: string) => ["useEns", address].filter(nonNullable);
 
 export const useEns = () => {
-  const networks = useTestableNetworks();
   const { provider, address, networkId } = useWeb3Context();
+  const isEnsSupported = networkId === NetworkId.MAINNET;
 
-  const isEnsSupported = networkId === networks.MAINNET;
-
-  const key = ensQueryKey(address);
-  return useQuery<{ name: string | null; avatar: string | null }, Error>(
-    key,
-    async () => {
-      queryAssertion(address, key);
-
-      const name = await provider.lookupAddress(address);
-      const avatar = name ? await provider.getAvatar(name) : null;
-
-      return { name, avatar };
-    },
-
-    { enabled: !!address && isEnsSupported },
-  );
+  return useQuery<string | null, Error>(ensQueryKey(address), () => provider.lookupAddress(address), {
+    enabled: !!address && isEnsSupported,
+  });
 };


### PR DESCRIPTION
- Prevents the content layout shift in the sidebar caused by the wallet address appearing after loading
- Moves the address to the connect button (common practice across most dapps)