### PR TITLE
Improve Test Speed

### DIFF
--- a/.github/workflows/coverageBadges.yml
+++ b/.github/workflows/coverageBadges.yml
@@ -1,0 +1,90 @@
+name: Code Coverage Badges
+
+on:
+  push:
+    branches: [develop]
+jobs:
+  test-branch:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout front end code.
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.ref}}
+    - name: Build UI
+      run: yarn install --frozen-lockfile
+    - name: Run unit tests
+      run:  yarn test:unit --silent --ci --json --coverage --testLocationInResults --maxWorkers=2 --outputFile=branch-report.json
+    - name: Upload Report
+      uses: actions/upload-artifact@v3
+      with:
+        name: branch-report
+        path: branch-report.json
+  prepareBadges:
+    runs-on: ubuntu-latest
+    needs: [test-branch]
+    steps:
+      - name: Download Branch Report
+        uses: actions/download-artifact@v3
+        with:
+          name: branch-report
+      - name: Prepare coverage badges
+        run: |
+          echo "COVERAGE_BRANCHES_PCT=$(echo $(jq .total.branches.pct branch-report.json))" >> $GITHUB_ENV
+          echo "COVERAGE_LINES_PCT=$(echo $(jq .total.lines.pct branch-report.json))" >> $GITHUB_ENV
+          echo "COVERAGE_STATEMENTS_PCT=$(echo $(jq .total.statements.pct branch-report.json))" >> $GITHUB_ENV
+          echo "COVERAGE_FUNCTIONS_PCT=$(echo $(jq .total.functions.pct branch-report.json))" >> $GITHUB_ENV
+
+          # get branch name
+          REF=${{ github.ref }}
+          echo "github.ref: $REF"
+          IFS='/' read -ra PATHS <<< "$REF"
+          BRANCH_NAME="${PATHS[1]}_${PATHS[2]}"
+          echo "BRANCH=$(echo ${BRANCH_NAME})" >> $GITHUB_ENV
+      - name: Create coverage branches badge
+        uses: schneegans/dynamic-badges-action@v1.0.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+          filename: olympus-frontend__coverage__branches__${{ env.BRANCH }}.json
+          label: Branches Coverage
+          message: ${{ env.COVERAGE_BRANCHES_PCT}}%
+          color: blue
+          namedLogo: jest
+          logoColor: lightblue
+      - name: Create coverage lines badge
+        uses: schneegans/dynamic-badges-action@v1.0.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+          filename: olympus-frontend__coverage__lines__${{ env.BRANCH }}.json
+          label: Lines Coverage
+          message: ${{ env.COVERAGE_LINES_PCT}}%
+          color: blue
+          namedLogo: jest
+          logoColor: lightblue
+      - name: Create coverage statements badge
+        uses: schneegans/dynamic-badges-action@v1.0.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+          filename: olympus-frontend__coverage__statements__${{ env.BRANCH }}.json
+          label: Statements Coverage
+          message: ${{ env.COVERAGE_STATEMENTS_PCT}}%
+          color: blue
+          namedLogo: jest
+          logoColor: lightblue
+      - name: Create coverage functions badge
+        uses: schneegans/dynamic-badges-action@v1.0.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+          filename: olympus-frontend__coverage__functions__${{ env.BRANCH }}.json
+          label: Functions Coverage
+          message: ${{ env.COVERAGE_FUNCTIONS_PCT}}%
+          color: blue
+          namedLogo: jest
+          logoColor: lightblue
+
+
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,6 @@
 name: Unit Tests
 
 on:
-  push:
-    branches: [master, develop]
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,23 +12,33 @@ jobs:
     steps:
       - name: Checkout front end code.
         uses: actions/checkout@v3
-      - name: Download dev coverage report
-        uses: actions/download-artifact@v3
-        with:
-          name: report.json
-          path: ./coverage/base/report.json
-      - name: Run unit tests
+      - name: Download base coverage report
+        id: base-coverage
+        uses: actions/cache@v3
+        with: 
+          path: coverage
+          key: ${{ github.base_ref }}
+      - name: Run unit tests with no base report
+        if: steps.base-coverage.cache-hit != 'true'
         uses: ArtiomTr/jest-coverage-report-action@v2.0.5
         with:
           test-script: yarn test:unit --silent
           package-manager: yarn
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          base-coverage-file: ./coverage/base/report.json
-      - name: Publish Coverage Report
-        uses: actions/upload-artifact@v3
+      - name: Run unit unit tests with base branch report
+        if: steps.base-coverage.cache-hit == 'true'
+        uses: ArtiomTr/jest-coverage-report-action@v2.0.5
         with:
-          name: ${{ github.ref }}-report.json
-          path: coverage/coverage-summary.json
+          test-script: yarn test:unit --silent
+          package-manager: yarn
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          base-coverage-file: ./coverage/coverage-summary.json
+      - name: Cache the coverage after run
+        id: branch-coverage
+        uses: actions/cache@v3
+        with: 
+          path: coverage
+          key: ${{ github.ref }}
       - name: Prepare coverage badges
         run: |
           echo "COVERAGE_BRANCHES_PCT=$(echo $(jq .total.branches.pct coverage/coverage-summary.json))" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Main CI
+name: Unit Tests
 
 on:
   push:
@@ -59,71 +59,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           coverage-file: branch-report.json
           base-coverage-file: base-report.json
-  prepareBadges:
-    runs-on: ubuntu-latest
-    needs: [test-branch]
-    steps:
-      - name: Download Branch Report
-        uses: actions/download-artifact@v3
-        with:
-          name: branch-report
-      - name: Prepare coverage badges
-        run: |
-          echo "COVERAGE_BRANCHES_PCT=$(echo $(jq .total.branches.pct branch-report.json))" >> $GITHUB_ENV
-          echo "COVERAGE_LINES_PCT=$(echo $(jq .total.lines.pct branch-report.json))" >> $GITHUB_ENV
-          echo "COVERAGE_STATEMENTS_PCT=$(echo $(jq .total.statements.pct branch-report.json))" >> $GITHUB_ENV
-          echo "COVERAGE_FUNCTIONS_PCT=$(echo $(jq .total.functions.pct branch-report.json))" >> $GITHUB_ENV
-
-          # get branch name
-          REF=${{ github.ref }}
-          echo "github.ref: $REF"
-          IFS='/' read -ra PATHS <<< "$REF"
-          BRANCH_NAME="${PATHS[1]}_${PATHS[2]}"
-          echo "BRANCH=$(echo ${BRANCH_NAME})" >> $GITHUB_ENV
-      - name: Create coverage branches badge
-        uses: schneegans/dynamic-badges-action@v1.0.0
-        with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-          filename: olympus-frontend__coverage__branches__${{ env.BRANCH }}.json
-          label: Branches Coverage
-          message: ${{ env.COVERAGE_BRANCHES_PCT}}%
-          color: blue
-          namedLogo: jest
-          logoColor: lightblue
-      - name: Create coverage lines badge
-        uses: schneegans/dynamic-badges-action@v1.0.0
-        with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-          filename: olympus-frontend__coverage__lines__${{ env.BRANCH }}.json
-          label: Lines Coverage
-          message: ${{ env.COVERAGE_LINES_PCT}}%
-          color: blue
-          namedLogo: jest
-          logoColor: lightblue
-      - name: Create coverage statements badge
-        uses: schneegans/dynamic-badges-action@v1.0.0
-        with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-          filename: olympus-frontend__coverage__statements__${{ env.BRANCH }}.json
-          label: Statements Coverage
-          message: ${{ env.COVERAGE_STATEMENTS_PCT}}%
-          color: blue
-          namedLogo: jest
-          logoColor: lightblue
-      - name: Create coverage functions badge
-        uses: schneegans/dynamic-badges-action@v1.0.0
-        with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-          filename: olympus-frontend__coverage__functions__${{ env.BRANCH }}.json
-          label: Functions Coverage
-          message: ${{ env.COVERAGE_FUNCTIONS_PCT}}%
-          color: blue
-          namedLogo: jest
-          logoColor: lightblue
+          annotations: none
 
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,63 +39,6 @@ jobs:
       with:
         name: branch-report.json
         path: report.json
-    - name: Prepare coverage badges
-      run: |
-        echo "COVERAGE_BRANCHES_PCT=$(echo $(jq .total.branches.pct report.json))" >> $GITHUB_ENV
-        echo "COVERAGE_LINES_PCT=$(echo $(jq .total.lines.pct report.json))" >> $GITHUB_ENV
-        echo "COVERAGE_STATEMENTS_PCT=$(echo $(jq .total.statements.pct report.json))" >> $GITHUB_ENV
-        echo "COVERAGE_FUNCTIONS_PCT=$(echo $(jq .total.functions.pct report.json))" >> $GITHUB_ENV
-
-        # get branch name
-        REF=${{ github.ref }}
-        echo "github.ref: $REF"
-        IFS='/' read -ra PATHS <<< "$REF"
-        BRANCH_NAME="${PATHS[1]}_${PATHS[2]}"
-        echo "BRANCH=$(echo ${BRANCH_NAME})" >> $GITHUB_ENV
-    - name: Create coverage branches badge
-      uses: schneegans/dynamic-badges-action@v1.0.0
-      with:
-        auth: ${{ secrets.GIST_SECRET }}
-        gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-        filename: olympus-frontend__coverage__branches__${{ env.BRANCH }}.json
-        label: Branches Coverage
-        message: ${{ env.COVERAGE_BRANCHES_PCT}}%
-        color: blue
-        namedLogo: jest
-        logoColor: lightblue
-    - name: Create coverage lines badge
-      uses: schneegans/dynamic-badges-action@v1.0.0
-      with:
-        auth: ${{ secrets.GIST_SECRET }}
-        gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-        filename: olympus-frontend__coverage__lines__${{ env.BRANCH }}.json
-        label: Lines Coverage
-        message: ${{ env.COVERAGE_LINES_PCT}}%
-        color: blue
-        namedLogo: jest
-        logoColor: lightblue
-    - name: Create coverage statements badge
-      uses: schneegans/dynamic-badges-action@v1.0.0
-      with:
-        auth: ${{ secrets.GIST_SECRET }}
-        gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-        filename: olympus-frontend__coverage__statements__${{ env.BRANCH }}.json
-        label: Statements Coverage
-        message: ${{ env.COVERAGE_STATEMENTS_PCT}}%
-        color: blue
-        namedLogo: jest
-        logoColor: lightblue
-    - name: Create coverage functions badge
-      uses: schneegans/dynamic-badges-action@v1.0.0
-      with:
-        auth: ${{ secrets.GIST_SECRET }}
-        gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-        filename: olympus-frontend__coverage__functions__${{ env.BRANCH }}.json
-        label: Functions Coverage
-        message: ${{ env.COVERAGE_FUNCTIONS_PCT}}%
-        color: blue
-        namedLogo: jest
-        logoColor: lightblue
   coverageReport:
     runs-on: ubuntu-latest
     needs: [test-base, test-branch]
@@ -104,19 +47,86 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: base-report.json
+          path: cov
       - name: Download Branch Report
         uses: actions/download-artifact@v3
         with:
           name: branch-report.json
+          path: cov
       - name: Generate Coverage Report
         uses: ArtiomTr/jest-coverage-report-action@v2.0.5
         with:
           test-script: yarn test:unit --silent
           package-manager: yarn
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          coverage-file: branch-report.json
-          base-coverage-file: base-report.json
+          coverage-file: cov/branch-report.json
+          base-coverage-file: cov/base-report.json
+  prepareBadges:
+    runs-on: ubuntu-latest
+    needs: [test-branch]
+    steps: 
+      - name: Download Branch Report
+      uses: actions/download-artifact@v3
+      with:
+        name: branch-report.json
+        path: cov
+      - name: Prepare coverage badges
+        run: |
+          echo "COVERAGE_BRANCHES_PCT=$(echo $(jq .total.branches.pct cov/branch-report.json))" >> $GITHUB_ENV
+          echo "COVERAGE_LINES_PCT=$(echo $(jq .total.lines.pct cov/branch-report.json))" >> $GITHUB_ENV
+          echo "COVERAGE_STATEMENTS_PCT=$(echo $(jq .total.statements.pct cov/branch-report.json))" >> $GITHUB_ENV
+          echo "COVERAGE_FUNCTIONS_PCT=$(echo $(jq .total.functions.pct cov/branch-report.json))" >> $GITHUB_ENV
 
+          # get branch name
+          REF=${{ github.ref }}
+          echo "github.ref: $REF"
+          IFS='/' read -ra PATHS <<< "$REF"
+          BRANCH_NAME="${PATHS[1]}_${PATHS[2]}"
+          echo "BRANCH=$(echo ${BRANCH_NAME})" >> $GITHUB_ENV
+      - name: Create coverage branches badge
+        uses: schneegans/dynamic-badges-action@v1.0.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+          filename: olympus-frontend__coverage__branches__${{ env.BRANCH }}.json
+          label: Branches Coverage
+          message: ${{ env.COVERAGE_BRANCHES_PCT}}%
+          color: blue
+          namedLogo: jest
+          logoColor: lightblue
+      - name: Create coverage lines badge
+        uses: schneegans/dynamic-badges-action@v1.0.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+          filename: olympus-frontend__coverage__lines__${{ env.BRANCH }}.json
+          label: Lines Coverage
+          message: ${{ env.COVERAGE_LINES_PCT}}%
+          color: blue
+          namedLogo: jest
+          logoColor: lightblue
+      - name: Create coverage statements badge
+        uses: schneegans/dynamic-badges-action@v1.0.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+          filename: olympus-frontend__coverage__statements__${{ env.BRANCH }}.json
+          label: Statements Coverage
+          message: ${{ env.COVERAGE_STATEMENTS_PCT}}%
+          color: blue
+          namedLogo: jest
+          logoColor: lightblue
+      - name: Create coverage functions badge
+        uses: schneegans/dynamic-badges-action@v1.0.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+          filename: olympus-frontend__coverage__functions__${{ env.BRANCH }}.json
+          label: Functions Coverage
+          message: ${{ env.COVERAGE_FUNCTIONS_PCT}}%
+          color: blue
+          namedLogo: jest
+          logoColor: lightblue
 
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Build UI
       run: yarn install --frozen-lockfile
     - name: Run unit tests
-      run:  yarn test:unit --silent --ci --json --coverage --testLocationInResults --outputFile=report.json
+      run:  yarn test:unit --silent --ci --json --coverage --testLocationInResults --maxWorkers=2 --outputFile=report.json
     - name: Upload Report
       uses: actions/upload-artifact@v3
       with:
@@ -33,7 +33,7 @@ jobs:
     - name: Build UI
       run: yarn install --frozen-lockfile
     - name: Run unit tests
-      run:  yarn test:unit --silent --ci --json --coverage --testLocationInResults --outputFile=report.json
+      run:  yarn test:unit --silent --ci --json --coverage --testLocationInResults --maxWorkers=2 --outputFile=report.json
     - name: Upload Report
       uses: actions/upload-artifact@v3
       with:
@@ -66,67 +66,67 @@ jobs:
     needs: [test-branch]
     steps: 
       - name: Download Branch Report
-      uses: actions/download-artifact@v3
-      with:
-        name: branch-report.json
-        path: cov
-      - name: Prepare coverage badges
-        run: |
-          echo "COVERAGE_BRANCHES_PCT=$(echo $(jq .total.branches.pct cov/branch-report.json))" >> $GITHUB_ENV
-          echo "COVERAGE_LINES_PCT=$(echo $(jq .total.lines.pct cov/branch-report.json))" >> $GITHUB_ENV
-          echo "COVERAGE_STATEMENTS_PCT=$(echo $(jq .total.statements.pct cov/branch-report.json))" >> $GITHUB_ENV
-          echo "COVERAGE_FUNCTIONS_PCT=$(echo $(jq .total.functions.pct cov/branch-report.json))" >> $GITHUB_ENV
+        uses: actions/download-artifact@v3
+        with:
+          name: branch-report.json
+          path: cov
+        - name: Prepare coverage badges
+          run: |
+            echo "COVERAGE_BRANCHES_PCT=$(echo $(jq .total.branches.pct cov/branch-report.json))" >> $GITHUB_ENV
+            echo "COVERAGE_LINES_PCT=$(echo $(jq .total.lines.pct cov/branch-report.json))" >> $GITHUB_ENV
+            echo "COVERAGE_STATEMENTS_PCT=$(echo $(jq .total.statements.pct cov/branch-report.json))" >> $GITHUB_ENV
+            echo "COVERAGE_FUNCTIONS_PCT=$(echo $(jq .total.functions.pct cov/branch-report.json))" >> $GITHUB_ENV
 
-          # get branch name
-          REF=${{ github.ref }}
-          echo "github.ref: $REF"
-          IFS='/' read -ra PATHS <<< "$REF"
-          BRANCH_NAME="${PATHS[1]}_${PATHS[2]}"
-          echo "BRANCH=$(echo ${BRANCH_NAME})" >> $GITHUB_ENV
-      - name: Create coverage branches badge
-        uses: schneegans/dynamic-badges-action@v1.0.0
-        with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-          filename: olympus-frontend__coverage__branches__${{ env.BRANCH }}.json
-          label: Branches Coverage
-          message: ${{ env.COVERAGE_BRANCHES_PCT}}%
-          color: blue
-          namedLogo: jest
-          logoColor: lightblue
-      - name: Create coverage lines badge
-        uses: schneegans/dynamic-badges-action@v1.0.0
-        with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-          filename: olympus-frontend__coverage__lines__${{ env.BRANCH }}.json
-          label: Lines Coverage
-          message: ${{ env.COVERAGE_LINES_PCT}}%
-          color: blue
-          namedLogo: jest
-          logoColor: lightblue
-      - name: Create coverage statements badge
-        uses: schneegans/dynamic-badges-action@v1.0.0
-        with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-          filename: olympus-frontend__coverage__statements__${{ env.BRANCH }}.json
-          label: Statements Coverage
-          message: ${{ env.COVERAGE_STATEMENTS_PCT}}%
-          color: blue
-          namedLogo: jest
-          logoColor: lightblue
-      - name: Create coverage functions badge
-        uses: schneegans/dynamic-badges-action@v1.0.0
-        with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-          filename: olympus-frontend__coverage__functions__${{ env.BRANCH }}.json
-          label: Functions Coverage
-          message: ${{ env.COVERAGE_FUNCTIONS_PCT}}%
-          color: blue
-          namedLogo: jest
-          logoColor: lightblue
+            # get branch name
+            REF=${{ github.ref }}
+            echo "github.ref: $REF"
+            IFS='/' read -ra PATHS <<< "$REF"
+            BRANCH_NAME="${PATHS[1]}_${PATHS[2]}"
+            echo "BRANCH=$(echo ${BRANCH_NAME})" >> $GITHUB_ENV
+        - name: Create coverage branches badge
+          uses: schneegans/dynamic-badges-action@v1.0.0
+          with:
+            auth: ${{ secrets.GIST_SECRET }}
+            gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+            filename: olympus-frontend__coverage__branches__${{ env.BRANCH }}.json
+            label: Branches Coverage
+            message: ${{ env.COVERAGE_BRANCHES_PCT}}%
+            color: blue
+            namedLogo: jest
+            logoColor: lightblue
+        - name: Create coverage lines badge
+          uses: schneegans/dynamic-badges-action@v1.0.0
+          with:
+            auth: ${{ secrets.GIST_SECRET }}
+            gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+            filename: olympus-frontend__coverage__lines__${{ env.BRANCH }}.json
+            label: Lines Coverage
+            message: ${{ env.COVERAGE_LINES_PCT}}%
+            color: blue
+            namedLogo: jest
+            logoColor: lightblue
+        - name: Create coverage statements badge
+          uses: schneegans/dynamic-badges-action@v1.0.0
+          with:
+            auth: ${{ secrets.GIST_SECRET }}
+            gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+            filename: olympus-frontend__coverage__statements__${{ env.BRANCH }}.json
+            label: Statements Coverage
+            message: ${{ env.COVERAGE_STATEMENTS_PCT}}%
+            color: blue
+            namedLogo: jest
+            logoColor: lightblue
+        - name: Create coverage functions badge
+          uses: schneegans/dynamic-badges-action@v1.0.0
+          with:
+            auth: ${{ secrets.GIST_SECRET }}
+            gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+            filename: olympus-frontend__coverage__functions__${{ env.BRANCH }}.json
+            label: Functions Coverage
+            message: ${{ env.COVERAGE_FUNCTIONS_PCT}}%
+            color: blue
+            namedLogo: jest
+            logoColor: lightblue
 
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,12 +17,12 @@ jobs:
     - name: Build UI
       run: yarn install --frozen-lockfile
     - name: Run unit tests
-      run:  yarn test:unit --silent --ci --json --coverage --testLocationInResults --maxWorkers=2 --outputFile=report.json
+      run:  yarn test:unit --silent --ci --json --coverage --testLocationInResults --maxWorkers=2 --outputFile=base-report.json
     - name: Upload Report
       uses: actions/upload-artifact@v3
       with:
-        name: base-report.json
-        path: report.json  
+        name: base-report
+        path: base-report.json  
   test-branch:
     runs-on: ubuntu-latest
     steps:
@@ -33,12 +33,12 @@ jobs:
     - name: Build UI
       run: yarn install --frozen-lockfile
     - name: Run unit tests
-      run:  yarn test:unit --silent --ci --json --coverage --testLocationInResults --maxWorkers=2 --outputFile=report.json
+      run:  yarn test:unit --silent --ci --json --coverage --testLocationInResults --maxWorkers=2 --outputFile=branch-report.json
     - name: Upload Report
       uses: actions/upload-artifact@v3
       with:
-        name: branch-report.json
-        path: report.json
+        name: branch-report
+        path: branch-report.json
   coverageReport:
     runs-on: ubuntu-latest
     needs: [test-base, test-branch]
@@ -46,21 +46,19 @@ jobs:
       - name: Download Base Report
         uses: actions/download-artifact@v3
         with:
-          name: base-report.json
-          path: cov
+          name: base-report
       - name: Download Branch Report
         uses: actions/download-artifact@v3
         with:
-          name: branch-report.json
-          path: cov
+          name: branch-report
       - name: Generate Coverage Report
         uses: ArtiomTr/jest-coverage-report-action@v2.0.5
         with:
           test-script: yarn test:unit --silent
           package-manager: yarn
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          coverage-file: cov/branch-report.json
-          base-coverage-file: cov/base-report.json
+          coverage-file: branch-report.json
+          base-coverage-file: base-report.json
   prepareBadges:
     runs-on: ubuntu-latest
     needs: [test-branch]
@@ -68,14 +66,13 @@ jobs:
       - name: Download Branch Report
         uses: actions/download-artifact@v3
         with:
-          name: branch-report.json
-          path: cov
+          name: branch-report
       - name: Prepare coverage badges
         run: |
-          echo "COVERAGE_BRANCHES_PCT=$(echo $(jq .total.branches.pct cov/branch-report.json))" >> $GITHUB_ENV
-          echo "COVERAGE_LINES_PCT=$(echo $(jq .total.lines.pct cov/branch-report.json))" >> $GITHUB_ENV
-          echo "COVERAGE_STATEMENTS_PCT=$(echo $(jq .total.statements.pct cov/branch-report.json))" >> $GITHUB_ENV
-          echo "COVERAGE_FUNCTIONS_PCT=$(echo $(jq .total.functions.pct cov/branch-report.json))" >> $GITHUB_ENV
+          echo "COVERAGE_BRANCHES_PCT=$(echo $(jq .total.branches.pct branch-report.json))" >> $GITHUB_ENV
+          echo "COVERAGE_LINES_PCT=$(echo $(jq .total.lines.pct branch-report.json))" >> $GITHUB_ENV
+          echo "COVERAGE_STATEMENTS_PCT=$(echo $(jq .total.statements.pct branch-report.json))" >> $GITHUB_ENV
+          echo "COVERAGE_FUNCTIONS_PCT=$(echo $(jq .total.functions.pct branch-report.json))" >> $GITHUB_ENV
 
           # get branch name
           REF=${{ github.ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,92 +7,116 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  test:
+  test-base:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout front end code.
-        uses: actions/checkout@v3
-      - name: Download base coverage report
-        id: base-coverage
-        uses: actions/cache@v3
-        with: 
-          path: coverage
-          key: ${{ github.base_ref }}
-      - name: Run unit tests with no base report
-        if: steps.base-coverage.cache-hit != 'true'
-        uses: ArtiomTr/jest-coverage-report-action@v2.0.5
+    - name: Checkout front end code.
+      uses: actions/checkout@v3
         with:
-          test-script: yarn test:unit --silent
-          package-manager: yarn
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run unit unit tests with base branch report
-        if: steps.base-coverage.cache-hit == 'true'
-        uses: ArtiomTr/jest-coverage-report-action@v2.0.5
+          ref: ${{ github.base_ref}}
+    - name: Build UI
+      run: yarn install --frozen-lockfile
+    - name: Run unit tests
+      run:  yarn test:unit --silent --ci --json --coverage --testLocationInResults --outputFile=report.json
+    - name: Upload Report
+      uses: actions/upload-artifact@v3
+      with:
+        name: base-report.json
+        path: report.json  
+  test-current:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout front end code.
+      uses: actions/checkout@v3
         with:
-          test-script: yarn test:unit --silent
-          package-manager: yarn
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          base-coverage-file: ./coverage/coverage-summary.json
-      - name: Cache the coverage after run
-        id: branch-coverage
-        uses: actions/cache@v3
-        with: 
-          path: coverage
-          key: ${{ github.ref }}
-      - name: Prepare coverage badges
-        run: |
-          echo "COVERAGE_BRANCHES_PCT=$(echo $(jq .total.branches.pct coverage/coverage-summary.json))" >> $GITHUB_ENV
-          echo "COVERAGE_LINES_PCT=$(echo $(jq .total.lines.pct coverage/coverage-summary.json))" >> $GITHUB_ENV
-          echo "COVERAGE_STATEMENTS_PCT=$(echo $(jq .total.statements.pct coverage/coverage-summary.json))" >> $GITHUB_ENV
-          echo "COVERAGE_FUNCTIONS_PCT=$(echo $(jq .total.functions.pct coverage/coverage-summary.json))" >> $GITHUB_ENV
+          ref: ${{ github.ref}}
+    - name: Build UI
+      run: yarn install --frozen-lockfile
+    - name: Run unit tests
+      run:  yarn test:unit --silent --ci --json --coverage --testLocationInResults --outputFile=report.json
+    - name: Upload Report
+      uses: actions/upload-artifact@v3
+      with:
+        name: branch-report.json
+        path: report.json
+    - name: Prepare coverage badges
+      run: |
+        echo "COVERAGE_BRANCHES_PCT=$(echo $(jq .total.branches.pct report.json))" >> $GITHUB_ENV
+        echo "COVERAGE_LINES_PCT=$(echo $(jq .total.lines.pct report.json))" >> $GITHUB_ENV
+        echo "COVERAGE_STATEMENTS_PCT=$(echo $(jq .total.statements.pct report.json))" >> $GITHUB_ENV
+        echo "COVERAGE_FUNCTIONS_PCT=$(echo $(jq .total.functions.pct report.json))" >> $GITHUB_ENV
 
-          # get branch name
-          REF=${{ github.ref }}
-          echo "github.ref: $REF"
-          IFS='/' read -ra PATHS <<< "$REF"
-          BRANCH_NAME="${PATHS[1]}_${PATHS[2]}"
-          echo "BRANCH=$(echo ${BRANCH_NAME})" >> $GITHUB_ENV
-      - name: Create coverage branches badge
-        uses: schneegans/dynamic-badges-action@v1.0.0
+        # get branch name
+        REF=${{ github.ref }}
+        echo "github.ref: $REF"
+        IFS='/' read -ra PATHS <<< "$REF"
+        BRANCH_NAME="${PATHS[1]}_${PATHS[2]}"
+        echo "BRANCH=$(echo ${BRANCH_NAME})" >> $GITHUB_ENV
+    - name: Create coverage branches badge
+      uses: schneegans/dynamic-badges-action@v1.0.0
+      with:
+        auth: ${{ secrets.GIST_SECRET }}
+        gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+        filename: olympus-frontend__coverage__branches__${{ env.BRANCH }}.json
+        label: Branches Coverage
+        message: ${{ env.COVERAGE_BRANCHES_PCT}}%
+        color: blue
+        namedLogo: jest
+        logoColor: lightblue
+    - name: Create coverage lines badge
+      uses: schneegans/dynamic-badges-action@v1.0.0
+      with:
+        auth: ${{ secrets.GIST_SECRET }}
+        gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+        filename: olympus-frontend__coverage__lines__${{ env.BRANCH }}.json
+        label: Lines Coverage
+        message: ${{ env.COVERAGE_LINES_PCT}}%
+        color: blue
+        namedLogo: jest
+        logoColor: lightblue
+    - name: Create coverage statements badge
+      uses: schneegans/dynamic-badges-action@v1.0.0
+      with:
+        auth: ${{ secrets.GIST_SECRET }}
+        gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+        filename: olympus-frontend__coverage__statements__${{ env.BRANCH }}.json
+        label: Statements Coverage
+        message: ${{ env.COVERAGE_STATEMENTS_PCT}}%
+        color: blue
+        namedLogo: jest
+        logoColor: lightblue
+    - name: Create coverage functions badge
+      uses: schneegans/dynamic-badges-action@v1.0.0
+      with:
+        auth: ${{ secrets.GIST_SECRET }}
+        gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+        filename: olympus-frontend__coverage__functions__${{ env.BRANCH }}.json
+        label: Functions Coverage
+        message: ${{ env.COVERAGE_FUNCTIONS_PCT}}%
+        color: blue
+        namedLogo: jest
+        logoColor: lightblue
+  coverageReport:
+    runs-on: ubuntu-latest
+    needs: [test-base, test-branch]
+    steps: 
+      - name: Download Base Report
+        uses: actions/download-artifact@v3
         with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-          filename: olympus-frontend__coverage__branches__${{ env.BRANCH }}.json
-          label: Branches Coverage
-          message: ${{ env.COVERAGE_BRANCHES_PCT}}%
-          color: blue
-          namedLogo: jest
-          logoColor: lightblue
-      - name: Create coverage lines badge
-        uses: schneegans/dynamic-badges-action@v1.0.0
+          name: base-report.json
+      - name: Download Branch Report
+        uses: actions/download-artifact@v3
         with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-          filename: olympus-frontend__coverage__lines__${{ env.BRANCH }}.json
-          label: Lines Coverage
-          message: ${{ env.COVERAGE_LINES_PCT}}%
-          color: blue
-          namedLogo: jest
-          logoColor: lightblue
-      - name: Create coverage statements badge
-        uses: schneegans/dynamic-badges-action@v1.0.0
+          name: branch-report.json
+      - name: Generate Coverage Report
+        uses: ArtiomTr/jest-coverage-report-action@v2.0.5
         with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-          filename: olympus-frontend__coverage__statements__${{ env.BRANCH }}.json
-          label: Statements Coverage
-          message: ${{ env.COVERAGE_STATEMENTS_PCT}}%
-          color: blue
-          namedLogo: jest
-          logoColor: lightblue
-      - name: Create coverage functions badge
-        uses: schneegans/dynamic-badges-action@v1.0.0
-        with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-          filename: olympus-frontend__coverage__functions__${{ env.BRANCH }}.json
-          label: Functions Coverage
-          message: ${{ env.COVERAGE_FUNCTIONS_PCT}}%
-          color: blue
-          namedLogo: jest
-          logoColor: lightblue
+          test-script: yarn test:unit --silent
+          package-manager: yarn
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          coverage-file: branch-report.json
+          base-coverage-file: base-report.json
+
+
+
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           package-manager: yarn
           github-token: ${{ secrets.SECRET_TOKEN }}
       - name: Publish Coverage Report
-      - uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3
         with:
           name: report.json
           path: coverage/coverage-summary.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout front end code.
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v2
+        with:
+          cache: 'yarn'
       - name: Run unit tests
         uses: ArtiomTr/jest-coverage-report-action@v2.0.5
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Download dev coverage report
         uses: actions/download-artifact@v3
         with:
-          name: ${{ github.base_ref }}-report.json
+          name: report.json
           path: ./coverage/base/report.json
       - name: Run unit tests
         uses: ArtiomTr/jest-coverage-report-action@v2.0.5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Main CI
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [master, develop]
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:
@@ -15,19 +15,19 @@ jobs:
       - name: Download dev coverage report
         uses: actions/download-artifact@v3
         with:
-          name: report.json
-          path: ./coverage/develop/report.json
+          name: ${{ github.base_ref }}-report.json
+          path: ./coverage/base/report.json
       - name: Run unit tests
         uses: ArtiomTr/jest-coverage-report-action@v2.0.5
         with:
           test-script: yarn test:unit --silent
           package-manager: yarn
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          base-coverage-file: ./coverage/develop/report.json
+          base-coverage-file: ./coverage/base/report.json
       - name: Publish Coverage Report
         uses: actions/upload-artifact@v3
         with:
-          name: report.json
+          name: ${{ github.ref }}-report.json
           path: coverage/coverage-summary.json
       - name: Prepare coverage badges
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,69 +64,69 @@ jobs:
   prepareBadges:
     runs-on: ubuntu-latest
     needs: [test-branch]
-    steps: 
+    steps:
       - name: Download Branch Report
         uses: actions/download-artifact@v3
         with:
           name: branch-report.json
           path: cov
-        - name: Prepare coverage badges
-          run: |
-            echo "COVERAGE_BRANCHES_PCT=$(echo $(jq .total.branches.pct cov/branch-report.json))" >> $GITHUB_ENV
-            echo "COVERAGE_LINES_PCT=$(echo $(jq .total.lines.pct cov/branch-report.json))" >> $GITHUB_ENV
-            echo "COVERAGE_STATEMENTS_PCT=$(echo $(jq .total.statements.pct cov/branch-report.json))" >> $GITHUB_ENV
-            echo "COVERAGE_FUNCTIONS_PCT=$(echo $(jq .total.functions.pct cov/branch-report.json))" >> $GITHUB_ENV
+      - name: Prepare coverage badges
+        run: |
+          echo "COVERAGE_BRANCHES_PCT=$(echo $(jq .total.branches.pct cov/branch-report.json))" >> $GITHUB_ENV
+          echo "COVERAGE_LINES_PCT=$(echo $(jq .total.lines.pct cov/branch-report.json))" >> $GITHUB_ENV
+          echo "COVERAGE_STATEMENTS_PCT=$(echo $(jq .total.statements.pct cov/branch-report.json))" >> $GITHUB_ENV
+          echo "COVERAGE_FUNCTIONS_PCT=$(echo $(jq .total.functions.pct cov/branch-report.json))" >> $GITHUB_ENV
 
-            # get branch name
-            REF=${{ github.ref }}
-            echo "github.ref: $REF"
-            IFS='/' read -ra PATHS <<< "$REF"
-            BRANCH_NAME="${PATHS[1]}_${PATHS[2]}"
-            echo "BRANCH=$(echo ${BRANCH_NAME})" >> $GITHUB_ENV
-        - name: Create coverage branches badge
-          uses: schneegans/dynamic-badges-action@v1.0.0
-          with:
-            auth: ${{ secrets.GIST_SECRET }}
-            gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-            filename: olympus-frontend__coverage__branches__${{ env.BRANCH }}.json
-            label: Branches Coverage
-            message: ${{ env.COVERAGE_BRANCHES_PCT}}%
-            color: blue
-            namedLogo: jest
-            logoColor: lightblue
-        - name: Create coverage lines badge
-          uses: schneegans/dynamic-badges-action@v1.0.0
-          with:
-            auth: ${{ secrets.GIST_SECRET }}
-            gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-            filename: olympus-frontend__coverage__lines__${{ env.BRANCH }}.json
-            label: Lines Coverage
-            message: ${{ env.COVERAGE_LINES_PCT}}%
-            color: blue
-            namedLogo: jest
-            logoColor: lightblue
-        - name: Create coverage statements badge
-          uses: schneegans/dynamic-badges-action@v1.0.0
-          with:
-            auth: ${{ secrets.GIST_SECRET }}
-            gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-            filename: olympus-frontend__coverage__statements__${{ env.BRANCH }}.json
-            label: Statements Coverage
-            message: ${{ env.COVERAGE_STATEMENTS_PCT}}%
-            color: blue
-            namedLogo: jest
-            logoColor: lightblue
-        - name: Create coverage functions badge
-          uses: schneegans/dynamic-badges-action@v1.0.0
-          with:
-            auth: ${{ secrets.GIST_SECRET }}
-            gistID: d630a3bd1cf13bb3dc3c1925df28efcd
-            filename: olympus-frontend__coverage__functions__${{ env.BRANCH }}.json
-            label: Functions Coverage
-            message: ${{ env.COVERAGE_FUNCTIONS_PCT}}%
-            color: blue
-            namedLogo: jest
-            logoColor: lightblue
+          # get branch name
+          REF=${{ github.ref }}
+          echo "github.ref: $REF"
+          IFS='/' read -ra PATHS <<< "$REF"
+          BRANCH_NAME="${PATHS[1]}_${PATHS[2]}"
+          echo "BRANCH=$(echo ${BRANCH_NAME})" >> $GITHUB_ENV
+      - name: Create coverage branches badge
+        uses: schneegans/dynamic-badges-action@v1.0.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+          filename: olympus-frontend__coverage__branches__${{ env.BRANCH }}.json
+          label: Branches Coverage
+          message: ${{ env.COVERAGE_BRANCHES_PCT}}%
+          color: blue
+          namedLogo: jest
+          logoColor: lightblue
+      - name: Create coverage lines badge
+        uses: schneegans/dynamic-badges-action@v1.0.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+          filename: olympus-frontend__coverage__lines__${{ env.BRANCH }}.json
+          label: Lines Coverage
+          message: ${{ env.COVERAGE_LINES_PCT}}%
+          color: blue
+          namedLogo: jest
+          logoColor: lightblue
+      - name: Create coverage statements badge
+        uses: schneegans/dynamic-badges-action@v1.0.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+          filename: olympus-frontend__coverage__statements__${{ env.BRANCH }}.json
+          label: Statements Coverage
+          message: ${{ env.COVERAGE_STATEMENTS_PCT}}%
+          color: blue
+          namedLogo: jest
+          logoColor: lightblue
+      - name: Create coverage functions badge
+        uses: schneegans/dynamic-badges-action@v1.0.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: d630a3bd1cf13bb3dc3c1925df28efcd
+          filename: olympus-frontend__coverage__functions__${{ env.BRANCH }}.json
+          label: Functions Coverage
+          message: ${{ env.COVERAGE_FUNCTIONS_PCT}}%
+          color: blue
+          namedLogo: jest
+          logoColor: lightblue
 
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - name: Checkout front end code.
         uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
-        with:
-          cache: 'yarn'
       - name: Run unit tests
         uses: ArtiomTr/jest-coverage-report-action@v2.0.5
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         name: base-report.json
         path: report.json  
-  test-current:
+  test-branch:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout front end code.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,12 +12,18 @@ jobs:
     steps:
       - name: Checkout front end code.
         uses: actions/checkout@v3
+      - name: Download dev coverage report
+        uses: actions/download-artifact@v3
+        with:
+          name: report.json
+          path: ./coverage/develop/report.json
       - name: Run unit tests
         uses: ArtiomTr/jest-coverage-report-action@v2.0.5
         with:
           test-script: yarn test:unit --silent
           package-manager: yarn
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          base-coverage-file: ./coverage/develop/report.json
       - name: Publish Coverage Report
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
     - name: Checkout front end code.
       uses: actions/checkout@v3
-        with:
-          ref: ${{ github.base_ref}}
+      with:
+        ref: ${{ github.base_ref}}
     - name: Build UI
       run: yarn install --frozen-lockfile
     - name: Run unit tests
@@ -28,8 +28,8 @@ jobs:
     steps:
     - name: Checkout front end code.
       uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref}}
+      with:
+        ref: ${{ github.ref}}
     - name: Build UI
       run: yarn install --frozen-lockfile
     - name: Run unit tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           test-script: yarn test:unit --silent
           package-manager: yarn
-          github-token: ${{ secrets.SECRET_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish Coverage Report
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,24 +10,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout front end code.
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
-        with:
-          cache: 'yarn'
-      - name: Build UI for production
-        run: |
-          yarn install --frozen-lockfile
-          yarn lint
-          yarn build
-        env:
-          CI: false
       - name: Run unit tests
         uses: ArtiomTr/jest-coverage-report-action@v2.0.5
         with:
           test-script: yarn test:unit --silent
-          skip-step: install
           package-manager: yarn
+          github-token: ${{ secrets.SECRET_TOKEN }}
+      - name: Publish Coverage Report
+      - uses: actions/upload-artifact@v3
+        with:
+          name: report.json
+          path: coverage/coverage-summary.json
       - name: Prepare coverage badges
         run: |
           echo "COVERAGE_BRANCHES_PCT=$(echo $(jq .total.branches.pct coverage/coverage-summary.json))" >> $GITHUB_ENV


### PR DESCRIPTION
Reduces Test Runtime by ~60%. 

### Improvements:
 - set maxWorkers to 2 for action run. Github Action runners CPUs were pegged at 100+% 
 - Run base and current branch in parallel in two separate jobs. They are not dependent on each other and do not need to run sequentially. 
 - Turn off on push rule for develop and master for tests. For tests this is a redundant step as all code enters these branches via PR's. 
 - Move prepareBadges into its own workflow and have it only run on push( merge) to develop branch. Previously this was running on every single PR and every single push to develop and master, which was unnecessary as readme only points to gist file for coverage generated on develop.
 - Generate test report artifacts to be used in dependent workflow jobs
 - Disable coverage annotations on code in github. I found this annoying, but we can add it if anyone found it valuable. 
 - Add Github Token for coverage report step. Hopefully this allows dependabot to execute successfully. If it doesn't, we can probably disable the coverage report step now for PR's via dependabot.. since now everything is isolated. 
 
 - Can potentially follow-up with some package caching improvements using a cache step. https://github.com/marketplace/actions/cache. Currently 1.5 min of build time is due to install/build. This is redundant for base branch (develop) on PR's... however it's an unavoidable and necessary step to run a clean install on the branch being compared. Since base and branch tests are now running in parallel we'd probably see marginal, if any gain on github actions.
 
 
![image](https://user-images.githubusercontent.com/95196612/170391202-29682b33-a79b-4dd3-8346-a667a3b4aaad.png)
 
 