### PR TITLE
Inverse bond low capacity

### DIFF
--- a/src/views/Bond/__tests__/InverseBond.unit.test.jsx
+++ b/src/views/Bond/__tests__/InverseBond.unit.test.jsx
@@ -105,7 +105,7 @@ describe("Inverse Bonds", () => {
     render(<Bond />);
 
     expect(await screen.findByTestId("8--bond")).toBeInTheDocument(); // bond id of 8
-    expect(await screen.findByText("$0.00")).toBeInTheDocument(); // Price of the DAI inverse bond
+    expect(await screen.findByText("Sold Out")).toBeInTheDocument(); // Price of the DAI inverse bond. isSoldOut = true so this should be not return price.
   });
 });
 

--- a/src/views/Bond/hooks/useBond.ts
+++ b/src/views/Bond/hooks/useBond.ts
@@ -156,7 +156,11 @@ export const fetchBond = async ({ id, isInverseBond, networkId }: UseBondOptions
    * Bonds are sold out if either there is no capacity left,
    * or the maximum has been paid out for a specific interval.
    */
-  const isSoldOut = capacityInBaseToken.lt("1") || maxPayoutInBaseToken.lt("1");
+
+  console.log(capacityInBaseToken, "cap in base token");
+  const isSoldOut = isInverseBond
+    ? capacityInQuoteToken.lt("1") || maxPayoutInQuoteToken.lt("1")
+    : capacityInBaseToken.lt("1") || maxPayoutInBaseToken.lt("1");
 
   return {
     id,

--- a/src/views/Bond/hooks/useBond.ts
+++ b/src/views/Bond/hooks/useBond.ts
@@ -157,7 +157,6 @@ export const fetchBond = async ({ id, isInverseBond, networkId }: UseBondOptions
    * or the maximum has been paid out for a specific interval.
    */
 
-  console.log(capacityInBaseToken, "cap in base token");
   const isSoldOut = isInverseBond
     ? maxPayoutInQuoteToken.lt("1")
     : capacityInBaseToken.lt("1") || maxPayoutInBaseToken.lt("1");

--- a/src/views/Bond/hooks/useBond.ts
+++ b/src/views/Bond/hooks/useBond.ts
@@ -159,8 +159,8 @@ export const fetchBond = async ({ id, isInverseBond, networkId }: UseBondOptions
 
   console.log(capacityInBaseToken, "cap in base token");
   const isSoldOut = isInverseBond
-    ? capacityInQuoteToken.lt("1") || maxPayoutInQuoteToken.lt("1")
-    : capacityInBaseToken.lt("1") || maxPayoutInBaseToken.lt("1");
+    ? capacityInQuoteToken.lt("1") || maxPayoutInBaseToken.lt("1")
+    : capacityInBaseToken.lt("1") || maxPayoutInQuoteToken.lt("1");
 
   return {
     id,

--- a/src/views/Bond/hooks/useBond.ts
+++ b/src/views/Bond/hooks/useBond.ts
@@ -159,7 +159,7 @@ export const fetchBond = async ({ id, isInverseBond, networkId }: UseBondOptions
 
   console.log(capacityInBaseToken, "cap in base token");
   const isSoldOut = isInverseBond
-    ? capacityInQuoteToken.lt("1")
+    ? maxPayoutInQuoteToken.lt("1")
     : capacityInBaseToken.lt("1") || maxPayoutInBaseToken.lt("1");
 
   return {

--- a/src/views/Bond/hooks/useBond.ts
+++ b/src/views/Bond/hooks/useBond.ts
@@ -159,8 +159,8 @@ export const fetchBond = async ({ id, isInverseBond, networkId }: UseBondOptions
 
   console.log(capacityInBaseToken, "cap in base token");
   const isSoldOut = isInverseBond
-    ? capacityInQuoteToken.lt("1") || maxPayoutInBaseToken.lt("1")
-    : capacityInBaseToken.lt("1") || maxPayoutInQuoteToken.lt("1");
+    ? capacityInQuoteToken.lt("1")
+    : capacityInBaseToken.lt("1") || maxPayoutInBaseToken.lt("1");
 
   return {
     id,


### PR DESCRIPTION
To keep UX consistent with regular bonds isSoldOut should also check for inverseBond low capacity <1 OHM and follow the same UX pattern as regular bonds. 

This change checks if maxPayoutInQuoteToken(OHM in the case of inverse bonds) is less than 1. If condition is true, it will return isSoldOut for Inverse Bonds. 
Before:
<img width="843" alt="image" src="https://user-images.githubusercontent.com/95196612/171768923-7ffd5a48-d05e-413e-8bef-441d284f449a.png">

After:
<img width="832" alt="image" src="https://user-images.githubusercontent.com/95196612/171768874-e1ba468b-cdff-49bd-9f70-d2c8343576e1.png">
