### PR TITLE
update dependabot to 7 simultaneous prs to reduce build errors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 7
     reviewers:
       - 'OlympusDAO/Frontend'
     schedule:


### PR DESCRIPTION
having 10 simultaneous open prs was causing build errors in the mornings bc fleek could not build that many all at once.