### PR TITLE
load app details on initial paint

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -174,6 +174,7 @@ function App() {
     if (shouldTriggerSafetyCheck()) {
       dispatch(info("Safety Check: Always verify you're on app.olympusdao.finance!"));
     }
+    loadDetails("app");
   }, []);
 
   // this useEffect picks up any time a user Connects via the button


### PR DESCRIPTION
migration modal would not load because it uses marketPrice from app-slice. app-slice was accidentally removed from app.tsx when changing to rainbow-kit & removing web3context.