### PR TITLE
deprecate useOhmPrice & useGOhmPrice from subgraph & replace all usag…

### DIFF
--- a/src/constants/tokens.ts
+++ b/src/constants/tokens.ts
@@ -107,6 +107,20 @@ export const DAI_TOKEN = new Token({
 });
 
 /**
+ * We have to add the custom pricing func after
+ * the token has been initialised to prevent
+ * circular references during initialisation.
+ */
+DAI_TOKEN.customPricingFunc = async () => {
+  // WHY DO WE FIX DAI to $1 in BOND PRICING?
+  // because we are trying to give the user a price in USD and
+  // there is no such thing as USD on chain. If we wanted to be
+  // more precise we could give a price in DAI like 13.59 DAI
+  // rather than $13.59
+  return new DecimalBigNumber("1", 18);
+};
+
+/**
  * For inverse bonds, we have to use a different DAI testnet token
  * for compatability. Reason why has something to do with how the
  * treasury was set up on the rinkeby contract.
@@ -122,6 +136,15 @@ export const TEST_DAI_TOKEN = new Token({
   factory: IERC20__factory,
   purchaseUrl: "",
 });
+
+/**
+ * We have to add the custom pricing func after
+ * the token has been initialised to prevent
+ * circular references during initialisation.
+ */
+TEST_DAI_TOKEN.customPricingFunc = async () => {
+  return new DecimalBigNumber("1", 18);
+};
 
 export const LUSD_TOKEN = new Token({
   icons: ["LUSD"],

--- a/src/hooks/useProtocolMetrics.ts
+++ b/src/hooks/useProtocolMetrics.ts
@@ -138,7 +138,7 @@ export const useOhmFloatingSupply = () => useProtocolMetrics(metrics => metrics[
  * Please avoid using this method unless you are intentionally trying to read from subgraph.
  * You should typically be using `useOhmPrice` from `src/hooks/usePrices.ts`... as subgraph has an indexing delay
  */
-export const useOhmPrice = () => useProtocolMetrics(metrics => metrics[0].ohmPrice);
+export const useOHMPrice = () => useProtocolMetrics(metrics => metrics[0].ohmPrice);
 
 /**
  * @deprecated

--- a/src/hooks/useProtocolMetrics.ts
+++ b/src/hooks/useProtocolMetrics.ts
@@ -132,6 +132,18 @@ export const useTreasuryLiquidBackingPerOhmFloating = () =>
   useProtocolMetrics(metrics => metrics[0].treasuryLiquidBackingPerOhmFloating);
 export const useOhmCirculatingSupply = () => useProtocolMetrics(metrics => metrics[0].ohmCirculatingSupply);
 export const useOhmFloatingSupply = () => useProtocolMetrics(metrics => metrics[0].ohmFloatingSupply);
+
+/**
+ * @deprecated
+ * Please avoid using this method.
+ * you should be using `useOhmPrice` from `src/hooks/usePrices.ts`... as subgraph has an indexing delay
+ */
 export const useOhmPrice = () => useProtocolMetrics(metrics => metrics[0].ohmPrice);
+
+/**
+ * @deprecated
+ * Please avoid using this method.
+ * you should be using `useGohmPrice` from `src/hooks/usePrices.ts`... as subgraph has an indexing delay
+ */
 export const useGOhmPrice = () => useProtocolMetrics(metrics => metrics[0].gOhmPrice);
 export const useCurrentIndex = () => useProtocolMetrics(metrics => metrics[0].currentIndex);

--- a/src/hooks/useProtocolMetrics.ts
+++ b/src/hooks/useProtocolMetrics.ts
@@ -135,15 +135,15 @@ export const useOhmFloatingSupply = () => useProtocolMetrics(metrics => metrics[
 
 /**
  * @deprecated
- * Please avoid using this method.
- * you should be using `useOhmPrice` from `src/hooks/usePrices.ts`... as subgraph has an indexing delay
+ * Please avoid using this method unless you are intentionally trying to read from subgraph.
+ * You should typically be using `useOhmPrice` from `src/hooks/usePrices.ts`... as subgraph has an indexing delay
  */
 export const useOhmPrice = () => useProtocolMetrics(metrics => metrics[0].ohmPrice);
 
 /**
  * @deprecated
- * Please avoid using this method.
- * you should be using `useGohmPrice` from `src/hooks/usePrices.ts`... as subgraph has an indexing delay
+ * Please avoid using this method unless you are intentionally trying to read from subgraph.
+ * You should typically be using `useGohmPrice` from `src/hooks/usePrices.ts`... as subgraph has an indexing delay
  */
 export const useGOhmPrice = () => useProtocolMetrics(metrics => metrics[0].gOhmPrice);
 export const useCurrentIndex = () => useProtocolMetrics(metrics => metrics[0].currentIndex);

--- a/src/views/Bond/components/BondModal/BondModal.tsx
+++ b/src/views/Bond/components/BondModal/BondModal.tsx
@@ -158,6 +158,9 @@ const BondModal: React.VFC<{ bond: Bond }> = ({ bond }) => {
 const TokenPrice: React.VFC<{ token: Token; isInverseBond?: boolean }> = ({ token, isInverseBond }) => {
   const { data: priceToken = new DecimalBigNumber("0") } = useTokenPrice({ token, networkId: NetworkId.MAINNET });
   const { data: ohmPrice = 0 } = useOhmPrice();
-  const price = isInverseBond ? new DecimalBigNumber(ohmPrice.toString()) : priceToken;
-  return price ? <>${price.toString({ decimals: 2, format: true, trim: false })}</> : <Skeleton width={60} />;
+  const price = isInverseBond
+    ? formatCurrency(ohmPrice, 2)
+    : `$${priceToken.toString({ decimals: 2, format: true, trim: false })}`;
+  return price ? <>{price}</> : <Skeleton width={60} />;
+};
 };

--- a/src/views/Bond/components/BondModal/BondModal.tsx
+++ b/src/views/Bond/components/BondModal/BondModal.tsx
@@ -158,6 +158,6 @@ const BondModal: React.VFC<{ bond: Bond }> = ({ bond }) => {
 const TokenPrice: React.VFC<{ token: Token; isInverseBond?: boolean }> = ({ token, isInverseBond }) => {
   const { data: priceToken = new DecimalBigNumber("0") } = useTokenPrice({ token, networkId: NetworkId.MAINNET });
   const { data: ohmPrice = 0 } = useOhmPrice();
-  const price = isInverseBond ? priceToken.mul(new DecimalBigNumber(ohmPrice.toString())) : priceToken;
+  const price = isInverseBond ? new DecimalBigNumber(ohmPrice.toString()) : priceToken;
   return price ? <>${price.toString({ decimals: 2, format: true, trim: false })}</> : <Skeleton width={60} />;
 };

--- a/src/views/Bond/components/BondModal/BondModal.tsx
+++ b/src/views/Bond/components/BondModal/BondModal.tsx
@@ -4,6 +4,7 @@ import { Icon, Metric, Modal, TokenStack } from "@olympusdao/component-library";
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
 import { NetworkId } from "src/constants";
+import { formatCurrency } from "src/helpers";
 import { Token } from "src/helpers/contracts/Token";
 import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber";
 import { usePathForNetwork } from "src/hooks/usePathForNetwork";
@@ -162,5 +163,4 @@ const TokenPrice: React.VFC<{ token: Token; isInverseBond?: boolean }> = ({ toke
     ? formatCurrency(ohmPrice, 2)
     : `$${priceToken.toString({ decimals: 2, format: true, trim: false })}`;
   return price ? <>{price}</> : <Skeleton width={60} />;
-};
 };

--- a/src/views/TreasuryDashboard/TreasuryDashboard.tsx
+++ b/src/views/TreasuryDashboard/TreasuryDashboard.tsx
@@ -14,7 +14,14 @@ import {
   OHMStakedGraph,
   ProtocolOwnedLiquidityGraph,
 } from "./components/Graph/Graph";
-import { BackingPerOHM, CircSupply, CurrentIndex, GOHMPrice, MarketCap, OHMPrice } from "./components/Metric/Metric";
+import {
+  BackingPerOHM,
+  CircSupply,
+  CurrentIndex,
+  GOHMPrice,
+  MarketCap,
+  OHMPriceFromSubgraph,
+} from "./components/Metric/Metric";
 
 const sharedMetricProps: PropsOf<typeof Metric> = { labelVariant: "h6", metricVariant: "h5" };
 
@@ -24,7 +31,7 @@ const MetricsDashboard = () => (
       <Paper className="ohm-card">
         <MetricCollection>
           <MarketCap {...sharedMetricProps} />
-          <OHMPrice {...sharedMetricProps} />
+          <OHMPriceFromSubgraph {...sharedMetricProps} />
           <GOHMPrice {...sharedMetricProps} className="wsoprice" />
           <CircSupply {...sharedMetricProps} />
           <BackingPerOHM {...sharedMetricProps} />

--- a/src/views/TreasuryDashboard/components/Metric/Metric.tsx
+++ b/src/views/TreasuryDashboard/components/Metric/Metric.tsx
@@ -1,13 +1,14 @@
 import { t } from "@lingui/macro";
 import { Metric } from "@olympusdao/component-library";
 import { formatCurrency, formatNumber } from "src/helpers";
+import { useOhmPrice } from "src/hooks/usePrices";
 import {
   useCurrentIndex,
   useGOhmPrice,
   useMarketCap,
   useOhmCirculatingSupply,
   useOhmFloatingSupply,
-  useOhmPrice,
+  useOHMPrice,
   useTotalSupply,
   useTotalValueDeposited,
   useTreasuryLiquidBackingPerOhmFloating,
@@ -35,6 +36,9 @@ export const MarketCap: React.FC<AbstractedMetricProps> = props => {
   return <Metric {..._props} />;
 };
 
+/**
+ * same as OHMPriceFromSubgraph but uses OHM-DAI on-chain price
+ */
 export const OHMPrice: React.FC<AbstractedMetricProps> = props => {
   const { data: ohmPrice } = useOhmPrice();
   const _props: MetricProps = {
@@ -48,8 +52,27 @@ export const OHMPrice: React.FC<AbstractedMetricProps> = props => {
   return <Metric {..._props} />;
 };
 
+/**
+ * same as OHMPrice but uses Subgraph price
+ */
+export const OHMPriceFromSubgraph: React.FC<AbstractedMetricProps> = props => {
+  const { data: ohmPrice } = useOHMPrice();
+  const _props: MetricProps = {
+    ...props,
+    label: "OHM " + t`Price`,
+  };
+
+  if (ohmPrice) _props.metric = formatCurrency(ohmPrice, 2);
+  else _props.isLoading = true;
+
+  return <Metric {..._props} />;
+};
+
+/**
+ * uses Subgraph price
+ */
 export const SOHMPrice: React.FC<AbstractedMetricProps> = props => {
-  const { data: ohmPrice } = useOhmPrice();
+  const { data: ohmPrice } = useOHMPrice();
 
   const _props: MetricProps = {
     ...props,
@@ -123,6 +146,9 @@ export const CurrentIndex: React.FC<AbstractedMetricProps> = props => {
   return <Metric {..._props} />;
 };
 
+/**
+ * uses Subgraph price
+ */
 export const GOHMPrice: React.FC<AbstractedMetricProps> = props => {
   const { data: gOhmPrice } = useGOhmPrice();
 

--- a/src/views/TreasuryDashboard/components/Metric/Metric.tsx
+++ b/src/views/TreasuryDashboard/components/Metric/Metric.tsx
@@ -1,13 +1,12 @@
 import { t } from "@lingui/macro";
 import { Metric } from "@olympusdao/component-library";
 import { formatCurrency, formatNumber } from "src/helpers";
+import { useGohmPrice, useOhmPrice } from "src/hooks/usePrices";
 import {
   useCurrentIndex,
-  useGOhmPrice,
   useMarketCap,
   useOhmCirculatingSupply,
   useOhmFloatingSupply,
-  useOhmPrice,
   useTotalSupply,
   useTotalValueDeposited,
   useTreasuryLiquidBackingPerOhmFloating,
@@ -37,7 +36,6 @@ export const MarketCap: React.FC<AbstractedMetricProps> = props => {
 
 export const OHMPrice: React.FC<AbstractedMetricProps> = props => {
   const { data: ohmPrice } = useOhmPrice();
-
   const _props: MetricProps = {
     ...props,
     label: "OHM " + t`Price`,
@@ -125,7 +123,7 @@ export const CurrentIndex: React.FC<AbstractedMetricProps> = props => {
 };
 
 export const GOHMPrice: React.FC<AbstractedMetricProps> = props => {
-  const { data: gOhmPrice } = useGOhmPrice();
+  const { data: gOhmPrice } = useGohmPrice();
 
   const _props: MetricProps = {
     ...props,

--- a/src/views/TreasuryDashboard/components/Metric/Metric.tsx
+++ b/src/views/TreasuryDashboard/components/Metric/Metric.tsx
@@ -1,12 +1,13 @@
 import { t } from "@lingui/macro";
 import { Metric } from "@olympusdao/component-library";
 import { formatCurrency, formatNumber } from "src/helpers";
-import { useGohmPrice, useOhmPrice } from "src/hooks/usePrices";
 import {
   useCurrentIndex,
+  useGOhmPrice,
   useMarketCap,
   useOhmCirculatingSupply,
   useOhmFloatingSupply,
+  useOhmPrice,
   useTotalSupply,
   useTotalValueDeposited,
   useTreasuryLiquidBackingPerOhmFloating,
@@ -123,7 +124,7 @@ export const CurrentIndex: React.FC<AbstractedMetricProps> = props => {
 };
 
 export const GOHMPrice: React.FC<AbstractedMetricProps> = props => {
-  const { data: gOhmPrice } = useGohmPrice();
+  const { data: gOhmPrice } = useGOhmPrice();
 
   const _props: MetricProps = {
     ...props,


### PR DESCRIPTION
…es with contract pricing calls

FYI, @0xJem @brightiron this fixes the bond pricing issues we've talked about the last few days.