### PR TITLE
Bond Market Capacity in table should show remaining market capacity not max payout

### DIFF
--- a/src/views/Bond/components/BondList.tsx
+++ b/src/views/Bond/components/BondList.tsx
@@ -18,12 +18,11 @@ import { sortByDiscount } from "src/helpers/bonds/sortByDiscount";
 import { Token } from "src/helpers/contracts/Token";
 import { useScreenSize } from "src/hooks/useScreenSize";
 import { NetworkId } from "src/networkDetails";
-
-import { Bond } from "../hooks/useBond";
-import { BondDiscount } from "./BondDiscount";
-import { BondDuration } from "./BondDuration";
-import { BondInfoText } from "./BondInfoText";
-import { BondPrice } from "./BondPrice";
+import { BondDiscount } from "src/views/Bond/components/BondDiscount";
+import { BondDuration } from "src/views/Bond/components/BondDuration";
+import { BondInfoText } from "src/views/Bond/components/BondInfoText";
+import { BondPrice } from "src/views/Bond/components/BondPrice";
+import { Bond } from "src/views/Bond/hooks/useBond";
 
 export const BondList: React.VFC<{ bonds: Bond[]; isInverseBond: boolean }> = ({ bonds, isInverseBond }) => {
   const isSmallScreen = useScreenSize("md");
@@ -193,19 +192,13 @@ const BondTable: React.FC<{ isInverseBond: boolean }> = ({ children, isInverseBo
 );
 const quoteTokenCapacity = (bond: Bond, isInverseBond: boolean) => {
   const quoteTokenCapacity = `
-  ${(bond.maxPayout.inQuoteToken.lt(bond.capacity.inQuoteToken)
-    ? bond.maxPayout.inQuoteToken
-    : bond.capacity.inQuoteToken
-  ).toString({ decimals: 3, format: true })}${" "}
+  ${bond.capacity.inQuoteToken.toString({ decimals: 3, format: true })}${" "}
   ${bond.quoteToken.name}`;
   return quoteTokenCapacity;
 };
 const payoutTokenCapacity = (bond: Bond, isInverseBond: boolean) => {
   const payoutFormatter = Intl.NumberFormat("en", { notation: "compact" });
-  const payoutTokenCapacity = `${(bond.maxPayout.inBaseToken.lt(bond.capacity.inBaseToken)
-    ? bond.maxPayout.inBaseToken
-    : bond.capacity.inBaseToken
-  ).toString()}`;
+  const payoutTokenCapacity = `${bond.capacity.inBaseToken.toString()}`;
   return `${payoutFormatter.format(parseInt(payoutTokenCapacity))} ${" "}
   ${isInverseBond ? bond.baseToken.name : `sOHM`}`;
 };

--- a/src/views/Bond/components/BondList.tsx
+++ b/src/views/Bond/components/BondList.tsx
@@ -125,7 +125,7 @@ const BondCard: React.VFC<{ bond: Bond; isInverseBond: boolean }> = ({ bond, isI
       )}
       <Box display="flex" justifyContent="space-between" mt="8px">
         <Typography>
-          <Trans>Capacity</Trans>
+          <Trans>Max Payout</Trans>
         </Typography>
         {payoutTokenCapacity(bond, isInverseBond)}({quoteTokenCapacity(bond, isInverseBond)})
       </Box>
@@ -176,7 +176,7 @@ const BondTable: React.FC<{ isInverseBond: boolean }> = ({ children, isInverseBo
             <Trans>Discount</Trans>
           </TableCell>
           <TableCell style={{ padding: "8px 0" }}>
-            <Trans>Capacity</Trans>
+            <Trans>Max Payout</Trans>
           </TableCell>
           {!isInverseBond && (
             <TableCell style={{ padding: "8px 0" }}>
@@ -192,13 +192,19 @@ const BondTable: React.FC<{ isInverseBond: boolean }> = ({ children, isInverseBo
 );
 const quoteTokenCapacity = (bond: Bond, isInverseBond: boolean) => {
   const quoteTokenCapacity = `
-  ${bond.capacity.inQuoteToken.toString({ decimals: 3, format: true })}${" "}
+  ${(bond.maxPayout.inQuoteToken.lt(bond.capacity.inQuoteToken)
+    ? bond.maxPayout.inQuoteToken
+    : bond.capacity.inQuoteToken
+  ).toString({ decimals: 3, format: true })}${" "}
   ${bond.quoteToken.name}`;
   return quoteTokenCapacity;
 };
 const payoutTokenCapacity = (bond: Bond, isInverseBond: boolean) => {
   const payoutFormatter = Intl.NumberFormat("en", { notation: "compact" });
-  const payoutTokenCapacity = `${bond.capacity.inBaseToken.toString()}`;
+  const payoutTokenCapacity = `${(bond.maxPayout.inBaseToken.lt(bond.capacity.inBaseToken)
+    ? bond.maxPayout.inBaseToken
+    : bond.capacity.inBaseToken
+  ).toString()}`;
   return `${payoutFormatter.format(parseInt(payoutTokenCapacity))} ${" "}
   ${isInverseBond ? bond.baseToken.name : `sOHM`}`;
 };


### PR DESCRIPTION
Currently we show max payout in the bond table, not remaining capacity on that specific bond market. This change moves the table view to showing remaining market capacity, as the column is labeled. 

Max Payout is still displayed on the individual bond modals. 

I think we should either make this proposed change, or change the column label from 'Capacity' to 'Max Payout' to bring clarity to the value displayed here. 

Before:
![image](https://user-images.githubusercontent.com/95196612/183254788-e26ffa60-75b5-4783-9516-499dbd1abb44.png)

After:
![image](https://user-images.githubusercontent.com/95196612/183254802-23a6f16f-fb81-4273-b59a-d166169d12bc.png)
