### PR TITLE
remove rebases per day listed in USD terms (wallet)

### DIFF
--- a/src/components/TopBar/Wallet/Assets/index.tsx
+++ b/src/components/TopBar/Wallet/Assets/index.tsx
@@ -158,10 +158,7 @@ const AssetsIndex: FC<OHMAssetsProps> = (props: { path?: string }) => {
       assetValue: sOhmBalance.toApproxNumber() * ohmPrice,
       alwaysShow: true,
       lineThreeLabel: "Rebases per day",
-      lineThreeValue:
-        Number(formattedSOhmBalance) > 0
-          ? `${trim(rebaseAmountPerDay, 3)} sOHM / ${formatCurrency(rebaseAmountPerDay * ohmPrice, 2)}`
-          : undefined,
+      lineThreeValue: Number(formattedSOhmBalance) > 0 ? `${trim(rebaseAmountPerDay, 3)} sOHM ` : undefined,
     },
     {
       symbol: ["sOHM"] as OHMTokenStackProps["tokens"],


### PR DESCRIPTION
Removes the USD calculation for rebases from sOHM card in wallet section. 