### PR TITLE
<fix>(M&S pool): the addr should be frax swap pool not uniswap

### DIFF
--- a/src/helpers/AllExternalPools.ts
+++ b/src/helpers/AllExternalPools.ts
@@ -135,10 +135,10 @@ export const frax_ohm_frax = new ExternalPool({
   stakeOn: "Frax Finance",
   pairGecko: "frax",
   rewardGecko: "frax",
-  href: "https://app.frax.finance/staking/univ2-frax-ohm",
-  address: "0x2dce0dda1c2f98e0f171de8333c3c6fe1bbf4877", //LP
-  masterchef: "0xfC77A420f56Dec53e3b91D7FC936902e132335FF", //deposit
-  rewarder: "0xd683C7051a28fA150EB3F4BD92263865D4a67778",
+  href: "https://app.frax.finance/swap/liquidity",
+  address: "0x38633ed142BCc8128b45aB04A2e4A6e53774699F", //LP
+  masterchef: "", //deposit
+  rewarder: "",
   poolId: 0,
   networkID: NetworkId.MAINNET,
   mintAndSync: true,

--- a/src/views/Stake/components/ExternalStakePools/hooks/useStakePoolAPY.ts
+++ b/src/views/Stake/components/ExternalStakePools/hooks/useStakePoolAPY.ts
@@ -242,7 +242,7 @@ export const ConvexPoolAPY = (pool: ExternalPool) => {
 
 //Returns Frax Pool APY and TVL. Response also returns TVL for the pool, unlike other queries.
 export const FraxPoolAPY = (pool: ExternalPool) => {
-  const fraxAPI = "https://api.frax.finance/pools";
+  const fraxAPI = "https://api.frax.finance/v2/fraxswap/pools/0x38633ed142BCc8128b45aB04A2e4A6e53774699F";
   const {
     data = { apy: 0, liquidity_locked: 0 },
     isFetched,


### PR DESCRIPTION
## Types of changes
<!--Please remove the types that does not apply to this change-->

- **Bugfix**

## Description
<!--Describe what the change is**-->

seems to me that the link, TVL and contract address of M&S is wrong

![Screen Shot 2022-08-23 at 12 02 32 PM](https://user-images.githubusercontent.com/9366404/186067043-c7f58aae-88d2-4a31-9cc0-fa9781b89d25.png)

per <https://facts.frax.finance/pools/0x38633ed142BCc8128b45aB04A2e4A6e53774699F>, TVL should be `$371,438
`

![Screen Shot 2022-08-23 at 12 03 33 PM](https://user-images.githubusercontent.com/9366404/186067142-e8661d4b-4d3d-4963-bfef-629d1632a380.png)

## Checklist:
- [x] update `src/helpers/AllExternalPools.ts`
- [ ] update `src/views/Stake/components/ExternalStakePools/hooks/useStakePoolAPY.ts` 's `FraxPoolAPY` for correct APY and TVL

## Context

https://discord.com/channels/798328113087119371/871044563890995211/1009785178908016640