### PR TITLE
Make Error Messages Great Again

### DIFF
--- a/src/components/TokenAllowanceGuard/hooks/useApproveToken.ts
+++ b/src/components/TokenAllowanceGuard/hooks/useApproveToken.ts
@@ -5,6 +5,7 @@ import { useDispatch } from "react-redux";
 import { AddressMap } from "src/constants/addresses";
 import { useDynamicTokenContract } from "src/hooks/useContract";
 import { contractAllowanceQueryKey } from "src/hooks/useContractAllowance";
+import { EthersError } from "src/lib/EthersTypes";
 import { error as createErrorToast, info as createInfoToast } from "src/slices/MessagesSlice";
 import { useAccount, useNetwork } from "wagmi";
 
@@ -16,7 +17,7 @@ export const useApproveToken = (tokenAddressMap: AddressMap, spenderAddressMap: 
   const { chain = { id: 1 } } = useNetwork();
   const token = useDynamicTokenContract(tokenAddressMap, true);
 
-  return useMutation<ContractReceipt, Error>(
+  return useMutation<ContractReceipt, EthersError>(
     async () => {
       const contractAddress = spenderAddressMap[chain.id as keyof typeof spenderAddressMap];
 
@@ -28,7 +29,7 @@ export const useApproveToken = (tokenAddressMap: AddressMap, spenderAddressMap: 
       return transaction.wait();
     },
     {
-      onError: error => void dispatch(createErrorToast(error.message)),
+      onError: error => void dispatch(createErrorToast("error" in error ? error.error.message : error.message)),
       onSuccess: async () => {
         dispatch(createInfoToast("Successfully approved"));
         await client.refetchQueries([contractAllowanceQueryKey(address, chain.id, tokenAddressMap, spenderAddressMap)]);

--- a/src/components/TopBar/Wallet/hooks/useFaucet.ts
+++ b/src/components/TopBar/Wallet/hooks/useFaucet.ts
@@ -4,13 +4,14 @@ import { ContractReceipt } from "ethers";
 import { useDispatch } from "react-redux";
 import { DEV_FAUCET } from "src/constants/addresses";
 import { useDynamicFaucetContract } from "src/hooks/useContract";
+import { EthersError } from "src/lib/EthersTypes";
 import { error as createErrorToast, info as createInfoToast } from "src/slices/MessagesSlice";
 
 export const useFaucet = () => {
   const dispatch = useDispatch();
   const contract = useDynamicFaucetContract(DEV_FAUCET, true);
 
-  return useMutation<ContractReceipt, Error, string>(
+  return useMutation<ContractReceipt, EthersError, string>(
     async token_ => {
       if (!contract)
         throw new Error(t`Faucet is not supported on this network. Please switch to Goerli Testnet to use the faucet`);
@@ -40,8 +41,7 @@ export const useFaucet = () => {
     },
     {
       onError: error => {
-        console.error(error.message);
-        dispatch(createErrorToast(error.message));
+        dispatch(createErrorToast("error" in error ? error.error.message : error.message));
       },
       onSuccess: async () => {
         dispatch(createInfoToast(t`Successfully requested tokens from Faucet`));

--- a/src/hooks/useZapExecute.ts
+++ b/src/hooks/useZapExecute.ts
@@ -10,6 +10,7 @@ import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber"
 import { isSupportedChain } from "src/helpers/ZapHelper";
 import { balanceQueryKey } from "src/hooks/useBalance";
 import { zapTokenBalancesKey } from "src/hooks/useZapTokenBalances";
+import { EthersError } from "src/lib/EthersTypes";
 import { addresses } from "src/networkDetails";
 import { error, info } from "src/slices/MessagesSlice";
 import { Zap__factory } from "src/typechain/factories/Zap__factory";
@@ -46,7 +47,7 @@ export const useZapExecute = () => {
   const { address = "" } = useAccount();
   const { chain = { id: 1 } } = useNetwork();
 
-  return useMutation<ContractReceipt, Error, ZapExecuteOptions>(
+  return useMutation<ContractReceipt, EthersError, ZapExecuteOptions>(
     /**
      * Ideally the parameters to this async function should be the slippage, etc.
      * However the `mutationFn` parameter to `useMutation` accepts a function with
@@ -124,7 +125,7 @@ export const useZapExecute = () => {
         } else if (e.message.indexOf("TRANSFER_AMOUNT_EXCEEDS_BALANCE") > 0) {
           dispatch(error(t`Insufficient balance.`));
         } else {
-          dispatch(error(e.message));
+          dispatch(error("error" in e ? e.error.message : e.message));
         }
 
         /**

--- a/src/lib/EthersTypes.ts
+++ b/src/lib/EthersTypes.ts
@@ -1,0 +1,3 @@
+export interface EthersError extends Error {
+  error: Error;
+}

--- a/src/views/Bond/components/BondModal/components/BondInputArea/hooks/usePurchaseBond.ts
+++ b/src/views/Bond/components/BondModal/components/BondInputArea/hooks/usePurchaseBond.ts
@@ -9,6 +9,7 @@ import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber"
 import { isValidAddress } from "src/helpers/misc/isValidAddress";
 import { balanceQueryKey, useBalance } from "src/hooks/useBalance";
 import { useTestableNetworks } from "src/hooks/useTestableNetworks";
+import { EthersError } from "src/lib/EthersTypes";
 import { error as createErrorToast, info as createInfoToast } from "src/slices/MessagesSlice";
 import { bondNotesQueryKey } from "src/views/Bond/components/ClaimBonds/hooks/useBondNotes";
 import { Bond } from "src/views/Bond/hooks/useBond";
@@ -25,7 +26,7 @@ export const usePurchaseBond = (bond: Bond) => {
 
   return useMutation<
     ContractReceipt,
-    Error,
+    EthersError,
     {
       amount: string;
       slippage: string;
@@ -102,7 +103,7 @@ export const usePurchaseBond = (bond: Bond) => {
     },
     {
       onError: error => {
-        dispatch(createErrorToast(error.message));
+        dispatch(createErrorToast("error" in error ? error.error.message : error.message));
       },
       onSuccess: async (tx, { amount }) => {
         trackGAEvent({

--- a/src/views/Bond/components/ClaimBonds/hooks/useClaimBonds.ts
+++ b/src/views/Bond/components/ClaimBonds/hooks/useClaimBonds.ts
@@ -6,6 +6,7 @@ import { BOND_DEPOSITORY_CONTRACT } from "src/constants/contracts";
 import { trackGAEvent, trackGtagEvent } from "src/helpers/analytics/trackGAEvent";
 import { isValidAddress } from "src/helpers/misc/isValidAddress";
 import { useTestableNetworks } from "src/hooks/useTestableNetworks";
+import { EthersError } from "src/lib/EthersTypes";
 import { error as createErrorToast, info as createInfoToast } from "src/slices/MessagesSlice";
 import { bondNotesQueryKey } from "src/views/Bond/components/ClaimBonds/hooks/useBondNotes";
 import { useAccount, useNetwork, useSigner } from "wagmi";
@@ -17,7 +18,7 @@ export const useClaimBonds = () => {
   const { address = "" } = useAccount();
   const { data: signer } = useSigner();
   const { chain = { id: 1 } } = useNetwork();
-  return useMutation<ContractReceipt, Error, { id?: string; isPayoutGohm: boolean }>(
+  return useMutation<ContractReceipt, EthersError, { id?: string; isPayoutGohm: boolean }>(
     async ({ id, isPayoutGohm }) => {
       if (!signer) throw new Error(t`Please connect a wallet to claim bonds`);
       if (chain.id !== networks.MAINNET)
@@ -40,7 +41,7 @@ export const useClaimBonds = () => {
     },
     {
       onError: error => {
-        dispatch(createErrorToast(error.message));
+        dispatch(createErrorToast("error" in error ? error.error.message : error.message));
       },
       onSuccess: async (tx, { id }) => {
         trackGAEvent({

--- a/src/views/Give/hooks/useEditGive.ts
+++ b/src/views/Give/hooks/useEditGive.ts
@@ -10,6 +10,7 @@ import { balanceQueryKey } from "src/hooks/useBalance";
 import { useDynamicGiveContract } from "src/hooks/useContract";
 import { donationInfoQueryKey, recipientInfoQueryKey } from "src/hooks/useGiveInfo";
 import { useTestableNetworks } from "src/hooks/useTestableNetworks";
+import { EthersError } from "src/lib/EthersTypes";
 import { error as createErrorToast, info as createInfoToast } from "src/slices/MessagesSlice";
 import { EditGiveData } from "src/views/Give/Interfaces";
 import { useAccount, useNetwork, useSigner } from "wagmi";
@@ -26,7 +27,7 @@ export const useIncreaseGive = () => {
   const contract = useDynamicGiveContract(GIVE_ADDRESSES, true);
 
   // Mutation to interact with the YieldDirector contract
-  return useMutation<ContractReceipt, Error, EditGiveData>(
+  return useMutation<ContractReceipt, EthersError, EditGiveData>(
     // Pass in an object with an amount and a recipient parameter
     async ({ id: id_, amount: amount_, recipient: recipient_, token: token_ }) => {
       // Validate inputs
@@ -65,7 +66,7 @@ export const useIncreaseGive = () => {
     },
     {
       onError: error => {
-        dispatch(createErrorToast(error.message));
+        dispatch(createErrorToast("error" in error ? error.error.message : error.message));
       },
       onSuccess: async (data, EditGiveData) => {
         // Refetch sOHM balance and donation info
@@ -104,7 +105,7 @@ export const useDecreaseGive = () => {
   );
 
   // Mutation to interact with the YieldDirector contract
-  return useMutation<ContractReceipt, Error, EditGiveData>(
+  return useMutation<ContractReceipt, EthersError, EditGiveData>(
     // Pass in an object with an amount and a recipient parameter
     async ({ id: id_, amount: amount_, recipient: recipient_, token: token_ }) => {
       // Validate inputs
@@ -150,7 +151,7 @@ export const useDecreaseGive = () => {
     },
     {
       onError: error => {
-        dispatch(createErrorToast(error.message));
+        dispatch(createErrorToast("error" in error ? error.error.message : error.message));
       },
       onSuccess: async (data, EditGiveData) => {
         // Refetch balances and donation info

--- a/src/views/Give/hooks/useGive.ts
+++ b/src/views/Give/hooks/useGive.ts
@@ -9,6 +9,7 @@ import { balanceQueryKey } from "src/hooks/useBalance";
 import { useDynamicGiveContract } from "src/hooks/useContract";
 import { donationInfoQueryKey, recipientInfoQueryKey } from "src/hooks/useGiveInfo";
 import { useTestableNetworks } from "src/hooks/useTestableNetworks";
+import { EthersError } from "src/lib/EthersTypes";
 import { error as createErrorToast, info as createInfoToast } from "src/slices/MessagesSlice";
 import { GiveData } from "src/views/Give/Interfaces";
 import { useAccount } from "wagmi";
@@ -25,7 +26,7 @@ export const useGive = () => {
   const contract = useDynamicGiveContract(GIVE_ADDRESSES, true);
 
   // Mutation to interact with the YieldDirector contract
-  return useMutation<ContractReceipt, Error, GiveData>(
+  return useMutation<ContractReceipt, EthersError, GiveData>(
     // Pass in an object with an amount and a recipient parameter
     async ({ amount: amount_, recipient: recipient_, token: token_ }) => {
       // Validate inputs
@@ -66,7 +67,7 @@ export const useGive = () => {
     {
       onError: error => {
         console.error(error.message);
-        dispatch(createErrorToast(error.message));
+        dispatch(createErrorToast("error" in error ? error.error.message : error.message));
       },
       onSuccess: async (data, GiveData) => {
         const keysToRefetch = [

--- a/src/views/Give/hooks/useRedeem.ts
+++ b/src/views/Give/hooks/useRedeem.ts
@@ -8,6 +8,7 @@ import { balanceQueryKey } from "src/hooks/useBalance";
 import { useDynamicGiveContract } from "src/hooks/useContract";
 import { recipientInfoQueryKey, redeemableBalanceQueryKey } from "src/hooks/useGiveInfo";
 import { useTestableNetworks } from "src/hooks/useTestableNetworks";
+import { EthersError } from "src/lib/EthersTypes";
 import { error as createErrorToast, info as createInfoToast } from "src/slices/MessagesSlice";
 import { RedeemData } from "src/views/Give/Interfaces";
 import { useAccount } from "wagmi";
@@ -23,7 +24,7 @@ export const useRedeem = () => {
   const networks = useTestableNetworks();
   const contract = useDynamicGiveContract(GIVE_ADDRESSES, true);
 
-  return useMutation<ContractReceipt, Error, RedeemData>(
+  return useMutation<ContractReceipt, EthersError, RedeemData>(
     async ({ token: token_ }) => {
       if (!contract)
         throw new Error(
@@ -55,7 +56,7 @@ export const useRedeem = () => {
     {
       onError: error => {
         console.error(error.message);
-        dispatch(createErrorToast(error.message));
+        dispatch(createErrorToast("error" in error ? error.error.message : error.message));
       },
       onSuccess: async () => {
         const keysToRefetch = [

--- a/src/views/Give/hooks/useRedeemV1.ts
+++ b/src/views/Give/hooks/useRedeemV1.ts
@@ -8,6 +8,7 @@ import { balanceQueryKey } from "src/hooks/useBalance";
 import { useDynamicV1GiveContract } from "src/hooks/useContract";
 import { recipientInfoQueryKey, redeemableBalanceQueryKey, v1RedeemableBalanceQueryKey } from "src/hooks/useGiveInfo";
 import { useTestableNetworks } from "src/hooks/useTestableNetworks";
+import { EthersError } from "src/lib/EthersTypes";
 import { error as createErrorToast, info as createInfoToast } from "src/slices/MessagesSlice";
 import { useAccount, useNetwork } from "wagmi";
 /**
@@ -22,7 +23,7 @@ export const useOldRedeem = () => {
   const networks = useTestableNetworks();
   const contract = useDynamicV1GiveContract(OLD_GIVE_ADDRESSES, true);
 
-  return useMutation<ContractReceipt, Error>(
+  return useMutation<ContractReceipt, EthersError>(
     async () => {
       if (chain.id != 1)
         throw new Error(t`The old Give contract is only supported on the mainnet. Please switch to Ethereum mainnet`);
@@ -57,7 +58,7 @@ export const useOldRedeem = () => {
     {
       onError: error => {
         console.error(error.message);
-        dispatch(createErrorToast(error.message));
+        dispatch(createErrorToast("error" in error ? error.error.message : error.message));
       },
       onSuccess: async () => {
         const keysToRefetch = [

--- a/src/views/Stake/components/StakeArea/components/StakeInputArea/hooks/useStakeToken.ts
+++ b/src/views/Stake/components/StakeArea/components/StakeInputArea/hooks/useStakeToken.ts
@@ -8,6 +8,7 @@ import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber"
 import { balanceQueryKey, useBalance } from "src/hooks/useBalance";
 import { useDynamicStakingContract } from "src/hooks/useContract";
 import { useTestableNetworks } from "src/hooks/useTestableNetworks";
+import { EthersError } from "src/lib/EthersTypes";
 import { error as createErrorToast, info as createInfoToast } from "src/slices/MessagesSlice";
 import { useAccount } from "wagmi";
 
@@ -19,7 +20,7 @@ export const useStakeToken = (toToken: "sOHM" | "gOHM") => {
   const balance = useBalance(OHM_ADDRESSES)[networks.MAINNET].data;
   const contract = useDynamicStakingContract(STAKING_ADDRESSES, true);
 
-  return useMutation<ContractReceipt, Error, string>(
+  return useMutation<ContractReceipt, EthersError, string>(
     async amount => {
       if (!amount || isNaN(Number(amount))) throw new Error(t`Please enter a number`);
 
@@ -44,7 +45,7 @@ export const useStakeToken = (toToken: "sOHM" | "gOHM") => {
     },
     {
       onError: error => {
-        dispatch(createErrorToast(error.message));
+        dispatch(createErrorToast("error" in error ? error.error.message : error.message));
       },
       onSuccess: async (tx, amount) => {
         trackGAEvent({

--- a/src/views/Stake/components/StakeArea/components/StakeInputArea/hooks/useUnstakeToken.ts
+++ b/src/views/Stake/components/StakeArea/components/StakeInputArea/hooks/useUnstakeToken.ts
@@ -8,6 +8,7 @@ import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber"
 import { balanceQueryKey, useBalance } from "src/hooks/useBalance";
 import { useDynamicStakingContract } from "src/hooks/useContract";
 import { useTestableNetworks } from "src/hooks/useTestableNetworks";
+import { EthersError } from "src/lib/EthersTypes";
 import { error as createErrorToast, info as createInfoToast } from "src/slices/MessagesSlice";
 import { useAccount } from "wagmi";
 
@@ -21,7 +22,7 @@ export const useUnstakeToken = (fromToken: "sOHM" | "gOHM") => {
   const addresses = fromToken === "sOHM" ? SOHM_ADDRESSES : GOHM_ADDRESSES;
   const balance = useBalance(addresses)[networks.MAINNET].data;
 
-  return useMutation<ContractReceipt, Error, string>(
+  return useMutation<ContractReceipt, EthersError, string>(
     async amount => {
       if (!amount || isNaN(Number(amount))) throw new Error(t`Please enter a number`);
 
@@ -46,7 +47,7 @@ export const useUnstakeToken = (fromToken: "sOHM" | "gOHM") => {
     },
     {
       onError: error => {
-        dispatch(createErrorToast(error.message));
+        dispatch(createErrorToast("error" in error ? error.error.message : error.message));
       },
       onSuccess: async (tx, amount) => {
         trackGAEvent({

--- a/src/views/Wrap/components/MigrateInputArea/hooks/useMigrateWsohm.tsx
+++ b/src/views/Wrap/components/MigrateInputArea/hooks/useMigrateWsohm.tsx
@@ -8,6 +8,7 @@ import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber"
 import { balanceQueryKey, useBalance } from "src/hooks/useBalance";
 import { useDynamicMigratorContract } from "src/hooks/useContract";
 import { useTestableNetworks } from "src/hooks/useTestableNetworks";
+import { EthersError } from "src/lib/EthersTypes";
 import { error as createErrorToast, info as createInfoToast } from "src/slices/MessagesSlice";
 import { useAccount, useNetwork } from "wagmi";
 export const useMigrateWsohm = () => {
@@ -21,7 +22,7 @@ export const useMigrateWsohm = () => {
 
   const contract = useDynamicMigratorContract(MIGRATOR_ADDRESSES, true);
 
-  return useMutation<ContractReceipt, Error, string>(
+  return useMutation<ContractReceipt, EthersError, string>(
     async amount => {
       if (!amount || isNaN(Number(amount))) throw new Error(t`Please enter a number`);
 
@@ -43,7 +44,7 @@ export const useMigrateWsohm = () => {
     },
     {
       onError: error => {
-        dispatch(createErrorToast(error.message));
+        dispatch(createErrorToast("error" in error ? error.error.message : error.message));
       },
       onSuccess: async (_, amount) => {
         trackGAEvent({

--- a/src/views/Wrap/components/WrapInputArea/hooks/useUnwrapGohm.tsx
+++ b/src/views/Wrap/components/WrapInputArea/hooks/useUnwrapGohm.tsx
@@ -8,6 +8,7 @@ import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber"
 import { balanceQueryKey, useBalance } from "src/hooks/useBalance";
 import { useDynamicStakingContract } from "src/hooks/useContract";
 import { useTestableNetworks } from "src/hooks/useTestableNetworks";
+import { EthersError } from "src/lib/EthersTypes";
 import { error as createErrorToast, info as createInfoToast } from "src/slices/MessagesSlice";
 import { useAccount } from "wagmi";
 
@@ -19,7 +20,7 @@ export const useUnwrapGohm = () => {
   const balance = useBalance(GOHM_ADDRESSES)[networks.MAINNET].data;
   const contract = useDynamicStakingContract(STAKING_ADDRESSES, true);
 
-  return useMutation<ContractReceipt, Error, string>(
+  return useMutation<ContractReceipt, EthersError, string>(
     async amount => {
       if (!amount || isNaN(Number(amount))) throw new Error(t`Please enter a number`);
 
@@ -40,7 +41,7 @@ export const useUnwrapGohm = () => {
     },
     {
       onError: error => {
-        dispatch(createErrorToast(error.message));
+        dispatch(createErrorToast("error" in error ? error.error.message : error.message));
       },
       onSuccess: async (_, amount) => {
         trackGAEvent({

--- a/src/views/Wrap/components/WrapInputArea/hooks/useWrapSohm.tsx
+++ b/src/views/Wrap/components/WrapInputArea/hooks/useWrapSohm.tsx
@@ -8,6 +8,7 @@ import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber"
 import { balanceQueryKey, useBalance } from "src/hooks/useBalance";
 import { useDynamicStakingContract } from "src/hooks/useContract";
 import { useTestableNetworks } from "src/hooks/useTestableNetworks";
+import { EthersError } from "src/lib/EthersTypes";
 import { error as createErrorToast, info as createInfoToast } from "src/slices/MessagesSlice";
 import { useAccount } from "wagmi";
 
@@ -20,7 +21,7 @@ export const useWrapSohm = () => {
   const balance = useBalance(SOHM_ADDRESSES)[networks.MAINNET].data;
   const contract = useDynamicStakingContract(STAKING_ADDRESSES, true);
 
-  return useMutation<ContractReceipt, Error, string>(
+  return useMutation<ContractReceipt, EthersError, string>(
     async amount => {
       if (!amount || isNaN(Number(amount))) throw new Error(t`Please enter a number`);
 
@@ -41,7 +42,7 @@ export const useWrapSohm = () => {
     },
     {
       onError: error => {
-        dispatch(createErrorToast(error.message));
+        dispatch(createErrorToast("error" in error ? error.error.message : error.message));
       },
       onSuccess: async (_, amount) => {
         trackGAEvent({


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/95196612/186443775-fdb2b211-e42f-4cee-92c3-1bdb03f3db0e.png)

After:
<img width="921" alt="$268,053,654" src="https://user-images.githubusercontent.com/95196612/186443942-5c470628-4959-4fa3-a133-f1068ef4c6a8.png">

Ethers includes a nested error object in their error response. This is inconsistent with the Error type, which doesn't have the concept of a nested error object, but it's nice because it does provide us with an object we can work with outside of the raw error response:
example nested error object from ethers:
```
{
    "code": -32603,
    "message": "execution reverted: TRANSFER_FROM_FAILED",
    "data": {
        "originalError": {
            "code": 3,
            "data": "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000145452414e534645525f46524f4d5f4641494c4544000000000000000000000000",
            "message": "execution reverted: TRANSFER_FROM_FAILED"
        }
    }
}

```

This change adds a custom EthersError type which extends the current Error type.
This will allow us to pass both custom errors, i.e. throw new Error('message') and also evaluate an ethers error response for just the message.  