### PR TITLE
Resolve v1 Migration Issues

### DIFF
--- a/src/slices/AppSlice.ts
+++ b/src/slices/AppSlice.ts
@@ -1,65 +1,21 @@
 import { createAsyncThunk, createSelector, createSlice } from "@reduxjs/toolkit";
 import { ethers } from "ethers";
-import sOHMv2 from "src/abi/sOhmv2.json";
 import { addresses, NetworkId } from "src/constants";
-import { SOHM_ADDRESSES, STAKING_ADDRESSES } from "src/constants/addresses";
+import { STAKING_ADDRESSES } from "src/constants/addresses";
 import { getMarketPrice, getTokenPrice, setAll } from "src/helpers";
 import { Providers } from "src/helpers/providers/Providers/Providers";
-import apollo from "src/lib/apolloClient";
 import { IBaseAsyncThunk } from "src/slices/interfaces";
 import { RootState } from "src/store";
-import { OlympusStaking__factory, OlympusStakingv2__factory, SOhmv2 } from "src/typechain";
-
-interface IProtocolMetrics {
-  readonly timestamp: string;
-  readonly ohmCirculatingSupply: string;
-  readonly sOhmCirculatingSupply: string;
-  readonly totalSupply: string;
-  readonly ohmPrice: string;
-  readonly marketCap: string;
-  readonly totalValueLocked: string;
-  readonly treasuryMarketValue: string;
-  readonly nextEpochRebase: string;
-  readonly nextDistributedOhm: string;
-}
+import { OlympusStaking__factory, OlympusStakingv2__factory } from "src/typechain";
 
 export const loadAppDetails = createAsyncThunk(
   "app/loadAppDetails",
   async ({ networkID, provider }: IBaseAsyncThunk, { dispatch }) => {
-    const protocolMetricsQuery = `
-      query {
-        _meta {
-          block {
-            number
-          }
-        }
-        protocolMetrics(first: 1, orderBy: timestamp, orderDirection: desc) {
-          timestamp
-          ohmCirculatingSupply
-          sOhmCirculatingSupply
-          totalSupply
-          ohmPrice
-          marketCap
-          totalValueLocked
-          treasuryMarketValue
-          nextEpochRebase
-          nextDistributedOhm
-        }
-      }
-    `;
-
     if (networkID !== NetworkId.MAINNET) {
       provider = Providers.getStaticProvider(NetworkId.MAINNET);
       networkID = NetworkId.MAINNET;
     }
-    const graphData = await apollo<{ protocolMetrics: IProtocolMetrics[] }>(protocolMetricsQuery);
 
-    if (!graphData || graphData == null) {
-      console.error("Returned a null response when querying TheGraph");
-      return;
-    }
-
-    const stakingTVL = parseFloat(graphData.data.protocolMetrics[0].totalValueLocked);
     // NOTE (appleseed): marketPrice from Graph was delayed, so get CoinGecko price
     // const marketPrice = parseFloat(graphData.data.protocolMetrics[0].ohmPrice);
     let marketPrice;
@@ -74,21 +30,12 @@ export const loadAppDetails = createAsyncThunk(
       return;
     }
 
-    const marketCap = parseFloat(graphData.data.protocolMetrics[0].marketCap);
-    const circSupply = parseFloat(graphData.data.protocolMetrics[0].ohmCirculatingSupply);
-    const totalSupply = parseFloat(graphData.data.protocolMetrics[0].totalSupply);
-    const treasuryMarketValue = parseFloat(graphData.data.protocolMetrics[0].treasuryMarketValue);
     // const currentBlock = parseFloat(graphData.data._meta.block.number);
 
     if (!provider) {
       console.error("failed to connect to provider, please connect your wallet");
       return {
-        stakingTVL,
         marketPrice,
-        marketCap,
-        circSupply,
-        totalSupply,
-        treasuryMarketValue,
       } as IAppData;
     }
     const currentBlock = await provider.getBlockNumber();
@@ -99,21 +46,6 @@ export const loadAppDetails = createAsyncThunk(
     );
     const stakingContractV1 = OlympusStaking__factory.connect(addresses[networkID].STAKING_ADDRESS, provider);
 
-    const sohmMainContract = new ethers.Contract(
-      SOHM_ADDRESSES[networkID as keyof typeof SOHM_ADDRESSES] as string,
-      sOHMv2.abi,
-      provider,
-    ) as SOhmv2;
-
-    // Calculating staking
-    const epoch = await stakingContract.epoch();
-    const secondsToEpoch = Number(await stakingContract.secondsToNextEpoch());
-    const stakingReward = epoch.distribute;
-    const circ = await sohmMainContract.circulatingSupply();
-    const stakingRebase = Number(stakingReward.toString()) / Number(circ.toString());
-    const fiveDayRate = Math.pow(1 + stakingRebase, 5 * 3) - 1;
-    const stakingAPY = Math.pow(1 + stakingRebase, 365 * 3) - 1;
-
     // Current index
     const currentIndex = await stakingContract.index();
     const currentIndexV1 = await stakingContractV1.index();
@@ -121,16 +53,7 @@ export const loadAppDetails = createAsyncThunk(
       currentIndex: ethers.utils.formatUnits(currentIndex, "gwei"),
       currentIndexV1: ethers.utils.formatUnits(currentIndexV1, "gwei"),
       currentBlock,
-      fiveDayRate,
-      stakingAPY,
-      stakingTVL,
-      stakingRebase,
-      marketCap,
       marketPrice,
-      circSupply,
-      totalSupply,
-      treasuryMarketValue,
-      secondsToEpoch,
     } as IAppData;
   },
 );
@@ -152,17 +75,12 @@ const loadMarketPrice = createAsyncThunk("app/loadMarketPrice", async ({}: IBase
 });
 
 export interface IAppData {
-  readonly circSupply?: number;
   readonly currentIndex?: string;
   readonly currentIndexV1?: string;
   readonly currentBlock?: number;
-  readonly fiveDayRate?: number;
   readonly loading: boolean;
   readonly loadingMarketPrice: boolean;
-  readonly marketCap?: number;
   readonly marketPrice?: number;
-  readonly stakingAPY?: number;
-  readonly stakingRebase?: number;
   readonly stakingTVL?: number;
   readonly totalSupply?: number;
   readonly treasuryBalance?: number;

--- a/src/views/V1-Stake/V1-Stake.jsx
+++ b/src/views/V1-Stake/V1-Stake.jsx
@@ -19,7 +19,7 @@ import {
 } from "@mui/material";
 import { Skeleton } from "@mui/material";
 import { Tab, TabPanel, Tabs } from "@olympusdao/component-library";
-import { DataRow, Metric, MetricCollection, Paper } from "@olympusdao/component-library";
+import { DataRow, MetricCollection, Paper } from "@olympusdao/component-library";
 import { ethers } from "ethers";
 import { useCallback, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -36,6 +36,10 @@ import { isPendingTxn, txnButtonText } from "src/slices/PendingTxnsSlice";
 import { changeApproval, changeStake } from "src/slices/StakeThunk";
 import { ExternalStakePools } from "src/views/Stake/components/ExternalStakePools/ExternalStakePools";
 import RebaseTimer from "src/views/Stake/components/StakeArea/components/RebaseTimer/RebaseTimer";
+import { StakeFiveDayYield } from "src/views/Stake/components/StakeArea/components/StakeFiveDayYield";
+import { StakeNextRebaseAmount } from "src/views/Stake/components/StakeArea/components/StakeNextRebaseAmount";
+import { StakeRebaseYield } from "src/views/Stake/components/StakeArea/components/StakeRebaseYield";
+import { CurrentIndex, StakingAPY, TotalValueDeposited } from "src/views/TreasuryDashboard/components/Metric/Metric";
 import { useAccount, useNetwork, useProvider } from "wagmi";
 
 function V1Stake({ setMigrationModalOpen }) {
@@ -54,9 +58,7 @@ function V1Stake({ setMigrationModalOpen }) {
   const currentIndex = useSelector(state => {
     return state.app.currentIndex;
   });
-  const fiveDayRate = useSelector(state => {
-    return state.app.fiveDayRate;
-  });
+
   const ohmBalance = useSelector(state => {
     return state.account.balances && state.account.balances.ohmV1;
   });
@@ -71,15 +73,6 @@ function V1Stake({ setMigrationModalOpen }) {
   });
   const unstakeAllowance = useSelector(state => {
     return state.account.staking && state.account.staking.ohmUnstakeV1;
-  });
-  const stakingRebase = useSelector(state => {
-    return state.app.stakingRebase;
-  });
-  const stakingAPY = useSelector(state => {
-    return state.app.stakingAPY;
-  });
-  const stakingTVL = useSelector(state => {
-    return state.app.stakingTVL;
   });
 
   const pendingTransactions = useSelector(state => {
@@ -166,46 +159,20 @@ function V1Stake({ setMigrationModalOpen }) {
       .reduce((a, b) => a + b, 0)
       .toFixed(4),
   );
-  const trimmedStakingAPY = trim(stakingAPY * 100, 1);
-  const stakingRebasePercentage = trim(stakingRebase * 100, 4);
-  const nextRewardValue = trim((stakingRebasePercentage / 100) * trimmedBalance, 4);
 
   const goToV2Stake = () => {
     navigate("/stake");
   };
 
-  const formattedTrimmedStakingAPY = new Intl.NumberFormat("en-US").format(Number(trimmedStakingAPY));
-  const formattedStakingTVL = new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 0,
-    minimumFractionDigits: 0,
-  }).format(stakingTVL);
-  const formattedCurrentIndex = trim(currentIndex, 1);
   return (
     <div id="v1-stake-view">
       <Paper headerText={`${t`Single Stake`} (3, 3)`} subHeader={<RebaseTimer />}>
         <Grid container direction="column" spacing={2}>
           <Grid item>
             <MetricCollection>
-              <Metric
-                className="stake-apy"
-                label={`${t`Annualized Rebases`} (v1)`}
-                metric={`${formattedTrimmedStakingAPY}%`}
-                isLoading={stakingAPY ? false : true}
-              />
-              <Metric
-                className="stake-tvl"
-                label={`${t`TVL`} (v1)`}
-                metric={formattedStakingTVL}
-                isLoading={stakingTVL ? false : true}
-              />
-              <Metric
-                className="stake-index"
-                label={`${t`Current Index`} (v1)`}
-                metric={`${formattedCurrentIndex} OHM`}
-                isLoading={currentIndex ? false : true}
-              />
+              <StakingAPY className="stake-apy" />
+              <TotalValueDeposited className="stake-tvl" />
+              <CurrentIndex className="stake-index" />
             </MetricCollection>
           </Grid>
 
@@ -394,17 +361,12 @@ function V1Stake({ setMigrationModalOpen }) {
                     </AccordionDetails>
                   </Accordion>
                   <Divider />
-                  <DataRow title={t`Your Next Rebase`} balance={`${nextRewardValue} sOHM`} isLoading={isAppLoading} />
-                  <DataRow
-                    title={t`Next Rebase Yield`}
-                    balance={`${stakingRebasePercentage}%`}
-                    isLoading={isAppLoading}
-                  />
-                  <DataRow
-                    title={t`Rebases (5-Day Rate)`}
-                    balance={`${trim(Number(fiveDayRate) * 100, 4)}%`}
-                    isLoading={isAppLoading}
-                  />
+
+                  <StakeNextRebaseAmount />
+
+                  <StakeRebaseYield />
+
+                  <StakeFiveDayYield />
                 </div>
               </>
             )}

--- a/src/views/V1-Stake/__tests__/__snapshots__/V1-Stake.unit.test.tsx.snap
+++ b/src/views/V1-Stake/__tests__/__snapshots__/V1-Stake.unit.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-label css-tlko1g-MuiTypography-root"
                           >
-                            Annualized Rebases (v1)
+                            Annualized Rebases
                           </p>
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-metric css-69sme-MuiTypography-root"
@@ -107,7 +107,7 @@ exports[`<Stake/> should render component. not connected 1`] = `
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-label css-tlko1g-MuiTypography-root"
                           >
-                            TVL (v1)
+                            Total Value Deposited
                           </p>
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-metric css-69sme-MuiTypography-root"
@@ -133,7 +133,28 @@ exports[`<Stake/> should render component. not connected 1`] = `
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-label css-tlko1g-MuiTypography-root"
                           >
-                            Current Index (v1)
+                            Current Index
+                            <div
+                              class="MuiBox-root css-w341jy"
+                              style="font-size: 14px;"
+                            >
+                              <div
+                                class="MuiBox-root css-0"
+                                style="display: inline-flex; justify-content: center; align-self: center;"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1fx2bp7-MuiSvgIcon-root"
+                                  focusable="false"
+                                  style="margin: 0px 5px; font-size: 1em;"
+                                  viewBox="0 0 20 20"
+                                >
+                                  <path
+                                    d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
                           </p>
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-metric css-69sme-MuiTypography-root"
@@ -2731,7 +2752,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-label css-tlko1g-MuiTypography-root"
                           >
-                            Annualized Rebases (v1)
+                            Annualized Rebases
                           </p>
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-metric css-69sme-MuiTypography-root"
@@ -2757,7 +2778,7 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-label css-tlko1g-MuiTypography-root"
                           >
-                            TVL (v1)
+                            Total Value Deposited
                           </p>
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-metric css-69sme-MuiTypography-root"
@@ -2783,7 +2804,28 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-label css-tlko1g-MuiTypography-root"
                           >
-                            Current Index (v1)
+                            Current Index
+                            <div
+                              class="MuiBox-root css-w341jy"
+                              style="font-size: 14px;"
+                            >
+                              <div
+                                class="MuiBox-root css-0"
+                                style="display: inline-flex; justify-content: center; align-self: center;"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1fx2bp7-MuiSvgIcon-root"
+                                  focusable="false"
+                                  style="margin: 0px 5px; font-size: 1em;"
+                                  viewBox="0 0 20 20"
+                                >
+                                  <path
+                                    d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
                           </p>
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-metric css-69sme-MuiTypography-root"
@@ -3083,7 +3125,10 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-4xvy19-MuiTypography-root"
                       style="text-align: right;"
                     >
-                      NaN sOHM
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse css-1l7q9tc-MuiSkeleton-root"
+                        style="width: 80px;"
+                      />
                     </p>
                   </div>
                   <div
@@ -3102,7 +3147,10 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-4xvy19-MuiTypography-root"
                       style="text-align: right;"
                     >
-                      NaN%
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse css-1l7q9tc-MuiSkeleton-root"
+                        style="width: 80px;"
+                      />
                     </p>
                   </div>
                   <div
@@ -3121,7 +3169,10 @@ exports[`<Stake/> should render the stake input Area when connected 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-4xvy19-MuiTypography-root"
                       style="text-align: right;"
                     >
-                      NaN%
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse css-1l7q9tc-MuiSkeleton-root"
+                        style="width: 80px;"
+                      />
                     </p>
                   </div>
                 </div>
@@ -5811,7 +5862,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-label css-tlko1g-MuiTypography-root"
                           >
-                            Annualized Rebases (v1)
+                            Annualized Rebases
                           </p>
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-metric css-69sme-MuiTypography-root"
@@ -5837,7 +5888,7 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-label css-tlko1g-MuiTypography-root"
                           >
-                            TVL (v1)
+                            Total Value Deposited
                           </p>
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-metric css-69sme-MuiTypography-root"
@@ -5863,7 +5914,28 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-label css-tlko1g-MuiTypography-root"
                           >
-                            Current Index (v1)
+                            Current Index
+                            <div
+                              class="MuiBox-root css-w341jy"
+                              style="font-size: 14px;"
+                            >
+                              <div
+                                class="MuiBox-root css-0"
+                                style="display: inline-flex; justify-content: center; align-self: center;"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1fx2bp7-MuiSvgIcon-root"
+                                  focusable="false"
+                                  style="margin: 0px 5px; font-size: 1em;"
+                                  viewBox="0 0 20 20"
+                                >
+                                  <path
+                                    d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
                           </p>
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-metric css-69sme-MuiTypography-root"
@@ -6163,7 +6235,10 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-4xvy19-MuiTypography-root"
                       style="text-align: right;"
                     >
-                      NaN sOHM
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse css-1l7q9tc-MuiSkeleton-root"
+                        style="width: 80px;"
+                      />
                     </p>
                   </div>
                   <div
@@ -6182,7 +6257,10 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-4xvy19-MuiTypography-root"
                       style="text-align: right;"
                     >
-                      NaN%
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse css-1l7q9tc-MuiSkeleton-root"
+                        style="width: 80px;"
+                      />
                     </p>
                   </div>
                   <div
@@ -6201,7 +6279,10 @@ exports[`<Stake/> should render the v1 migration modal 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-4xvy19-MuiTypography-root"
                       style="text-align: right;"
                     >
-                      NaN%
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse css-1l7q9tc-MuiSkeleton-root"
+                        style="width: 80px;"
+                      />
                     </p>
                   </div>
                 </div>
@@ -8891,7 +8972,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-label css-tlko1g-MuiTypography-root"
                           >
-                            Annualized Rebases (v1)
+                            Annualized Rebases
                           </p>
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-metric css-69sme-MuiTypography-root"
@@ -8917,7 +8998,7 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-label css-tlko1g-MuiTypography-root"
                           >
-                            TVL (v1)
+                            Total Value Deposited
                           </p>
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-metric css-69sme-MuiTypography-root"
@@ -8943,7 +9024,28 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-label css-tlko1g-MuiTypography-root"
                           >
-                            Current Index (v1)
+                            Current Index
+                            <div
+                              class="MuiBox-root css-w341jy"
+                              style="font-size: 14px;"
+                            >
+                              <div
+                                class="MuiBox-root css-0"
+                                style="display: inline-flex; justify-content: center; align-self: center;"
+                              >
+                                <svg
+                                  aria-hidden="true"
+                                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1fx2bp7-MuiSvgIcon-root"
+                                  focusable="false"
+                                  style="margin: 0px 5px; font-size: 1em;"
+                                  viewBox="0 0 20 20"
+                                >
+                                  <path
+                                    d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
                           </p>
                           <p
                             class="MuiTypography-root MuiTypography-body1 Metric-metric css-69sme-MuiTypography-root"
@@ -9243,7 +9345,10 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-4xvy19-MuiTypography-root"
                       style="text-align: right;"
                     >
-                      NaN sOHM
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse css-1l7q9tc-MuiSkeleton-root"
+                        style="width: 80px;"
+                      />
                     </p>
                   </div>
                   <div
@@ -9262,7 +9367,10 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-4xvy19-MuiTypography-root"
                       style="text-align: right;"
                     >
-                      NaN%
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse css-1l7q9tc-MuiSkeleton-root"
+                        style="width: 80px;"
+                      />
                     </p>
                   </div>
                   <div
@@ -9281,7 +9389,10 @@ exports[`<Stake/> should render the v1 migration modal and banner 1`] = `
                       class="MuiTypography-root MuiTypography-body1 css-4xvy19-MuiTypography-root"
                       style="text-align: right;"
                     >
-                      NaN%
+                      <span
+                        class="MuiSkeleton-root MuiSkeleton-text MuiSkeleton-pulse css-1l7q9tc-MuiSkeleton-root"
+                        style="width: 80px;"
+                      />
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
There was a protocol metrics graphql query in AppSlice that was throwing a silent Max Call Stack Exceeded error, and causing the rest of AppSlice to not load. 
This caused an issue with loading migration data, as loading this data happened below the protocol metrics query.

This PR removes the protocol metrics query from AppSlice.. since it's not being used, and also moves the APR, TVL, and Current Index metrics for V1 stake to use our current react-query hooks, instead of what's in AppSlice.

This leaves us with only having currentIndex, currentIndexV1 and marketPrice in AppSlice.

These can also be migrated, we'll just need to update tests and wanted to get something out quickly. I'll circle back with another PR for that.. 

