### PR TITLE
Annualized Rebases Calculation Adjustment

### DIFF
--- a/src/views/TreasuryDashboard/components/Metric/Metric.tsx
+++ b/src/views/TreasuryDashboard/components/Metric/Metric.tsx
@@ -235,7 +235,7 @@ export const StakingAPY: React.FC<AbstractedMetricProps> = props => {
   };
 
   if (rebaseRate) {
-    const apy = (Math.pow(1 + rebaseRate, 365 * 3) - 1) * 100;
+    const apy = rebaseRate * 365 * 3 * 100;
     const formatted = formatNumber(apy, 1);
 
     _props.metric = `${formatted}%`;


### PR DESCRIPTION
Currently the calculation is:
(1 +rebaseRate^1095) - 1 * 100 

I think it should be:
rebaseRate * 365 * 3 * 100;

With the rate adjustment the next rebase rate and Annualized Rate do not line up.