### PR TITLE
reduce max for v3 bonds by 1%

### DIFF
--- a/src/views/Bond/components/BondModal/BondModal.tsx
+++ b/src/views/Bond/components/BondModal/BondModal.tsx
@@ -147,7 +147,7 @@ export const BondModal: React.VFC<{ bond: Bond }> = ({ bond }) => {
 
         <Box mt="24px" textAlign="center" width={["100%", "70%"]}>
           <Typography variant="body2" color="textSecondary" style={{ fontSize: "1.075em" }}>
-            <BondInfoText isInverseBond={isInverseBond} />
+            {!bond.isV3Bond && <BondInfoText isInverseBond={isInverseBond} />}
           </Typography>
         </Box>
       </Box>

--- a/src/views/Bond/components/BondModal/components/BondInputArea/BondInputArea.tsx
+++ b/src/views/Bond/components/BondModal/components/BondInputArea/BondInputArea.tsx
@@ -53,19 +53,21 @@ export const BondInputArea: React.VFC<{
    */
   const setMax = () => {
     if (!balance) return;
+    const reduceMax = props.bond.isV3Bond ? new DecimalBigNumber("0.99") : new DecimalBigNumber("1");
 
     if (props.bond.capacity.inQuoteToken.lt(props.bond.maxPayout.inQuoteToken)) {
+      //temporarily reduce max on v3bonds by 1%
       return setAmount(
         props.bond.capacity.inQuoteToken.lt(balance)
-          ? props.bond.capacity.inQuoteToken.toString() // Capacity is the smallest
-          : balance.toString(),
+          ? props.bond.capacity.inQuoteToken.mul(reduceMax).toString() // Capacity is the smallest
+          : balance.mul(reduceMax).toString(),
       );
     }
 
     setAmount(
       props.bond.maxPayout.inQuoteToken.lt(balance)
-        ? props.bond.maxPayout.inQuoteToken.toString() // Payout is the smallest
-        : balance.toString(),
+        ? props.bond.maxPayout.inQuoteToken.mul(reduceMax).toString() // Payout is the smallest
+        : balance.mul(reduceMax).toString(),
     );
   };
 


### PR DESCRIPTION
- Reduce the max purchase amount by 1% while looking into maxPayout
- remove CTA at bottom of modal for v3 bonds