### PR TITLE
lowercase bond token when evaluating

### DIFF
--- a/src/views/Bond/hooks/useBondTokens.ts
+++ b/src/views/Bond/hooks/useBondTokens.ts
@@ -26,7 +26,7 @@ export const useBondTokens = () => {
       const tokens: string[] = logs
         .map((result: { topics: string[]; data: string }) => {
           const parsed = iface.parseLog({ topics: result.topics, data: result.data });
-          if (parsed.args.underlying === OHM_ADDRESSES[networks.MAINNET]) return parsed.args.bondToken;
+          if (parsed.args.underlying.toLowerCase() === OHM_ADDRESSES[networks.MAINNET]) return parsed.args.bondToken;
         })
         .filter((result_1: string) => result_1 != undefined);
       return tokens;


### PR DESCRIPTION
0x64aa3364F17a4D01c6f1751Fd97C2BD3D7e7f1D5 !== 0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5

lowercase the result from the bond protocol