### PR TITLE
price regular bonds in token per ohm

### DIFF
--- a/src/views/Bond/__tests__/Bond.unit.test.jsx
+++ b/src/views/Bond/__tests__/Bond.unit.test.jsx
@@ -113,7 +113,7 @@ describe("Bonds", () => {
   it("Should display the correct LP value", async () => {
     render(<Bond />);
 
-    expect(await screen.findByText("14.21 OHM")).toBeInTheDocument();
+    expect(await screen.findByText("14.21 FRAX")).toBeInTheDocument();
   });
 
   it("Should display the correct % Discount value", async () => {

--- a/src/views/Bond/components/BondList.tsx
+++ b/src/views/Bond/components/BondList.tsx
@@ -156,7 +156,7 @@ const BondCard: React.VFC<{ bond: Bond; isInverseBond: boolean }> = ({ bond, isI
           }
         >
           <TertiaryButton fullWidth>
-            {isInverseBond ? t`Bond ${quoteTokenName} for ${baseTokenName}` : t`Bond for ${quoteTokenName}`}
+            Bond {quoteTokenName} for {baseTokenName}
           </TertiaryButton>
         </Link>
       </Box>
@@ -294,7 +294,7 @@ const BondRow: React.VFC<{ bond: Bond; isInverseBond: boolean }> = ({ bond, isIn
             {bond.isSoldOut
               ? t({ message: "Sold Out", comment: "Bond is sold out" })
               : t({
-                  message: isInverseBond ? `Bond for ${baseTokenName}` : `Bond for ${quoteTokenName}`,
+                  message: `Bond for ${baseTokenName}`,
                   comment: "The act of bonding",
                 })}
           </TertiaryButton>

--- a/src/views/Bond/components/BondList.tsx
+++ b/src/views/Bond/components/BondList.tsx
@@ -105,7 +105,11 @@ const BondCard: React.VFC<{ bond: Bond; isInverseBond: boolean }> = ({ bond, isI
           {bond.isSoldOut ? (
             "--"
           ) : (
-            <BondPrice price={bond.price.inBaseToken} isInverseBond={isInverseBond} symbol={baseTokenName} />
+            <BondPrice
+              price={bond.price.inBaseToken}
+              isInverseBond={isInverseBond}
+              symbol={isInverseBond ? baseTokenName : quoteTokenName}
+            />
           )}
         </Typography>
       </Box>
@@ -248,7 +252,7 @@ const BondRow: React.VFC<{ bond: Bond; isInverseBond: boolean }> = ({ bond, isIn
               price={bond.price.inBaseToken}
               isInverseBond={isInverseBond}
               isV3Bond={bond.isV3Bond}
-              symbol={baseTokenName}
+              symbol={isInverseBond ? baseTokenName : quoteTokenName}
             />
           )}
         </Typography>

--- a/src/views/Bond/components/BondModal/BondModal.tsx
+++ b/src/views/Bond/components/BondModal/BondModal.tsx
@@ -184,7 +184,9 @@ const TokenPrice: React.VFC<{ token: Token; isInverseBond?: boolean; baseSymbol:
     ? formatNumber(1, 2)
     : isInverseBond
     ? formatNumber(ohmPrice, 2)
-    : `$${priceToken.toString({ decimals: 2, format: true, trim: false })}`;
+    : priceToken.gt(new DecimalBigNumber("0"))
+    ? new DecimalBigNumber("1").div(priceToken).toString({ decimals: 2, format: true, trim: false })
+    : "0.00";
   return price ? (
     <>
       {price} {baseSymbol}

--- a/src/views/Bond/components/BondModal/BondModal.tsx
+++ b/src/views/Bond/components/BondModal/BondModal.tsx
@@ -95,7 +95,11 @@ export const BondModal: React.VFC<{ bond: Bond }> = ({ bond }) => {
               bond.isSoldOut ? (
                 "--"
               ) : (
-                <BondPrice price={bond.price.inBaseToken} isInverseBond={isInverseBond} symbol={bond.baseToken.name} />
+                <BondPrice
+                  price={bond.price.inBaseToken}
+                  isInverseBond={isInverseBond}
+                  symbol={isInverseBond ? bond.baseToken.name : bond.quoteToken.name}
+                />
               )
             }
           />
@@ -184,12 +188,10 @@ const TokenPrice: React.VFC<{ token: Token; isInverseBond?: boolean; baseSymbol:
     ? formatNumber(1, 2)
     : isInverseBond
     ? formatNumber(ohmPrice, 2)
-    : priceToken.gt(new DecimalBigNumber("0"))
-    ? new DecimalBigNumber("1").div(priceToken).toString({ decimals: 2, format: true, trim: false })
-    : "0.00";
+    : `${priceToken.toString({ decimals: 2, format: true, trim: false })}`;
   return price ? (
     <>
-      {price} {baseSymbol}
+      {price} {isInverseBond ? baseSymbol : quoteSymbol}
     </>
   ) : (
     <Skeleton width={60} />


### PR DESCRIPTION
Bond Button CTA was displaying 'Bond for DAI' on regular bonds, which is incorrect.
Changing Pricing of Regular V2 Bonds to be priced in token per ohm instead of usd 
<img width="783" alt="image" src="https://user-images.githubusercontent.com/95196612/194789507-a94b86e4-6d9d-4c79-992d-c984d197d458.png">
<img width="852" alt="image" src="https://user-images.githubusercontent.com/95196612/194789547-aed51b4c-aa8d-4a74-9947-85a196efdb58.png">