### PR TITLE
Unsupported networks fix

### DIFF
--- a/src/components/TokenAllowanceGuard/TokenAllowanceGuard.tsx
+++ b/src/components/TokenAllowanceGuard/TokenAllowanceGuard.tsx
@@ -66,7 +66,7 @@ export const TokenAllowanceGuard: React.FC<{
   const { chain = { id: 1 } } = useNetwork();
   const { data: balance = new DecimalBigNumber("0") } = useBalance(tokenAddressMap)[
     chain.id as keyof typeof tokenAddressMap
-  ] || { data: { balance: new DecimalBigNumber("0") } };
+  ] || { data: new DecimalBigNumber("0") };
 
   if (!allowance)
     return (
@@ -110,7 +110,7 @@ export const GiveTokenAllowanceGuard: React.FC<{
   const { chain = { id: 1 } } = useNetwork();
   const { data: balance = new DecimalBigNumber("0") } = useBalance(props.tokenAddressMap)[
     chain.id as keyof typeof props.tokenAddressMap
-  ] || { data: { balance: new DecimalBigNumber("0") } };
+  ] || { data: new DecimalBigNumber("0") };
 
   if (_useContractAllowance.isLoading)
     return (

--- a/src/components/TokenAllowanceGuard/TokenAllowanceGuard.tsx
+++ b/src/components/TokenAllowanceGuard/TokenAllowanceGuard.tsx
@@ -9,7 +9,7 @@ import { AddressMap } from "src/constants/addresses";
 import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber";
 import { useBalance } from "src/hooks/useBalance";
 import { useContractAllowance } from "src/hooks/useContractAllowance";
-import { useNetwork } from "wagmi";
+import { useTestableNetworks } from "src/hooks/useTestableNetworks";
 
 const PREFIX = "TokenAllowanceGuard";
 
@@ -62,9 +62,8 @@ export const TokenAllowanceGuard: React.FC<{
 }> = ({ message, isVertical = false, tokenAddressMap, spenderAddressMap, children }) => {
   const approveMutation = useApproveToken(tokenAddressMap, spenderAddressMap);
   const { data: allowance } = useContractAllowance(tokenAddressMap, spenderAddressMap);
-
-  const { chain = { id: 1 } } = useNetwork();
-  const balance = useBalance(tokenAddressMap)[chain.id as keyof typeof tokenAddressMap].data;
+  const networks = useTestableNetworks();
+  const { data: balance = new DecimalBigNumber("0") } = useBalance(tokenAddressMap)[networks.MAINNET];
 
   const getBalance = (): DecimalBigNumber => {
     if (balance) return balance;
@@ -109,9 +108,8 @@ export const GiveTokenAllowanceGuard: React.FC<{
 }> = props => {
   const approveMutation = useApproveToken(props.tokenAddressMap, props.spenderAddressMap);
   const _useContractAllowance = useContractAllowance(props.tokenAddressMap, props.spenderAddressMap);
-
-  const { chain = { id: 1 } } = useNetwork();
-  const balance = useBalance(props.tokenAddressMap)[chain.id as keyof typeof props.tokenAddressMap].data;
+  const networks = useTestableNetworks();
+  const { data: balance = new DecimalBigNumber("0") } = useBalance(props.tokenAddressMap)[networks.MAINNET];
 
   const getBalance = (): DecimalBigNumber => {
     if (balance) return balance;

--- a/src/components/TokenAllowanceGuard/TokenAllowanceGuard.tsx
+++ b/src/components/TokenAllowanceGuard/TokenAllowanceGuard.tsx
@@ -68,11 +68,6 @@ export const TokenAllowanceGuard: React.FC<{
     chain.id as keyof typeof tokenAddressMap
   ] || { data: { balance: new DecimalBigNumber("0") } };
 
-  const getBalance = (): DecimalBigNumber => {
-    if (balance) return balance;
-    return new DecimalBigNumber("0");
-  };
-
   if (!allowance)
     return (
       <Box display="flex" alignItems="center" justifyContent="center" height={isVertical ? "84px" : "40px"}>
@@ -80,7 +75,7 @@ export const TokenAllowanceGuard: React.FC<{
       </Box>
     );
 
-  if (allowance.eq(0) || allowance.lt(getBalance().toBigNumber()))
+  if (allowance.eq(0) || allowance.lt(balance.toBigNumber()))
     return (
       <Grid container>
         <Grid item xs={12} sm={isVertical ? 12 : 8}>
@@ -117,11 +112,6 @@ export const GiveTokenAllowanceGuard: React.FC<{
     chain.id as keyof typeof props.tokenAddressMap
   ] || { data: { balance: new DecimalBigNumber("0") } };
 
-  const getBalance = (): DecimalBigNumber => {
-    if (balance) return balance;
-    return new DecimalBigNumber("0");
-  };
-
   if (_useContractAllowance.isLoading)
     return (
       <Grid container className={classes.inputRow}>
@@ -132,7 +122,7 @@ export const GiveTokenAllowanceGuard: React.FC<{
   if (
     !_useContractAllowance.data ||
     _useContractAllowance.data.eq(0) ||
-    _useContractAllowance.data.lt(getBalance().toBigNumber())
+    _useContractAllowance.data.lt(balance.toBigNumber())
   )
     return (
       <Grid container className={classes.inputRow} direction="column" spacing={5}>

--- a/src/components/TokenAllowanceGuard/TokenAllowanceGuard.tsx
+++ b/src/components/TokenAllowanceGuard/TokenAllowanceGuard.tsx
@@ -9,7 +9,7 @@ import { AddressMap } from "src/constants/addresses";
 import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber";
 import { useBalance } from "src/hooks/useBalance";
 import { useContractAllowance } from "src/hooks/useContractAllowance";
-import { useTestableNetworks } from "src/hooks/useTestableNetworks";
+import { useNetwork } from "wagmi";
 
 const PREFIX = "TokenAllowanceGuard";
 
@@ -62,8 +62,11 @@ export const TokenAllowanceGuard: React.FC<{
 }> = ({ message, isVertical = false, tokenAddressMap, spenderAddressMap, children }) => {
   const approveMutation = useApproveToken(tokenAddressMap, spenderAddressMap);
   const { data: allowance } = useContractAllowance(tokenAddressMap, spenderAddressMap);
-  const networks = useTestableNetworks();
-  const { data: balance = new DecimalBigNumber("0") } = useBalance(tokenAddressMap)[networks.MAINNET];
+
+  const { chain = { id: 1 } } = useNetwork();
+  const { data: balance = new DecimalBigNumber("0") } = useBalance(tokenAddressMap)[
+    chain.id as keyof typeof tokenAddressMap
+  ] || { data: { balance: new DecimalBigNumber("0") } };
 
   const getBalance = (): DecimalBigNumber => {
     if (balance) return balance;
@@ -108,8 +111,11 @@ export const GiveTokenAllowanceGuard: React.FC<{
 }> = props => {
   const approveMutation = useApproveToken(props.tokenAddressMap, props.spenderAddressMap);
   const _useContractAllowance = useContractAllowance(props.tokenAddressMap, props.spenderAddressMap);
-  const networks = useTestableNetworks();
-  const { data: balance = new DecimalBigNumber("0") } = useBalance(props.tokenAddressMap)[networks.MAINNET];
+
+  const { chain = { id: 1 } } = useNetwork();
+  const { data: balance = new DecimalBigNumber("0") } = useBalance(props.tokenAddressMap)[
+    chain.id as keyof typeof props.tokenAddressMap
+  ] || { data: { balance: new DecimalBigNumber("0") } };
 
   const getBalance = (): DecimalBigNumber => {
     if (balance) return balance;


### PR DESCRIPTION
Make sure balance always set to 0 if returns undefined from useBalance query
getBalance not needed anymore since `balance` is always set