### PR TITLE
refactor v3  reduced capacity / payout by 1%. 

### DIFF
--- a/src/views/Bond/components/BondModal/components/BondInputArea/BondInputArea.tsx
+++ b/src/views/Bond/components/BondModal/components/BondInputArea/BondInputArea.tsx
@@ -53,21 +53,19 @@ export const BondInputArea: React.VFC<{
    */
   const setMax = () => {
     if (!balance) return;
-    const reduceMax = props.bond.isV3Bond ? new DecimalBigNumber("0.99") : new DecimalBigNumber("1");
 
     if (props.bond.capacity.inQuoteToken.lt(props.bond.maxPayout.inQuoteToken)) {
-      //temporarily reduce max on v3bonds by 1%
       return setAmount(
         props.bond.capacity.inQuoteToken.lt(balance)
-          ? props.bond.capacity.inQuoteToken.mul(reduceMax).toString() // Capacity is the smallest
-          : balance.mul(reduceMax).toString(),
+          ? props.bond.capacity.inQuoteToken.toString() // Capacity is the smallest
+          : balance.toString(),
       );
     }
 
     setAmount(
       props.bond.maxPayout.inQuoteToken.lt(balance)
-        ? props.bond.maxPayout.inQuoteToken.mul(reduceMax).toString() // Payout is the smallest
-        : balance.mul(reduceMax).toString(),
+        ? props.bond.maxPayout.inQuoteToken.toString() // Payout is the smallest
+        : balance.toString(),
     );
   };
 

--- a/src/views/Bond/hooks/useBondV3.ts
+++ b/src/views/Bond/hooks/useBondV3.ts
@@ -123,12 +123,12 @@ export const fetchBondV3 = async ({ id, isInverseBond, networkId }: UseBondOptio
       inBaseToken: quoteTokenPerBaseToken,
     },
     capacity: {
-      inBaseToken: capacityData.capacityInBaseToken,
-      inQuoteToken: capacityData.capacityInQuoteToken,
+      inBaseToken: capacityData.capacityInBaseToken.mul(new DecimalBigNumber("0.99")), //reduce capacity by 1%
+      inQuoteToken: capacityData.capacityInQuoteToken.mul(new DecimalBigNumber("0.99")), //reduce capacity by 1%
     },
     maxPayout: {
-      inBaseToken: maxPayoutInBaseToken,
-      inQuoteToken: maxPayoutInQuoteToken,
+      inBaseToken: maxPayoutInBaseToken.mul(new DecimalBigNumber("0.99")), //reduce payout by 1%
+      inQuoteToken: maxPayoutInQuoteToken.mul(new DecimalBigNumber("0.99")), //reduce payout by 1%
     },
     isV3Bond: true,
     bondToken,


### PR DESCRIPTION
Move this into the useBondV3 hook so that capacity / max you can buy values are consistent everywhere. 
also makes it easily adjustable in the future. 

w/ the current implementation we were only adjusting it when the user clicked the 'max' button. But 'Max you Can Buy' values displayed were higher. 