### PR TITLE
Improve reliability of subgraph hooks

### DIFF
--- a/src/hooks/useSubgraphProtocolMetrics.ts
+++ b/src/hooks/useSubgraphProtocolMetrics.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   ProtocolMetric,
   ProtocolMetric_Filter,
@@ -42,30 +42,28 @@ export const useProtocolMetricsQuery = (
   earliestDate: string | null,
   dateOffset?: number,
 ): Map<string, ProtocolMetric[]> | null => {
-  // NOTE: useRef is used throughout this function, as we don't want changes to calculated variables to cause a re-render. That is instead caused by re-fetching and the updating of the byDateTokenRecords
-
   /**
    * Cached variables
    */
-  const paginator = useRef<NextPageParamType>();
+  const [paginator, setPaginator] = useState<NextPageParamType | undefined>();
   const functionName = useMemo(() => `${chartName}/ProtocolMetric`, [chartName]);
 
   /**
    * Handle changes to the props
    */
-  const dataSource = useRef<{ endpoint: string; fetchParams?: RequestInit }>({
+  const [dataSource, setDataSource] = useState<{ endpoint: string; fetchParams?: RequestInit }>({
     endpoint: subgraphUrl,
   });
-  const queryVariables = useRef<ProtocolMetricsQueryVariables>({
+  const [queryVariables, setQueryVariables] = useState<ProtocolMetricsQueryVariables>({
     filter: {
       ...baseFilter,
     },
     recordCount: DEFAULT_RECORD_COUNT,
     endpoint: subgraphUrl,
   });
-  const queryOptions = useRef<QueryOptionsType>({
+  const [queryOptions, setQueryOptions] = useState<QueryOptionsType>({
     enabled: false,
-    getNextPageParam: paginator.current,
+    getNextPageParam: paginator,
   });
   // Handle changes to query options, endpoint and variables
   // These setter calls are co-located to avoid race conditions that can result in strange behaviour (OlympusDAO/olympus-frontend#2325)
@@ -77,7 +75,7 @@ export const useProtocolMetricsQuery = (
     setByDateProtocolMetrics(null);
 
     const finishDate = getISO8601String(adjustDateByDays(new Date(), 1)); // Tomorrow
-    queryVariables.current = {
+    setQueryVariables({
       filter: {
         ...baseFilter,
         date_gte: !earliestDate ? null : getNextPageStartDate(finishDate, earliestDate, dateOffset),
@@ -85,46 +83,53 @@ export const useProtocolMetricsQuery = (
       },
       recordCount: DEFAULT_RECORD_COUNT,
       endpoint: subgraphUrl,
-    };
+    });
 
-    dataSource.current = {
+    setDataSource({
       endpoint: subgraphUrl,
-    };
+    });
 
     // Create a new paginator with the new earliestDate
     const tempPaginator =
       earliestDate !== null && subgraphUrl !== null
         ? getNextPageParamFactory(chartName, earliestDate, DEFAULT_RECORD_COUNT, baseFilter, subgraphUrl, dateOffset)
         : undefined;
-    paginator.current = tempPaginator;
+    setPaginator(tempPaginator);
 
-    queryOptions.current = {
-      enabled: earliestDate !== null && subgraphUrl.length > 0 && paginator.current !== undefined,
-      getNextPageParam: paginator.current,
+    const tempQueryOptions = {
+      enabled: earliestDate !== null && subgraphUrl.length > 0 && tempPaginator !== undefined,
+      getNextPageParam: tempPaginator,
     };
+    setQueryOptions(tempQueryOptions);
+    console.debug(
+      `${functionName}: Inputs changed. Updated query variables. Query enabled: ${tempQueryOptions.enabled}
+      earliestDate: ${earliestDate}
+      endpoint: ${subgraphUrl}
+      paginator set: ${tempPaginator !== undefined}`,
+    );
   }, [baseFilter, earliestDate, dateOffset, functionName, subgraphUrl, chartName]);
 
   /**
    * Data fetching
    */
   const { data, hasNextPage, fetchNextPage, refetch, isFetching } = useInfiniteProtocolMetricsQuery(
-    dataSource.current,
+    dataSource,
     "filter",
-    queryVariables.current,
-    queryOptions.current,
+    queryVariables,
+    queryOptions,
   );
 
   /**
    * If the queryOptions change (triggered by the props changing), then we will force a refetch.
    */
   useEffect(() => {
-    if (!queryOptions.current.enabled) return;
+    if (!queryOptions.enabled) return;
 
     // Force fetching of data with the new paginator
     // Calling refetch() after setting the new paginator causes the query to never finish
     console.info(`${functionName}: Re-fetching.`);
     refetch();
-  }, [queryOptions.current, functionName, refetch]);
+  }, [queryOptions, functionName, refetch]);
 
   // Handle subsequent pages
   useEffect(() => {

--- a/src/views/TreasuryDashboard/components/Graph/helpers/ProtocolMetricsQueryHelper.ts
+++ b/src/views/TreasuryDashboard/components/Graph/helpers/ProtocolMetricsQueryHelper.ts
@@ -32,6 +32,11 @@ export const getNextPageParamFactory = (
   const logPrefix = `${queryName}/ProtocolMetric/${earliestDate}`;
   console.debug(`${logPrefix}: create getNextPageParam with earliestDate ${earliestDate}`);
   return (lastPage: ProtocolMetricsQuery): ProtocolMetricsQueryVariables | undefined => {
+    // lastPage is sometimes undefined
+    if (typeof lastPage === "undefined") {
+      return;
+    }
+
     console.debug(`${logPrefix}: Received ${lastPage.protocolMetrics.length} records`);
 
     if (lastPage.protocolMetrics.length === 0) {

--- a/src/views/TreasuryDashboard/components/Graph/helpers/TokenRecordsQueryHelper.ts
+++ b/src/views/TreasuryDashboard/components/Graph/helpers/TokenRecordsQueryHelper.ts
@@ -42,6 +42,11 @@ export const getNextPageParamFactory = (
   const logPrefix = `${queryName}/getNextPageParam/TokenRecord/${earliestDate}`;
   console.debug(`${logPrefix}: create getNextPageParam with earliestDate ${earliestDate}`);
   return (lastPage: TokenRecordsQuery): TokenRecordsQueryVariables | undefined => {
+    // lastPage is sometimes undefined
+    if (typeof lastPage === "undefined") {
+      return;
+    }
+
     console.debug(`${logPrefix}: Received ${lastPage.tokenRecords.length} records`);
 
     if (lastPage.tokenRecords.length === 0) {

--- a/src/views/TreasuryDashboard/components/Graph/helpers/TokenSupplyQueryHelper.ts
+++ b/src/views/TreasuryDashboard/components/Graph/helpers/TokenSupplyQueryHelper.ts
@@ -32,6 +32,11 @@ export const getNextPageParamFactory = (
   const logPrefix = `${queryName}/TokenSupply/${earliestDate}`;
   console.debug(`${logPrefix}: create getNextPageParam with earliestDate ${earliestDate}`);
   return (lastPage: TokenSuppliesQuery): TokenSuppliesQueryVariables | undefined => {
+    // lastPage is sometimes undefined
+    if (typeof lastPage === "undefined") {
+      return;
+    }
+
     console.debug(`${logPrefix}: Received ${lastPage.tokenSupplies.length} records`);
 
     if (lastPage.tokenSupplies.length === 0) {


### PR DESCRIPTION
- Liquid backing per OHM (dashboard) and treasury balance (bonds) were not consistently loading
- Shifting from `useRef` to `useState` and removing some redundant caching seems to have fixed this

To test:
- 30d -> Max date range
- Max -> smaller date range
- OHM -> gOHM toggle
- Switch to bonds page
- Switch back to dashboards page

Relates to #2355 and #2363