### PR TITLE
remove alternative asset quantity from ohm bonds since we are bonding…

### DIFF
--- a/src/views/Bond/components/BondList.tsx
+++ b/src/views/Bond/components/BondList.tsx
@@ -134,7 +134,9 @@ const BondCard: React.VFC<{ bond: Bond; isInverseBond: boolean }> = ({ bond, isI
         <Typography>
           <Trans>Max Payout</Trans>
         </Typography>
-        {payoutTokenCapacity(bond, isInverseBond)}({quoteTokenCapacity(bond, isInverseBond)})
+        {`${payoutTokenCapacity(bond, isInverseBond)}${
+          bond.baseToken.name !== bond.quoteToken.name ? ` (${quoteTokenCapacity(bond)})` : ``
+        }`}
       </Box>
 
       {!isInverseBond && (
@@ -204,9 +206,8 @@ const BondTable: React.FC<{ isInverseBond: boolean }> = ({ children, isInverseBo
     </Table>
   </TableContainer>
 );
-const quoteTokenCapacity = (bond: Bond, isInverseBond: boolean) => {
-  const quoteTokenCapacity = `
-  ${(bond.maxPayout.inQuoteToken.lt(bond.capacity.inQuoteToken)
+const quoteTokenCapacity = (bond: Bond) => {
+  const quoteTokenCapacity = `${(bond.maxPayout.inQuoteToken.lt(bond.capacity.inQuoteToken)
     ? bond.maxPayout.inQuoteToken
     : bond.capacity.inQuoteToken
   ).toString({ decimals: 3, format: true })}${" "}
@@ -260,9 +261,11 @@ const BondRow: React.VFC<{ bond: Bond; isInverseBond: boolean }> = ({ bond, isIn
       <TableCell style={{ padding: "8px 0" }}>
         <Box display="flex" flexDirection={"column"}>
           <Typography style={{ lineHeight: "20px" }}>{payoutTokenCapacity(bond, isInverseBond)}</Typography>
-          <Typography color="textSecondary" style={{ fontSize: "12px", fontWeight: 400, lineHeight: "18px" }}>
-            {quoteTokenCapacity(bond, isInverseBond)}
-          </Typography>
+          {bond.baseToken.name !== bond.quoteToken.name && (
+            <Typography color="textSecondary" style={{ fontSize: "12px", fontWeight: 400, lineHeight: "18px" }}>
+              {quoteTokenCapacity(bond)}
+            </Typography>
+          )}
         </Box>
       </TableCell>
       {!isInverseBond && (

--- a/src/views/Bond/components/BondModal/components/BondInputArea/BondInputArea.tsx
+++ b/src/views/Bond/components/BondModal/components/BondInputArea/BondInputArea.tsx
@@ -187,6 +187,8 @@ export const BondInputArea: React.VFC<{
             <span>
               {isInverseBond
                 ? `${quoteTokenString} (≈${baseTokenString})`
+                : props.bond.baseToken === props.bond.quoteToken
+                ? `${baseTokenString}`
                 : `${baseTokenString} (≈${quoteTokenString})`}
             </span>
           }


### PR DESCRIPTION
… ohm for ohm, not ohm for dai or dai for ohm

Before:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/80423742/197024473-780cec43-1831-429f-b811-225e90219a4a.png">
![image](https://user-images.githubusercontent.com/80423742/197024038-ba134ea2-ee6e-4609-a009-48c3934afb0b.png)

After:
<img width="848" alt="image" src="https://user-images.githubusercontent.com/80423742/197024131-fabdbcea-8e58-4de1-8625-596ae16bcf02.png">
![image](https://user-images.githubusercontent.com/80423742/197024066-b8d70329-8874-4b70-94a9-c718b4c0a0cb.png)

Dai <-> OHM bonds still show the alt asset quantity: 
<img width="851" alt="image" src="https://user-images.githubusercontent.com/80423742/197024338-9138e47b-ca8a-4363-892a-605354ca73dd.png">
