### PR TITLE
Fix coverage report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build UI
         run: yarn install --frozen-lockfile
       - name: Run unit tests
-        run: yarn test:unit --reporter=json --outputFile=branch-report.json
+        run: yarn test:unit --reporter=json --outputFile=branch-report.json && node ./scripts/fix-coverage-report.js --outputFile branch-report.json
       - name: Upload Report
         uses: actions/upload-artifact@v3
         with:
@@ -47,13 +47,11 @@ jobs:
       - name: Download Base Report
         uses: actions/download-artifact@v3
         with:
-          name: base-report
-          path: base-report.json
+          name: branch-report
       - name: Download Branch Report
         uses: actions/download-artifact@v3
         with:
           name: branch-report
-          path: branch-report.json
       - name: Generate Coverage Report
         uses: ArtiomTr/jest-coverage-report-action@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build UI
         run: yarn install --frozen-lockfile
       - name: Run unit tests
-        run: yarn test:unit --reporter=json --outputFile=base-report.json && node ./scripts/fix-coverage-report.js --outputFile base-report.json
+        run: yarn test:unit --reporter=json --outputFile=base-report.json
       - name: Upload Report
         uses: actions/upload-artifact@v3
         with:
@@ -47,7 +47,7 @@ jobs:
       - name: Download Base Report
         uses: actions/download-artifact@v3
         with:
-          name: base-report
+          name: branch-report
       - name: Download Branch Report
         uses: actions/download-artifact@v3
         with:
@@ -59,5 +59,5 @@ jobs:
           package-manager: yarn
           github-token: ${{ secrets.GITHUB_TOKEN }}
           coverage-file: branch-report.json
-          base-coverage-file: base-report.json
+          base-coverage-file: branch-report.json
           annotations: none

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,5 +59,5 @@ jobs:
           package-manager: yarn
           github-token: ${{ secrets.GITHUB_TOKEN }}
           coverage-file: branch-report.json
-          base-coverage-file: base-report.json
+          base-coverage-file: branch-report.json
           annotations: none

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build UI
         run: yarn install --frozen-lockfile
       - name: Run unit tests
-        run: yarn test:unit --reporter=json --outputFile=base-report.json
+        run: yarn test:unit --reporter=json --outputFile=base-report.json && node ./scripts/fix-coverage-report.js --outputFile base-report.json
       - name: Upload Report
         uses: actions/upload-artifact@v3
         with:
@@ -47,7 +47,7 @@ jobs:
       - name: Download Base Report
         uses: actions/download-artifact@v3
         with:
-          name: branch-report
+          name: base-report
       - name: Download Branch Report
         uses: actions/download-artifact@v3
         with:
@@ -59,5 +59,5 @@ jobs:
           package-manager: yarn
           github-token: ${{ secrets.GITHUB_TOKEN }}
           coverage-file: branch-report.json
-          base-coverage-file: branch-report.json
+          base-coverage-file: base-report.json
           annotations: none

--- a/scripts/fix-coverage-report.js
+++ b/scripts/fix-coverage-report.js
@@ -1,0 +1,33 @@
+const fs = require("fs");
+const coverageFinalFilename = "coverage-final.json";
+const outputFile = process.argv[2] && process.argv[2] === "--outputFile" ? process.argv[3] : "report.json";
+const cwd = process.cwd();
+const reportJsonFilepath = `${cwd}/${outputFile}`;
+const coverageFinalFilepath = `${cwd}/coverage/${coverageFinalFilename}`;
+let reportJsonFile;
+let coverageFinalJsonFile;
+if (fs.existsSync(reportJsonFilepath)) {
+  reportJsonFile = require(reportJsonFilepath);
+}
+if (fs.existsSync(coverageFinalFilepath)) {
+  coverageFinalJsonFile = require(coverageFinalFilepath);
+}
+console.log("Files exists?", { outputFilename: !!reportJsonFile, coverageFinalFilename: !!coverageFinalJsonFile });
+if (reportJsonFile && coverageFinalJsonFile) {
+  if (!reportJsonFile.coverageMap) {
+    console.log(`Adding coverageMap property to ${outputFile} based on ${coverageFinalFilename}`);
+    reportJsonFile.coverageMap = coverageFinalJsonFile;
+    fs.writeFileSync(reportJsonFilepath, JSON.stringify(reportJsonFile), err => {
+      if (err) {
+        console.error(err);
+        process.exit(1);
+      }
+    });
+  } else {
+    console.log(`coverageMap already exists in ${outputFile}, not doing anything...`);
+    process.exit(0);
+  }
+} else {
+  console.log("Not doing anything...");
+  process.exit(0);
+}


### PR DESCRIPTION
the report generator action expects a coverageMap object. vitest doesnt supply that, so we need to transform the report to include it. including a utility to help. 
see: https://github.com/ArtiomTr/jest-coverage-report-action/issues/244

this will fail until merged b/c base doesnt have the script. going to push another commit to illustrate passing state.