### PR TITLE
set quorum to 1

### DIFF
--- a/src/views/Governance/ProposalsDashboard.tsx
+++ b/src/views/Governance/ProposalsDashboard.tsx
@@ -91,7 +91,7 @@ const ProposalContainer = ({ instructionsId }: { instructionsId: number }) => {
               publishedDate={new Date(proposal?.submissionTimestamp)}
               status={proposal?.state}
               voteEndDate={new Date(proposal?.nextDeadline)}
-              quorum={0}
+              quorum={1}
               votesAgainst={proposal?.noVotes}
               votesFor={proposal?.yesVotes}
             />


### PR DESCRIPTION
width of the bars are being calculated based on quorum. If quorum is set to zero it causes overflow and a div by zero error on the calc. if we aren't using quorum we can set this to 1, to render a proper result. 