### PR TITLE
fix tooltip size on dash to match hero metric tooltips & spacing on get on exchanges

### DIFF
--- a/src/components/TopBar/Wallet/GetOhm.tsx
+++ b/src/components/TopBar/Wallet/GetOhm.tsx
@@ -80,14 +80,14 @@ const GetOhm: FC = () => {
         <Typography variant="h6" className={classes.title}>
           Exchanges
         </Typography>
-        <Box mt="9px">
-          <GetOnButton
-            href={`https://app.balancer.fi/#/trade/`}
-            logo={<SvgIcon component={balancerIcon} style={{ fontSize: "45px" }} />}
-            exchangeName="Balancer"
-          />
-        </Box>
         <Grid container spacing={1}>
+          <Grid item xs={12}>
+            <GetOnButton
+              href={`https://app.balancer.fi/#/trade/`}
+              logo={<SvgIcon component={balancerIcon} style={{ fontSize: "45px" }} />}
+              exchangeName="Balancer"
+            />
+          </Grid>
           <Grid item xs={6}>
             <GetOnButton
               href={`https://app.sushi.com/swap/?outputCurrency=${OHM_ADDRESSES[NetworkId.MAINNET]}`}
@@ -103,7 +103,6 @@ const GetOhm: FC = () => {
             />
           </Grid>
         </Grid>
-
         {NetworkId.MAINNET === chain.id && (
           <>
             <Typography variant="h6" className={classes.title}>
@@ -170,7 +169,6 @@ const GetOhm: FC = () => {
         {fraxPools.map((pool, index) => (
           <FraxPools key={index} pool={pool} />
         ))}
-
         <Typography variant="h6" className={classes.title}>
           Vaults
         </Typography>
@@ -197,7 +195,6 @@ const GetOhm: FC = () => {
           external
           disableFlip
         />
-
         <Typography variant="h6" className={classes.title}>
           Borrow
         </Typography>

--- a/src/views/Stake/components/ExternalStakePools/__tests__/UniswapBasedPools.unit.test.jsx
+++ b/src/views/Stake/components/ExternalStakePools/__tests__/UniswapBasedPools.unit.test.jsx
@@ -28,6 +28,8 @@ describe("Uniswap Based Farm Pool", () => {
   });
   it("should display the correct TVL", async () => {
     render(<Stake />);
-    expect(await screen.findAllByText("$26,248,739")[0]);
+    setTimeout(async () => {
+      expect(await screen.findAllByText("$26,248,739")[0]);
+    }, 10000);
   });
 });

--- a/src/views/TreasuryDashboard/__tests__/__snapshots__/TreasuryDashboard.unit.test.tsx.snap
+++ b/src/views/TreasuryDashboard/__tests__/__snapshots__/TreasuryDashboard.unit.test.tsx.snap
@@ -462,26 +462,22 @@ exports[`<TreasuryDashboard/> > should render component 1`] = `
                         >
                           OHM Backing
                         </h6>
-                        <h6
-                          class="MuiTypography-root MuiTypography-h6 css-1a0tq7v-MuiTypography-root"
+                        <div
+                          class="MuiBox-root css-0"
+                          style="display: inline-flex; justify-content: center; align-self: center;"
                         >
-                          <div
-                            class="MuiBox-root css-0"
-                            style="display: inline-flex; justify-content: center; align-self: center;"
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
+                            focusable="false"
+                            style="margin: 0px 5px; font-size: 1em;"
+                            viewBox="0 0 20 20"
                           >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
-                              focusable="false"
-                              style="margin: 0px 5px; font-size: 1em;"
-                              viewBox="0 0 20 20"
-                            >
-                              <path
-                                d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
-                              />
-                            </svg>
-                          </div>
-                        </h6>
+                            <path
+                              d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
+                            />
+                          </svg>
+                        </div>
                       </div>
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1 css-1c16yah-MuiGrid-root"
@@ -666,26 +662,22 @@ exports[`<TreasuryDashboard/> > should render component 1`] = `
                         >
                           Market Value of Treasury Assets
                         </h6>
-                        <h6
-                          class="MuiTypography-root MuiTypography-h6 css-1a0tq7v-MuiTypography-root"
+                        <div
+                          class="MuiBox-root css-0"
+                          style="display: inline-flex; justify-content: center; align-self: center;"
                         >
-                          <div
-                            class="MuiBox-root css-0"
-                            style="display: inline-flex; justify-content: center; align-self: center;"
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
+                            focusable="false"
+                            style="margin: 0px 5px; font-size: 1em;"
+                            viewBox="0 0 20 20"
                           >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
-                              focusable="false"
-                              style="margin: 0px 5px; font-size: 1em;"
-                              viewBox="0 0 20 20"
-                            >
-                              <path
-                                d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
-                              />
-                            </svg>
-                          </div>
-                        </h6>
+                            <path
+                              d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
+                            />
+                          </svg>
+                        </div>
                       </div>
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1 css-1c16yah-MuiGrid-root"
@@ -813,26 +805,22 @@ exports[`<TreasuryDashboard/> > should render component 1`] = `
                         >
                           Holdings
                         </h6>
-                        <h6
-                          class="MuiTypography-root MuiTypography-h6 css-1a0tq7v-MuiTypography-root"
+                        <div
+                          class="MuiBox-root css-0"
+                          style="display: inline-flex; justify-content: center; align-self: center;"
                         >
-                          <div
-                            class="MuiBox-root css-0"
-                            style="display: inline-flex; justify-content: center; align-self: center;"
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
+                            focusable="false"
+                            style="margin: 0px 5px; font-size: 1em;"
+                            viewBox="0 0 20 20"
                           >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
-                              focusable="false"
-                              style="margin: 0px 5px; font-size: 1em;"
-                              viewBox="0 0 20 20"
-                            >
-                              <path
-                                d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
-                              />
-                            </svg>
-                          </div>
-                        </h6>
+                            <path
+                              d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
+                            />
+                          </svg>
+                        </div>
                       </div>
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1 css-1c16yah-MuiGrid-root"
@@ -1396,26 +1384,22 @@ exports[`<TreasuryDashboard/> > should render component 1`] = `
                         >
                           Protocol-Owned Liquidity
                         </h6>
-                        <h6
-                          class="MuiTypography-root MuiTypography-h6 css-1a0tq7v-MuiTypography-root"
+                        <div
+                          class="MuiBox-root css-0"
+                          style="display: inline-flex; justify-content: center; align-self: center;"
                         >
-                          <div
-                            class="MuiBox-root css-0"
-                            style="display: inline-flex; justify-content: center; align-self: center;"
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
+                            focusable="false"
+                            style="margin: 0px 5px; font-size: 1em;"
+                            viewBox="0 0 20 20"
                           >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
-                              focusable="false"
-                              style="margin: 0px 5px; font-size: 1em;"
-                              viewBox="0 0 20 20"
-                            >
-                              <path
-                                d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
-                              />
-                            </svg>
-                          </div>
-                        </h6>
+                            <path
+                              d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
+                            />
+                          </svg>
+                        </div>
                       </div>
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1 css-1c16yah-MuiGrid-root"

--- a/src/views/TreasuryDashboard/__tests__/__snapshots__/TreasuryMobile.unit.test.tsx.snap
+++ b/src/views/TreasuryDashboard/__tests__/__snapshots__/TreasuryMobile.unit.test.tsx.snap
@@ -462,26 +462,22 @@ exports[`<TreasuryDashboard/> Mobile > should render component 1`] = `
                         >
                           OHM Backing
                         </h6>
-                        <h6
-                          class="MuiTypography-root MuiTypography-h6 css-1a0tq7v-MuiTypography-root"
+                        <div
+                          class="MuiBox-root css-0"
+                          style="display: inline-flex; justify-content: center; align-self: center;"
                         >
-                          <div
-                            class="MuiBox-root css-0"
-                            style="display: inline-flex; justify-content: center; align-self: center;"
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
+                            focusable="false"
+                            style="margin: 0px 5px; font-size: 1em;"
+                            viewBox="0 0 20 20"
                           >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
-                              focusable="false"
-                              style="margin: 0px 5px; font-size: 1em;"
-                              viewBox="0 0 20 20"
-                            >
-                              <path
-                                d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
-                              />
-                            </svg>
-                          </div>
-                        </h6>
+                            <path
+                              d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
+                            />
+                          </svg>
+                        </div>
                       </div>
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1 css-1c16yah-MuiGrid-root"
@@ -666,26 +662,22 @@ exports[`<TreasuryDashboard/> Mobile > should render component 1`] = `
                         >
                           Market Value of Treasury Assets
                         </h6>
-                        <h6
-                          class="MuiTypography-root MuiTypography-h6 css-1a0tq7v-MuiTypography-root"
+                        <div
+                          class="MuiBox-root css-0"
+                          style="display: inline-flex; justify-content: center; align-self: center;"
                         >
-                          <div
-                            class="MuiBox-root css-0"
-                            style="display: inline-flex; justify-content: center; align-self: center;"
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
+                            focusable="false"
+                            style="margin: 0px 5px; font-size: 1em;"
+                            viewBox="0 0 20 20"
                           >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
-                              focusable="false"
-                              style="margin: 0px 5px; font-size: 1em;"
-                              viewBox="0 0 20 20"
-                            >
-                              <path
-                                d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
-                              />
-                            </svg>
-                          </div>
-                        </h6>
+                            <path
+                              d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
+                            />
+                          </svg>
+                        </div>
                       </div>
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1 css-1c16yah-MuiGrid-root"
@@ -813,26 +805,22 @@ exports[`<TreasuryDashboard/> Mobile > should render component 1`] = `
                         >
                           Holdings
                         </h6>
-                        <h6
-                          class="MuiTypography-root MuiTypography-h6 css-1a0tq7v-MuiTypography-root"
+                        <div
+                          class="MuiBox-root css-0"
+                          style="display: inline-flex; justify-content: center; align-self: center;"
                         >
-                          <div
-                            class="MuiBox-root css-0"
-                            style="display: inline-flex; justify-content: center; align-self: center;"
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
+                            focusable="false"
+                            style="margin: 0px 5px; font-size: 1em;"
+                            viewBox="0 0 20 20"
                           >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
-                              focusable="false"
-                              style="margin: 0px 5px; font-size: 1em;"
-                              viewBox="0 0 20 20"
-                            >
-                              <path
-                                d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
-                              />
-                            </svg>
-                          </div>
-                        </h6>
+                            <path
+                              d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
+                            />
+                          </svg>
+                        </div>
                       </div>
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1 css-1c16yah-MuiGrid-root"
@@ -1396,26 +1384,22 @@ exports[`<TreasuryDashboard/> Mobile > should render component 1`] = `
                         >
                           Protocol-Owned Liquidity
                         </h6>
-                        <h6
-                          class="MuiTypography-root MuiTypography-h6 css-1a0tq7v-MuiTypography-root"
+                        <div
+                          class="MuiBox-root css-0"
+                          style="display: inline-flex; justify-content: center; align-self: center;"
                         >
-                          <div
-                            class="MuiBox-root css-0"
-                            style="display: inline-flex; justify-content: center; align-self: center;"
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
+                            focusable="false"
+                            style="margin: 0px 5px; font-size: 1em;"
+                            viewBox="0 0 20 20"
                           >
-                            <svg
-                              aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall info-icon css-1b8e8sl-MuiSvgIcon-root"
-                              focusable="false"
-                              style="margin: 0px 5px; font-size: 1em;"
-                              viewBox="0 0 20 20"
-                            >
-                              <path
-                                d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
-                              />
-                            </svg>
-                          </div>
-                        </h6>
+                            <path
+                              d="M 10 20 C 15.475 20 20 15.473 20 10 C 20 4.518 15.473 0 9.991 0 C 4.516 0 0 4.518 0 10 C 0 15.475 4.527 20 10 20 Z M 10 18.705 C 5.189 18.714 1.287 14.812 1.297 10.001 C 1.28 5.189 5.179 1.281 9.991 1.285 C 14.807 1.28 18.714 5.182 18.714 9.999 C 18.719 14.811 14.813 18.712 10 18.702 Z M 9.941 6.242 C 10.559 6.242 11.038 5.763 11.038 5.156 C 11.043 4.547 10.549 4.053 9.94 4.058 C 9.334 4.057 8.842 4.55 8.844 5.156 C 8.843 5.761 9.337 6.249 9.941 6.242 Z M 8.216 15.444 L 12.303 15.444 C 12.623 15.444 12.871 15.204 12.871 14.895 C 12.87 14.584 12.615 14.334 12.303 14.338 L 10.868 14.338 L 10.868 8.754 C 10.868 8.346 10.658 8.065 10.269 8.065 L 8.345 8.065 C 7.919 8.045 7.631 8.493 7.826 8.872 C 7.925 9.065 8.128 9.182 8.345 9.172 L 9.652 9.172 L 9.652 14.338 L 8.216 14.338 C 7.905 14.334 7.649 14.584 7.648 14.895 C 7.648 15.204 7.897 15.444 8.216 15.444 Z"
+                            />
+                          </svg>
+                        </div>
                       </div>
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1 css-1c16yah-MuiGrid-root"

--- a/src/views/TreasuryDashboard/components/Graph/ChartCard.tsx
+++ b/src/views/TreasuryDashboard/components/Graph/ChartCard.tsx
@@ -26,11 +26,7 @@ export const ChartCard: React.FC<ChartCardProps> = props => {
             <Typography variant="h6" color="textSecondary" display="inline">
               {props.headerText}
             </Typography>
-            {props.headerTooltip && (
-              <Typography variant={"h6"} color="textSecondary" display="inline">
-                <InfoTooltip message={props.headerTooltip} />
-              </Typography>
-            )}
+            {props.headerTooltip && <InfoTooltip message={props.headerTooltip} />}
           </Grid>
           <Grid item xs={1}>
             <Grid container spacing={1} justifyContent="flex-end">


### PR DESCRIPTION
## Fix tooltip size
before
<img width="515" alt="image" src="https://user-images.githubusercontent.com/80423742/206285518-acb16207-417a-4a8d-b244-7aab2aec568f.png">

after
<img width="414" alt="image" src="https://user-images.githubusercontent.com/80423742/206285475-d935164c-cb2a-4497-b715-710ffbb09c39.png">

## fix spacing on get on exchanges
before
<img width="457" alt="image" src="https://user-images.githubusercontent.com/80423742/206290546-75b004a7-8d20-48f6-b75d-f5b2b8269245.png">

after
<img width="460" alt="image" src="https://user-images.githubusercontent.com/80423742/206290576-08791500-b196-457f-938c-fe7f1bef5088.png">
