### PR TITLE
Range Bond Price and UX Improvements

### DIFF
--- a/src/views/Bond/components/BondDiscount.tsx
+++ b/src/views/Bond/components/BondDiscount.tsx
@@ -6,7 +6,6 @@ import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber"
 export const BondDiscount: React.VFC<{ discount: DecimalBigNumber; textOnly?: boolean }> = ({ discount, textOnly }) => {
   const theme = useTheme();
   const discountString = `${formatNumber(Number(discount.mul(new DecimalBigNumber("100").toString())), 2)}%`;
-  console.log(discount.toString(), "bondDiscount");
   return textOnly ? (
     <Box
       style={{

--- a/src/views/Bond/components/BondDiscount.tsx
+++ b/src/views/Bond/components/BondDiscount.tsx
@@ -6,6 +6,7 @@ import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber"
 export const BondDiscount: React.VFC<{ discount: DecimalBigNumber; textOnly?: boolean }> = ({ discount, textOnly }) => {
   const theme = useTheme();
   const discountString = `${formatNumber(Number(discount.mul(new DecimalBigNumber("100").toString())), 2)}%`;
+  console.log(discount.toString(), "bondDiscount");
   return textOnly ? (
     <Box
       style={{

--- a/src/views/Bond/components/BondDiscount.tsx
+++ b/src/views/Bond/components/BondDiscount.tsx
@@ -1,10 +1,11 @@
 import { Box, useTheme } from "@mui/material";
 import { Chip } from "@olympusdao/component-library";
+import { formatNumber } from "src/helpers";
 import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber";
 
 export const BondDiscount: React.VFC<{ discount: DecimalBigNumber; textOnly?: boolean }> = ({ discount, textOnly }) => {
   const theme = useTheme();
-  const discountString = `${discount.mul(new DecimalBigNumber("100")).toString({ decimals: 2, trim: false })}%`;
+  const discountString = `${formatNumber(Number(discount.mul(new DecimalBigNumber("100").toString())), 2)}%`;
   return textOnly ? (
     <Box
       style={{
@@ -15,7 +16,7 @@ export const BondDiscount: React.VFC<{ discount: DecimalBigNumber; textOnly?: bo
     </Box>
   ) : (
     <Chip
-      label={`${discount.mul(new DecimalBigNumber("100")).toString({ decimals: 2, trim: false })}%`}
+      label={`${formatNumber(Number(discount.mul(new DecimalBigNumber("100")).toString()), 2)}%`}
       template={new DecimalBigNumber("0").gt(discount) ? "error" : "success"}
     />
   );

--- a/src/views/Bond/components/BondModal/BondModal.tsx
+++ b/src/views/Bond/components/BondModal/BondModal.tsx
@@ -160,7 +160,7 @@ const TokenPrice: React.VFC<{ token: Token; isInverseBond?: boolean; baseSymbol:
     ? formatNumber(1, 2)
     : isInverseBond
     ? formatNumber(ohmPrice, 2)
-    : `${priceToken.toString({ decimals: 2, format: true, trim: false })}`;
+    : `${formatNumber(Number(priceToken.toString({ decimals: 2, format: true, trim: false })), 2)}`;
   return price ? (
     <>
       {price} {isInverseBond ? baseSymbol : quoteSymbol}

--- a/src/views/Range/RangeChart.tsx
+++ b/src/views/Range/RangeChart.tsx
@@ -156,7 +156,6 @@ const RangeChart = (props: {
 
   const theme = useTheme();
 
-  console.log(chartData);
   return isFetched ? (
     <StyledResponsiveContainer width="100%" height={400}>
       <ComposedChart data={chartData}>

--- a/src/views/Range/RangeChart.tsx
+++ b/src/views/Range/RangeChart.tsx
@@ -46,13 +46,11 @@ const RangeChart = (props: {
   sellActive: boolean;
   reserveSymbol: string;
 }) => {
-  const { rangeData, currentPrice, bidPrice, askPrice, sellActive, reserveSymbol } = props;
+  const { rangeData, currentPrice, bidPrice, askPrice, reserveSymbol } = props;
   //TODO - Figure out which Subgraphs to query. Currently Uniswap.
   const { data: priceData, isFetched } = PriceHistory(reserveSymbol);
   const { data: targetPrice } = OperatorTargetPrice();
   const { data: movingAverage } = OperatorMovingAverage();
-
-  console.log(targetPrice, "targetPrice");
 
   const formattedWallHigh = trim(parseBigNumber(rangeData.wall.high.price, 18), 2);
   const formattedWallLow = trim(parseBigNumber(rangeData.wall.low.price, 18), 2);
@@ -61,6 +59,12 @@ const RangeChart = (props: {
   const chartData = priceData.map((item: any) => {
     return {
       ...item,
+      timestamp: new Date(item.timestamp).toLocaleString("en-US", {
+        day: "numeric",
+        month: "short",
+        hour: "numeric",
+        minute: "numeric",
+      }),
       uv: [formattedWallHigh, formattedCushionHigh],
       lv: [formattedWallLow, formattedCushionLow],
       ma: targetPrice,
@@ -151,6 +155,8 @@ const RangeChart = (props: {
   };
 
   const theme = useTheme();
+
+  console.log(chartData);
   return isFetched ? (
     <StyledResponsiveContainer width="100%" height={400}>
       <ComposedChart data={chartData}>
@@ -184,7 +190,6 @@ const RangeChart = (props: {
               Math.max(dataMax, askPrice, bidPrice, parseBigNumber(rangeData.wall.low.price, 18)) * 1.05,
           ]}
           padding={{ top: 20, bottom: 20 }}
-          width={42}
         />
         <Tooltip content={<TooltipContent />} />
         <Area

--- a/src/views/Range/__tests__/Range.test.tsx
+++ b/src/views/Range/__tests__/Range.test.tsx
@@ -25,7 +25,6 @@ vi.mock("src/views/Range/RangeChart", () => ({
     sellActive: boolean;
     reserveSymbol: string;
   }) => {
-    console.log(formatCurrency(props.bidPrice, 2), "bidprice");
     return (
       <>
         <div>Ask: {formatCurrency(props.askPrice, 2)}</div>

--- a/src/views/Range/__tests__/Range.test.tsx
+++ b/src/views/Range/__tests__/Range.test.tsx
@@ -4,11 +4,11 @@ import { formatCurrency } from "src/helpers";
 import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber";
 import * as Balance from "src/hooks/useBalance";
 import { useContractAllowance } from "src/hooks/useContractAllowance";
+import * as Prices from "src/hooks/usePrices";
 import { connectWallet, invalidAddress } from "src/testHelpers";
 import { fireEvent, render, screen } from "src/testUtils";
 import * as IERC20Factory from "src/typechain/factories/IERC20__factory";
 import * as RangeFactory from "src/typechain/factories/Range__factory";
-import * as RANGEPriceContract from "src/typechain/factories/RangePrice__factory";
 import { RangeData } from "src/views/Range/__mocks__/mockRangeCalls";
 import { Range } from "src/views/Range/index";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -44,9 +44,9 @@ const defaultStatesWithApproval = () => {
   IERC20Factory.IERC20__factory.connect = vi.fn().mockReturnValue({
     symbol: vi.fn().mockReturnValue("DAI"),
   });
-  RANGEPriceContract.RangePrice__factory.connect = vi.fn().mockReturnValue({
-    getCurrentPrice: vi.fn().mockReturnValue(BigNumber.from("13209363085060059262")),
-  });
+  //@ts-expect-error
+  vi.spyOn(Prices, "useOhmPrice").mockReturnValue({ data: "13.209363085" });
+
   //@ts-ignore
   rangeOperator.mockReturnValue({
     connect: vi.fn().mockReturnValue({

--- a/src/views/Range/__tests__/RangeBondsLower.test.tsx
+++ b/src/views/Range/__tests__/RangeBondsLower.test.tsx
@@ -3,11 +3,11 @@ import * as Contract from "src/constants/contracts";
 import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber";
 import * as Balance from "src/hooks/useBalance";
 import { useContractAllowance } from "src/hooks/useContractAllowance";
+import * as Prices from "src/hooks/usePrices";
 import { connectWallet } from "src/testHelpers";
 import { fireEvent, render, screen } from "src/testUtils";
 import * as BondTellerContract from "src/typechain/factories/BondTeller__factory";
 import * as IERC20Factory from "src/typechain/factories/IERC20__factory";
-import * as RANGEPriceContract from "src/typechain/factories/RangePrice__factory";
 import { ohmPriceHistory, RangeData, reservePriceHistory } from "src/views/Range/__mocks__/mockRangeCalls";
 import * as RangeHooks from "src/views/Range/hooks";
 import { Range } from "src/views/Range/index";
@@ -25,9 +25,9 @@ const setupTest = () => {
   IERC20Factory.IERC20__factory.connect = vi.fn().mockReturnValue({
     symbol: vi.fn().mockReturnValue("DAI"),
   });
-  RANGEPriceContract.RangePrice__factory.connect = vi.fn().mockReturnValue({
-    getCurrentPrice: vi.fn().mockReturnValue(BigNumber.from("13209363085060059262")),
-  });
+  //@ts-expect-error
+  vi.spyOn(Prices, "useOhmPrice").mockReturnValue({ data: "13.209363085" });
+
   BondTellerContract.BondTeller__factory.connect = vi.fn().mockReturnValue({
     purchase: vi.fn().mockReturnValue({
       wait: vi.fn().mockResolvedValue(true),

--- a/src/views/Range/__tests__/RangeBondsLower.test.tsx
+++ b/src/views/Range/__tests__/RangeBondsLower.test.tsx
@@ -32,6 +32,7 @@ const setupTest = () => {
     purchase: vi.fn().mockReturnValue({
       wait: vi.fn().mockResolvedValue(true),
     }),
+    getTeller: vi.fn().mockReturnValue(0),
   });
 
   //@ts-expect-error
@@ -82,8 +83,7 @@ describe("Lower Wall Active Bond Market", () => {
     vi.spyOn(RangeHooks, "DetermineRangePrice").mockReturnValue({ data: { price: "10.12" } });
     //@ts-expect-error
     vi.spyOn(RangeHooks, "OperatorReserveSymbol").mockReturnValue({ data: { reserveAddress: "0x", symbol: "OHM" } });
-    const { container } = render(<Range />);
-    fireEvent.click(container.getElementsByClassName("arrow-wrapper")[0]);
+    render(<Range />);
     fireEvent.input(await screen.findByTestId("reserve-amount"), { target: { value: "6" } });
     fireEvent.click(screen.getByTestId("range-submit"));
     expect(await screen.findByText("I understand that I am selling at a discount to current market price"));

--- a/src/views/Range/__tests__/RangeBondsUpper.test.tsx
+++ b/src/views/Range/__tests__/RangeBondsUpper.test.tsx
@@ -25,7 +25,6 @@ vi.mock("src/views/Range/RangeChart", () => ({
     sellActive: boolean;
     reserveSymbol: string;
   }) => {
-    console.log(formatCurrency(props.bidPrice, 2), "bidprice");
     return (
       <>
         <div>Ask: {formatCurrency(props.askPrice, 2)}</div>

--- a/src/views/Range/__tests__/RangeBondsUpper.test.tsx
+++ b/src/views/Range/__tests__/RangeBondsUpper.test.tsx
@@ -4,11 +4,11 @@ import { formatCurrency } from "src/helpers";
 import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber";
 import * as Balance from "src/hooks/useBalance";
 import { useContractAllowance } from "src/hooks/useContractAllowance";
+import * as Prices from "src/hooks/usePrices";
 import { connectWallet } from "src/testHelpers";
 import { fireEvent, render, screen } from "src/testUtils";
 import * as BondTellerContract from "src/typechain/factories/BondTeller__factory";
 import * as IERC20Factory from "src/typechain/factories/IERC20__factory";
-import * as RANGEPriceContract from "src/typechain/factories/RangePrice__factory";
 import { ohmPriceHistory, RangeData, reservePriceHistory } from "src/views/Range/__mocks__/mockRangeCalls";
 import * as RangeHooks from "src/views/Range/hooks";
 import { Range } from "src/views/Range/index";
@@ -46,9 +46,8 @@ describe("Upper Wall Active Bond Market", () => {
     IERC20Factory.IERC20__factory.connect = vi.fn().mockReturnValue({
       symbol: vi.fn().mockReturnValue("DAI"),
     });
-    RANGEPriceContract.RangePrice__factory.connect = vi.fn().mockReturnValue({
-      getCurrentPrice: vi.fn().mockReturnValue(BigNumber.from("13209363085060059262")),
-    });
+    //@ts-expect-error
+    vi.spyOn(Prices, "useOhmPrice").mockReturnValue({ data: "13.209363085" });
     //@ts-ignore
     BondTellerContract.BondTeller__factory.connect = vi.fn().mockReturnValue({
       purchase: vi.fn().mockReturnValue({

--- a/src/views/Range/hooks.tsx
+++ b/src/views/Range/hooks.tsx
@@ -9,19 +9,18 @@ import {
   RANGE_OPERATOR_CONTRACT,
   RANGE_PRICE_CONTRACT,
 } from "src/constants/contracts";
-import { OHM_TOKEN } from "src/constants/tokens";
 import { parseBigNumber } from "src/helpers";
 import { trackGAEvent, trackGtagEvent } from "src/helpers/analytics/trackGAEvent";
-import { getTokenByAddress } from "src/helpers/contracts/getTokenByAddress";
-// import { trackGAEvent, trackGtagEvent } from "src/helpers/analytics/trackGAEvent";
 import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber";
 import { isValidAddress } from "src/helpers/misc/isValidAddress";
 import { Providers } from "src/helpers/providers/Providers/Providers";
 import { queryAssertion } from "src/helpers/react-query/queryAssertion";
 import { assert } from "src/helpers/types/assert";
+import { useOhmPrice } from "src/hooks/usePrices";
 import { useTestableNetworks } from "src/hooks/useTestableNetworks";
 import { BondFixedTermSDA__factory, BondTeller__factory, IERC20__factory } from "src/typechain";
 import { RANGEv1 as OlympusRange } from "src/typechain/Range";
+import { useBondV3 } from "src/views/Bond/hooks/useBondV3";
 import { useSigner } from "wagmi";
 
 /**Chainlink Price Feed. Retrieves OHMETH and ETH/{RESERVE} feed **/
@@ -126,7 +125,6 @@ export const OperatorTargetPrice = () => {
     isLoading,
   } = useQuery(["getOperatorTargetPrice", networks.MAINNET], async () => {
     const targetPrice = parseBigNumber(await contract.getTargetPrice(), 18);
-    console.log("targetPrice hook", targetPrice);
 
     return targetPrice;
   });
@@ -214,47 +212,6 @@ const band: OlympusRange.BandStruct = {
   spread: BigNumber.from(0),
 };
 
-/**
- * Returns the market price for the given bond market
- * @param id Bond Market ID
- */
-export const RangeBondPrice = (id: BigNumber, side: "low" | "high") => {
-  const networks = useTestableNetworks();
-  const contract = BOND_AGGREGATOR_CONTRACT.getEthersContract(networks.MAINNET);
-  const { data, isFetched, isLoading } = useQuery(
-    ["getRangeBondPrice", id, networks.MAINNET, side],
-    async () => {
-      const bondPrice = await contract.marketPrice(id);
-      const auctioneerAddress = await contract.getAuctioneer(id);
-      const auctioneerContract = BondFixedTermSDA__factory.connect(auctioneerAddress, contract.provider);
-      const market = await auctioneerContract.markets(id);
-      const inverse =
-        market.payoutToken.toLowerCase() !==
-        OHM_ADDRESSES[networks.MAINNET as keyof typeof OHM_ADDRESSES].toLowerCase();
-      const baseToken = inverse
-        ? await getTokenByAddress({ address: market.payoutToken, networkId: networks.MAINNET })
-        : OHM_TOKEN;
-      assert(baseToken, `Unknown base token address: ${market.payoutToken}`);
-      const quoteToken = inverse
-        ? OHM_TOKEN
-        : await getTokenByAddress({ address: market.quoteToken, networkId: networks.MAINNET });
-      assert(quoteToken, `Unknown quote token address: ${market.quoteToken}`);
-
-      const scale = await contract.marketScale(id);
-      const baseScale = BigNumber.from("10").pow(BigNumber.from("36").add(baseToken.decimals).sub(quoteToken.decimals));
-      const shift = baseScale.div(scale);
-      if (side === "low") {
-        return 1 / parseBigNumber(bondPrice.mul(shift), 36);
-      }
-      return parseBigNumber(bondPrice.mul(shift), 36);
-    },
-    {
-      enabled: id.gt(-1) && id.lt(ethers.constants.MaxUint256),
-    }, //Disable this query for negative markets (default value) or Max Integer (market not active from range call)
-  );
-  return { data, isFetched, isLoading };
-};
-
 export const RangeBondMaxPayout = (id: BigNumber) => {
   const networks = useTestableNetworks();
   const aggregatorContract = BOND_AGGREGATOR_CONTRACT.getEthersContract(networks.MAINNET);
@@ -305,21 +262,31 @@ export const BondTellerAddress = (id: BigNumber) => {
 
 export const DetermineRangePrice = (bidOrAsk: "bid" | "ask") => {
   const { data: rangeData } = RangeData();
-  const { data: upperBondMarket = 0 } = RangeBondPrice(rangeData.high.market, "high");
-  const { data: lowerBondMarket = 0 } = RangeBondPrice(rangeData.low.market, "low");
+  const { data: currentOhmPrice } = useOhmPrice();
+  const { data: upperBondMarket } = useBondV3({ id: rangeData.high.market.toString() });
+  const { data: lowerBondMarket } = useBondV3({ id: rangeData.low.market.toString(), isInverseBond: true });
+
   const {
     data = { price: 0, contract: "swap" },
     isFetched,
     isLoading,
   } = useQuery(
-    ["getDetermineRangePrice", bidOrAsk, rangeData, upperBondMarket, lowerBondMarket],
+    ["getDetermineRangePrice", bidOrAsk, rangeData, upperBondMarket, lowerBondMarket, currentOhmPrice],
     async () => {
       const sideActive = bidOrAsk === "ask" ? rangeData.high.active : rangeData.low.active;
       const market = bidOrAsk === "ask" ? rangeData.high.market : rangeData.low.market;
       const activeBondMarket = market.gt(-1) && market.lt(ethers.constants.MaxUint256); //>=0 <=MAXUint256
       if (sideActive && activeBondMarket) {
+        assert(currentOhmPrice, "Current OHM price not available");
         return {
-          price: bidOrAsk === "ask" ? upperBondMarket : lowerBondMarket,
+          price:
+            bidOrAsk === "ask"
+              ? upperBondMarket
+                ? Number(upperBondMarket?.price.inUsd.toString()) * currentOhmPrice
+                : 0
+              : lowerBondMarket
+              ? Number(lowerBondMarket?.price.inUsd.toString()) * currentOhmPrice
+              : 0,
           contract: "bond" as RangeContracts,
         };
       } else {
@@ -332,14 +299,14 @@ export const DetermineRangePrice = (bidOrAsk: "bid" | "ask") => {
         };
       }
     },
-    { enabled: !!rangeData },
+    { enabled: !!rangeData && !!currentOhmPrice },
   );
 
   return { data, isFetched, isLoading };
 };
 
 export const DetermineRangeDiscount = (bidOrAsk: "bid" | "ask") => {
-  const { data: currentOhmPrice } = OperatorPrice();
+  const { data: currentOhmPrice } = useOhmPrice();
   const { data: reserveSymbol } = OperatorReserveSymbol();
 
   const { data: bidOrAskPrice } = DetermineRangePrice(bidOrAsk);

--- a/src/views/Range/index.tsx
+++ b/src/views/Range/index.tsx
@@ -73,11 +73,10 @@ export const Range = () => {
   }, [sellActive]);
 
   useEffect(() => {
-    const sellDiscount = (currentPrice - bidPrice.price) / -currentPrice;
-    if (sellDiscount > 0) {
+    if (currentPrice < parseBigNumber(rangeData.cushion.low.price, 18)) {
       setSellActive(true);
     }
-  }, [bidPrice, currentPrice]);
+  }, [rangeData.cushion.low.price, currentPrice]);
 
   const maxBalanceString = `${formatNumber(maxCapacity, 2)} ${buyAsset}  (${formatNumber(
     sellActive ? maxCapacity / bidPrice.price : maxCapacity * askPrice.price,
@@ -136,7 +135,7 @@ export const Range = () => {
   const reserveAmountAsNumber = new DecimalBigNumber(reserveAmount, 18);
   const capacityBN = new DecimalBigNumber(maxCapacity.toString(), sellActive ? 18 : 9); //reserve asset if sell, OHM if buy
   const amountAboveCapacity = sellActive ? reserveAmountAsNumber.gt(capacityBN) : ohmAmountAsNumber.gt(capacityBN);
-  const amountAboveBalance = sellActive ? ohmAmountAsNumber.gt(ohmBalance) : reserveAmountAsNumber.gt(reserveBalance);
+  const amountAboveBalance = sellActive ? reserveAmountAsNumber.gt(reserveBalance) : ohmAmountAsNumber.gt(ohmBalance);
 
   const swapButtonText = `Swap ${sellAsset} for ${buyAsset}`;
 

--- a/src/views/Range/index.tsx
+++ b/src/views/Range/index.tsx
@@ -9,14 +9,9 @@ import { formatNumber, parseBigNumber } from "src/helpers";
 import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber";
 import { useBalance } from "src/hooks/useBalance";
 import { usePathForNetwork } from "src/hooks/usePathForNetwork";
+import { useOhmPrice } from "src/hooks/usePrices";
 import { useTestableNetworks } from "src/hooks/useTestableNetworks";
-import {
-  DetermineRangePrice,
-  OperatorPrice,
-  OperatorReserveSymbol,
-  RangeBondMaxPayout,
-  RangeData,
-} from "src/views/Range/hooks";
+import { DetermineRangePrice, OperatorReserveSymbol, RangeBondMaxPayout, RangeData } from "src/views/Range/hooks";
 import RangeChart from "src/views/Range/RangeChart";
 import RangeConfirmationModal from "src/views/Range/RangeConfirmationModal";
 import RangeInputForm from "src/views/Range/RangeInputForm";
@@ -48,7 +43,7 @@ export const Range = () => {
   const { data: reserveBalance = new DecimalBigNumber("0", 18) } = useBalance(DAI_ADDRESSES)[networks.MAINNET];
   const { data: ohmBalance = new DecimalBigNumber("0", 9) } = useBalance(OHM_ADDRESSES)[networks.MAINNET];
 
-  const { data: currentPrice = 0 } = OperatorPrice();
+  const { data: currentPrice = 0 } = useOhmPrice();
 
   const maxString = sellActive ? `Max You Can Sell` : `Max You Can Buy`;
 
@@ -84,10 +79,10 @@ export const Range = () => {
     }
   }, [bidPrice, currentPrice]);
 
-  const maxBalanceString = `${maxCapacity.toFixed(2)} ${buyAsset}  (${(sellActive
-    ? maxCapacity / bidPrice.price
-    : maxCapacity * askPrice.price
-  ).toFixed(2)} ${sellAsset})`;
+  const maxBalanceString = `${formatNumber(maxCapacity, 2)} ${buyAsset}  (${formatNumber(
+    sellActive ? maxCapacity / bidPrice.price : maxCapacity * askPrice.price,
+    2,
+  )} ${sellAsset})`;
 
   const discount =
     (currentPrice - (sellActive ? bidPrice.price : askPrice.price)) / (sellActive ? -currentPrice : currentPrice);


### PR DESCRIPTION
**New Features**
- Display ‘Current Price’ as price from our Balancer LP instead of the currentPrice from the range price contract. This would bring this view consistent with the market price displayed on the bond view. The ‘historical’ data on the chart will still use the chainlink feed, but the current price dot and the “current price” in the tooltip will display our balancer LP price.  
- Default to Sell View if current price is below the start of the lower cushion. Otherwise, default to the buy view.
- Route orders to operator (wall) if bondPrice is below lower wall or above upper wall. This will produce a more desirable trade in most scenarios. A user can still interact directly with the bond markets via the bond page if they desire.  

**Other General Improvements:** 
- Bring consistency to discount calculations displayed on bond view and range view. These will now be exactly the same when a bond market is live. 
-  RangeChart. Fix formatting on Y Axis (overflow). Improve timestamp on X axis
- move away from .toString({decimals}) for bond percentage discounts. It trims and does not round. 
- use useV3Bond hook for pulling rangeBond data instead of previously implemented hooks specific to range. These existed only because we hadn't deployed v3 bonds yet and was keeping everything isolated to the range section. Discrepancies in discount percent sometimes existed due to minor rounding errors in the different implementations. 
- useV3Bond should use .div on a BigNumber instead of / on a Number to prevent potential underflow.
- 

I'd like to dry run this with Oighty on testnet contracts to double check all states are handled correctly after these changes.