### PR TITLE
fix for balance message. Clicking swap card should focus input

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@mui/material": "^5.11.0",
     "@mui/system": "^5.10.8",
     "@mui/x-data-grid": "^5.17.16",
-    "@olympusdao/component-library": "^3.0.0",
+    "@olympusdao/component-library": "^3.1.0",
     "@rainbow-me/rainbowkit": "^0.7.4",
     "@reduxjs/toolkit": "^1.9.1",
     "@tanstack/react-query": "^4.2.3",

--- a/src/views/Range/__tests__/Range.test.tsx
+++ b/src/views/Range/__tests__/Range.test.tsx
@@ -44,7 +44,7 @@ const defaultStatesWithApproval = () => {
     symbol: vi.fn().mockReturnValue("DAI"),
   });
   //@ts-expect-error
-  vi.spyOn(Prices, "useOhmPrice").mockReturnValue({ data: "13.209363085" });
+  vi.spyOn(Prices, "useOhmPrice").mockReturnValue({ data: "18.209363085" });
 
   //@ts-ignore
   rangeOperator.mockReturnValue({

--- a/src/views/Range/index.tsx
+++ b/src/views/Range/index.tsx
@@ -116,7 +116,7 @@ export const Range = () => {
   const reserveAmountAsNumber = new DecimalBigNumber(reserveAmount, 18);
   const capacityBN = new DecimalBigNumber(maxCapacity.toString(), sellActive ? 18 : 9); //reserve asset if sell, OHM if buy
   const amountAboveCapacity = sellActive ? reserveAmountAsNumber.gt(capacityBN) : ohmAmountAsNumber.gt(capacityBN);
-  const amountAboveBalance = sellActive ? reserveAmountAsNumber.gt(reserveBalance) : ohmAmountAsNumber.gt(ohmBalance);
+  const amountAboveBalance = sellActive ? ohmAmountAsNumber.gt(ohmBalance) : reserveAmountAsNumber.gt(reserveBalance);
 
   const swapButtonText = `Swap ${sellAsset} for ${buyAsset}`;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2309,10 +2309,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@olympusdao/component-library@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@olympusdao/component-library/-/component-library-3.0.0.tgz#984aee01e32b88ca58862166b23c89e7a4e0a7c1"
-  integrity sha512-k3p8lQNUqHLYh31Vbqz7HtE2BDUNzi0bzVB2GnhJmtHBw+zOL1FxbagHFbDiClvUQ9t/ZU7ofd1hO9ny9GWiHQ==
+"@olympusdao/component-library@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@olympusdao/component-library/-/component-library-3.1.0.tgz#059ce6f620cad236ffc1597d930a74c67bb6608b"
+  integrity sha512-AnpO4Wbm3QG5I3k+x/ArdzxE0oMoLXqDpjpxfskq3JFRHkDu8es8kgS2tbizabtsHSJCi/tM8nx4EbYFzCt0Pw==
   dependencies:
     "@react-spring/web" "^9.5.5"
 


### PR DESCRIPTION
- Clicking anywhere in the swap card should focus input
- amountAboveBalance check should be checking ohmAmount on the sell side, and reserveAmount on the buy side. This was inverted and in some cases displaying an 'amount exceeds balance' message. i.e. if on sell Side, and user had OHM Balance of 10, and DAI balance of 5, it was displaying an 'amount exceeds balance' message for an amount input over 5 in the OHM field. 