### PR TITLE
Mobile formatting improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,7 @@ const StyledDiv = styled("div")(({ theme }) => ({
 
   [`& .${classes.content}`]: {
     flexGrow: 1,
-    padding: "9px",
+    padding: "15px",
     transition: theme.transitions.create("margin", {
       easing: theme.transitions.easing.sharp,
       duration: transitionDuration,

--- a/src/components/TopBar/Wallet/GetOhm.tsx
+++ b/src/components/TopBar/Wallet/GetOhm.tsx
@@ -94,7 +94,7 @@ const GetOhm: FC = () => {
             <ItemCard
               tokens={["wETH", "wBTC", "USDC", "DAI"]}
               title={`Zap with more assets`}
-              href={`/zap`}
+              href={`/stake`}
               disableFlip
             />
             <Typography variant="h6" className={classes.title}>
@@ -169,31 +169,6 @@ const GetOhm: FC = () => {
         <Typography variant="h6" className={classes.title}>
           Borrow
         </Typography>
-        <ItemCard
-          tokens={["RARI"]}
-          title={`Borrow on Rari`}
-          href={`https://app.rari.capital/fuse/pool/18`}
-          external
-          roi={`${fuseSupplyApy}%`}
-          days="APY"
-          disableFlip
-        />
-        <ItemCard
-          tokens={["MARKET"]}
-          title={`Borrow on Market.xyz`}
-          networkName={"POLYGON"}
-          href={`https://polygon.market.xyz/pool/8`}
-          external
-          disableFlip
-        />
-        <ItemCard
-          tokens={["MARKET"]}
-          title={`Borrow on Market.xyz`}
-          networkName={"AVAX"}
-          href={`https://avax.market.xyz/pool/3`}
-          external
-          disableFlip
-        />
         <ItemCard
           tokens={["VST"]}
           title={`Borrow on Vesta Finance`}

--- a/src/views/Stake/__tests__/Stake.unit.test.tsx
+++ b/src/views/Stake/__tests__/Stake.unit.test.tsx
@@ -14,7 +14,7 @@ describe("<Stake/>", () => {
     expect(screen.getAllByText("Stake")[0]);
     //  there should be a Farm Pool table
 
-    expect(screen.getByText("Farm Pool"));
+    expect(screen.getByText("Farm Pools"));
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/views/Stake/__tests__/__snapshots__/Stake.unit.test.tsx.snap
+++ b/src/views/Stake/__tests__/__snapshots__/Stake.unit.test.tsx.snap
@@ -437,7 +437,7 @@ exports[`<Stake/> > should render component 1`] = `
               <p
                 class="MuiTypography-root MuiTypography-body1 header-text css-18k89ek-MuiTypography-root"
               >
-                Farm Pool
+                Farm Pools
               </p>
             </div>
             <div
@@ -1717,7 +1717,7 @@ exports[`<Stake/> > should render correct staking headers 1`] = `
               <p
                 class="MuiTypography-root MuiTypography-body1 header-text css-18k89ek-MuiTypography-root"
               >
-                Farm Pool
+                Farm Pools
               </p>
             </div>
             <div

--- a/src/views/Stake/components/ExternalStakePools/ExternalStakePools.tsx
+++ b/src/views/Stake/components/ExternalStakePools/ExternalStakePools.tsx
@@ -63,9 +63,16 @@ export const ExternalStakePools = () => {
   return (
     <>
       {isSmallScreen ? (
-        <AllPools isSmallScreen={isSmallScreen} />
+        <Table>
+          <Box display="flex" justifyContent="start" mt="42px">
+            <Typography fontSize="24px" textAlign="left" fontWeight={600}>
+              Farm Pools
+            </Typography>
+          </Box>
+          <AllPools isSmallScreen={isSmallScreen} />
+        </Table>
       ) : (
-        <Paper headerText={`Farm Pool`}>
+        <Paper headerText={`Farm Pools`}>
           <Table>
             <StyledTableHeader className={classes.stakePoolHeaderText}>
               <TableRow>
@@ -179,7 +186,7 @@ const MobileStakePool: React.FC<{ pool: ExternalPool; tvl?: number; apy?: number
   const userBalance = userBalances[props.pool.networkID].data;
 
   return (
-    <Paper>
+    <Box mt="42px">
       <StyledPoolInfo className={classes.poolPair}>
         <TokenStack tokens={props.pool.icons} style={{ fontSize: "24px" }} />
 
@@ -209,7 +216,7 @@ const MobileStakePool: React.FC<{ pool: ExternalPool; tvl?: number; apy?: number
       <SecondaryButton href={props.pool.href} fullWidth>
         {`Stake on`} {props.pool.stakeOn}
       </SecondaryButton>
-    </Paper>
+    </Box>
   );
 };
 

--- a/src/views/V1-Stake/__tests__/__snapshots__/V1-Stake.unit.test.tsx.snap
+++ b/src/views/V1-Stake/__tests__/__snapshots__/V1-Stake.unit.test.tsx.snap
@@ -215,7 +215,7 @@ exports[`<Stake/> > should render component. not connected 1`] = `
               <p
                 class="MuiTypography-root MuiTypography-body1 header-text css-18k89ek-MuiTypography-root"
               >
-                Farm Pool
+                Farm Pools
               </p>
             </div>
             <div
@@ -1576,7 +1576,7 @@ exports[`<Stake/> > should render the stake input Area when connected 1`] = `
               <p
                 class="MuiTypography-root MuiTypography-body1 header-text css-18k89ek-MuiTypography-root"
               >
-                Farm Pool
+                Farm Pools
               </p>
             </div>
             <div
@@ -3000,7 +3000,7 @@ exports[`<Stake/> > should render the v1 migration modal 1`] = `
               <p
                 class="MuiTypography-root MuiTypography-body1 header-text css-18k89ek-MuiTypography-root"
               >
-                Farm Pool
+                Farm Pools
               </p>
             </div>
             <div
@@ -4424,7 +4424,7 @@ exports[`<Stake/> > should render the v1 migration modal and banner 1`] = `
               <p
                 class="MuiTypography-root MuiTypography-body1 header-text css-18k89ek-MuiTypography-root"
               >
-                Farm Pool
+                Farm Pools
               </p>
             </div>
             <div


### PR DESCRIPTION
- Add left/right padding on mobile
- make farm pools full width

also includes #2597 improvements. 
Before: 
<img width="442" alt="image" src="https://user-images.githubusercontent.com/95196612/211158080-92ee7cbe-2834-4545-922e-c9c005537fcd.png">
After:
<img width="487" alt="image" src="https://user-images.githubusercontent.com/95196612/211158116-91cf9a27-aa77-45ee-9f46-14c652447bcd.png">
