### PR TITLE
Shift Known Issues from Markdown to HTML

### DIFF
--- a/src/views/TreasuryDashboard/__tests__/__snapshots__/TreasuryDashboard.unit.test.tsx.snap
+++ b/src/views/TreasuryDashboard/__tests__/__snapshots__/TreasuryDashboard.unit.test.tsx.snap
@@ -1547,10 +1547,13 @@ exports[`<TreasuryDashboard/> > should render component 1`] = `
                       Illiquid assets have been removed from market value and will be re-introduced when they reach their date of maturity
                     </li>
                     <li>
-                      Due to technical limitations, the balance and value of native ETH is not included 
+                      Due to technical limitations, the balance and value of native ETH is not included
                     </li>
                     <li>
                       There may be a visible delay when capital is deployed to a new contract or blockchain
+                    </li>
+                    <li>
+                      The timestamp shown in each tooltip represents the time of the most recently-indexed block across all chains
                     </li>
                   </div>
                 </div>

--- a/src/views/TreasuryDashboard/__tests__/__snapshots__/TreasuryMobile.unit.test.tsx.snap
+++ b/src/views/TreasuryDashboard/__tests__/__snapshots__/TreasuryMobile.unit.test.tsx.snap
@@ -1547,10 +1547,13 @@ exports[`<TreasuryDashboard/> Mobile > should render component 1`] = `
                       Illiquid assets have been removed from market value and will be re-introduced when they reach their date of maturity
                     </li>
                     <li>
-                      Due to technical limitations, the balance and value of native ETH is not included 
+                      Due to technical limitations, the balance and value of native ETH is not included
                     </li>
                     <li>
                       There may be a visible delay when capital is deployed to a new contract or blockchain
+                    </li>
+                    <li>
+                      The timestamp shown in each tooltip represents the time of the most recently-indexed block across all chains
                     </li>
                   </div>
                 </div>

--- a/src/views/TreasuryDashboard/components/KnownIssues/KnownIssues.tsx
+++ b/src/views/TreasuryDashboard/components/KnownIssues/KnownIssues.tsx
@@ -35,11 +35,6 @@ const KnownIssues = (): JSX.Element => {
         <li>
           The timestamp shown in each tooltip represents the time of the most recently-indexed block across all chains
         </li>
-        <li>
-          $24m of liquidity was migrated from a Curve FRAX3Curve pool into a new Frax staking/locking contract on 5th
-          January 2023. The DAO is working on updating the subgraph that powers this dashboard so that the staked
-          liquidity is recognised.
-        </li>
       </Grid>
     </Grid>
   );

--- a/src/views/TreasuryDashboard/components/KnownIssues/KnownIssues.tsx
+++ b/src/views/TreasuryDashboard/components/KnownIssues/KnownIssues.tsx
@@ -30,8 +30,16 @@ const KnownIssues = (): JSX.Element => {
           Illiquid assets have been removed from market value and will be re-introduced when they reach their date of
           maturity
         </li>
-        <li>Due to technical limitations, the balance and value of native ETH is not included </li>
+        <li>Due to technical limitations, the balance and value of native ETH is not included</li>
         <li>There may be a visible delay when capital is deployed to a new contract or blockchain</li>
+        <li>
+          The timestamp shown in each tooltip represents the time of the most recently-indexed block across all chains
+        </li>
+        <li>
+          $24m of liquidity was migrated from a Curve FRAX3Curve pool into a new Frax staking/locking contract on 5th
+          January 2023. The DAO is working on updating the subgraph that powers this dashboard so that the staked
+          liquidity is recognised.
+        </li>
       </Grid>
     </Grid>
   );

--- a/src/views/TreasuryDashboard/components/KnownIssues/content.md
+++ b/src/views/TreasuryDashboard/components/KnownIssues/content.md
@@ -1,5 +1,0 @@
-- Illiquid assets have been removed from market value and will be re-introduced when they reach their date of maturity
-- Due to technical limitations, the balance and value of native ETH is not included
-- There may be a visible delay when capital is deployed to a new contract or blockchain
-- The timestamp shown in each tooltip represents the time of the most recently-indexed block across all chains
-- $24m of liquidity was migrated from a Curve FRAX3Curve pool into a new Frax staking/locking contract on 5th January 2023. The DAO is working on updating the subgraph that powers this dashboard so that the staked liquidity is recognised.

--- a/src/views/TreasuryDashboard/components/KnownIssues/markdown.d.ts
+++ b/src/views/TreasuryDashboard/components/KnownIssues/markdown.d.ts
@@ -1,5 +1,0 @@
-// Tells the compiler how to handle markdown files
-declare module "*.md" {
-  const value: string;
-  export default value;
-}


### PR DESCRIPTION
- In https://github.com/OlympusDAO/olympus-frontend/pull/2252, the react-markdown package had been removed and raw HTML added to the KnownIssues.tsx file
- The content.md file remained and was subsequently updated
- This PR removes the content.md file and known issues are just listed as HTML in KnownIssues.tsx