### PR TITLE
Add support for OHM supply in boosted liquidity vaults

### DIFF
--- a/src/helpers/subgraph/Constants.ts
+++ b/src/helpers/subgraph/Constants.ts
@@ -7,6 +7,7 @@ export const TOKEN_SUPPLY_TYPE_BONDS_PREMINTED = "OHM Bonds (Pre-minted)";
 export const TOKEN_SUPPLY_TYPE_BONDS_VESTING_DEPOSITS = "OHM Bonds (Vesting Deposits)";
 export const TOKEN_SUPPLY_TYPE_BONDS_VESTING_TOKENS = "OHM Bonds (Vesting Tokens)";
 export const TOKEN_SUPPLY_TYPE_LIQUIDITY = "Liquidity";
+export const TOKEN_SUPPLY_TYPE_BOOSTED_LIQUIDITY_VAULT = "Boosted Liquidity Vault";
 export const TOKEN_SUPPLY_TYPE_OFFSET = "Manual Offset";
 export const TOKEN_SUPPLY_TYPE_TOTAL_SUPPLY = "Total Supply";
 export const TOKEN_SUPPLY_TYPE_TREASURY = "Treasury";

--- a/src/helpers/subgraph/TreasuryQueryHelper.ts
+++ b/src/helpers/subgraph/TreasuryQueryHelper.ts
@@ -7,6 +7,7 @@ import {
   TOKEN_SUPPLY_TYPE_BONDS_PREMINTED,
   TOKEN_SUPPLY_TYPE_BONDS_VESTING_DEPOSITS,
   TOKEN_SUPPLY_TYPE_BONDS_VESTING_TOKENS,
+  TOKEN_SUPPLY_TYPE_BOOSTED_LIQUIDITY_VAULT,
   TOKEN_SUPPLY_TYPE_LENDING,
   TOKEN_SUPPLY_TYPE_LIQUIDITY,
   TOKEN_SUPPLY_TYPE_OFFSET,
@@ -96,6 +97,10 @@ export const getBondPremintedSupply = (records: TokenSupply[]): number => {
   return getTokenSupplyBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_BONDS_PREMINTED]);
 };
 
+export const getBoostedLiquidityVaultSupply = (records: TokenSupply[]): number => {
+  return getTokenSupplyBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_BOOSTED_LIQUIDITY_VAULT]);
+};
+
 export const getExternalSupply = (records: TokenSupply[]): number => {
   return (
     getOhmTotalSupply(records) -
@@ -105,7 +110,8 @@ export const getExternalSupply = (records: TokenSupply[]): number => {
     getBondDepositsSupply(records) -
     getBondVestingTokensSupply(records) -
     getBondPremintedSupply(records) -
-    getLendingSupply(records)
+    getLendingSupply(records) -
+    getBoostedLiquidityVaultSupply(records)
   );
 };
 
@@ -131,6 +137,7 @@ export const getOhmCirculatingSupply = (records: TokenSupply[]): number => {
     TOKEN_SUPPLY_TYPE_BONDS_PREMINTED,
     TOKEN_SUPPLY_TYPE_BONDS_VESTING_DEPOSITS,
     TOKEN_SUPPLY_TYPE_BONDS_DEPOSITS,
+    TOKEN_SUPPLY_TYPE_BOOSTED_LIQUIDITY_VAULT,
   ];
 
   return records
@@ -161,6 +168,7 @@ export const getOhmFloatingSupply = (records: TokenSupply[]): number => {
     TOKEN_SUPPLY_TYPE_BONDS_PREMINTED,
     TOKEN_SUPPLY_TYPE_BONDS_VESTING_DEPOSITS,
     TOKEN_SUPPLY_TYPE_BONDS_DEPOSITS,
+    TOKEN_SUPPLY_TYPE_BOOSTED_LIQUIDITY_VAULT,
     TOKEN_SUPPLY_TYPE_LIQUIDITY,
   ];
 
@@ -192,6 +200,7 @@ export const getOhmBackedSupply = (records: TokenSupply[]): number => {
     TOKEN_SUPPLY_TYPE_BONDS_PREMINTED,
     TOKEN_SUPPLY_TYPE_BONDS_VESTING_DEPOSITS,
     TOKEN_SUPPLY_TYPE_BONDS_DEPOSITS,
+    TOKEN_SUPPLY_TYPE_BOOSTED_LIQUIDITY_VAULT,
     TOKEN_SUPPLY_TYPE_LIQUIDITY,
     TOKEN_SUPPLY_TYPE_LENDING,
   ];

--- a/src/views/TreasuryDashboard/components/Graph/OhmSupplyGraph.tsx
+++ b/src/views/TreasuryDashboard/components/Graph/OhmSupplyGraph.tsx
@@ -12,6 +12,7 @@ import {
   getBondDepositsSupply,
   getBondPremintedSupply,
   getBondVestingTokensSupply,
+  getBoostedLiquidityVaultSupply,
   getExternalSupply,
   getLendingSupply,
   getMigrationOffsetSupply,
@@ -76,6 +77,7 @@ export const OhmSupplyGraph = ({ subgraphUrls, earliestDate, subgraphDaysOffset 
     bondPreminted: number;
     external: number;
     lending: number;
+    boostedLiquidityVault: number;
   };
   const [byDateOhmSupply, setByDateOhmSupply] = useState<OhmSupplyComparison[]>([]);
   useMemo(() => {
@@ -105,6 +107,7 @@ export const OhmSupplyGraph = ({ subgraphUrls, earliestDate, subgraphDaysOffset 
         bondPreminted: getBondPremintedSupply(dateSupplyValues),
         external: getExternalSupply(dateSupplyValues),
         lending: getLendingSupply(dateSupplyValues),
+        boostedLiquidityVault: getBoostedLiquidityVaultSupply(dateSupplyValues),
       };
 
       tempByDateOhmSupply.push(dateOhmSupply);
@@ -128,6 +131,7 @@ export const OhmSupplyGraph = ({ subgraphUrls, earliestDate, subgraphDaysOffset 
     "lending",
     "bondVestingTokens",
     "protocolOwnedLiquidity",
+    "boostedLiquidityVault",
     "treasury",
     "migrationOffset",
     "bondPreminted",
@@ -142,6 +146,7 @@ export const OhmSupplyGraph = ({ subgraphUrls, earliestDate, subgraphDaysOffset 
     `Deployed to Lending Markets`,
     `OHM Bonds (Vesting)`,
     `Protocol-Owned Liquidity`,
+    `Boosted Liquidity Vault`,
     `Treasury`,
     `Migration Offset`,
     `OHM Bonds (Pre-minted)`,


### PR DESCRIPTION
Needs to be deployed by Monday, before the BLV launch.