### PR TITLE
Migrates to new subgraph version supporting DAO working capital

### DIFF
--- a/src/helpers/SubgraphUrlHelper.ts
+++ b/src/helpers/SubgraphUrlHelper.ts
@@ -3,7 +3,7 @@ import { Environment } from "src/helpers/environment/Environment/Environment";
 const STUB_API_KEY = "[api-key]";
 
 const SUBGRAPH_URL_ETHEREUM =
-  "https://gateway.thegraph.com/api/[api-key]/deployments/id/QmPgTQgy9jYo4qWKsFPnVJAFN1JrkBiPWuThdesfT2V3aa";
+  "https://gateway.thegraph.com/api/[api-key]/deployments/id/QmTX2jyTzouDkqXfmPx3mFYnXFi7TuEnMt1oTRvvXyfYRx";
 const SUBGRAPH_URL_ARBITRUM = "https://api.thegraph.com/subgraphs/name/olympusdao/protocol-metrics-arbitrum";
 const SUBGRAPH_URL_FANTOM = "https://api.thegraph.com/subgraphs/name/olympusdao/protocol-metrics-fantom";
 const SUBGRAPH_URL_POLYGON = "https://api.thegraph.com/subgraphs/name/olympusdao/protocol-metrics-polygon";


### PR DESCRIPTION
Shifts to the subgraph version associated with https://github.com/OlympusDAO/olympus-protocol-metrics-subgraph/pull/200

(This PR is for `develop`)