### PR TITLE
Multi-Chain OHM Supply

### DIFF
--- a/src/components/Chart/CustomTooltip.tsx
+++ b/src/components/Chart/CustomTooltip.tsx
@@ -1,5 +1,6 @@
 import { Grid, Paper, Typography } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
+import React from "react";
 import { CSSProperties } from "react";
 import { DataFormat } from "src/components/Chart/Constants";
 import { formatCurrency } from "src/helpers";
@@ -123,7 +124,7 @@ const renderBulletpointRow = (
 
   // Don't render a tooltip row if the value is 0 (#2673)
   if (!item.value) {
-    return <></>;
+    return <React.Fragment key={item.dataKey}></React.Fragment>;
   }
 
   return (
@@ -134,7 +135,7 @@ const renderBulletpointRow = (
       alignContent="center"
       justifyContent="space-between"
       style={{ marginBottom: "2px" }}
-      key={index}
+      key={item.dataKey}
     >
       <Grid item xs={1} alignContent="left">
         <span style={bulletpointStyle}></span>
@@ -176,7 +177,7 @@ const renderTooltipItems = (
             (dataKeysExcludedFromTotal && dataKeysExcludedFromTotal.includes(item.dataKey))
           ) {
             ignoredIndex++;
-            return { label: label, element: <></> };
+            return { label: label, element: <React.Fragment key={item.dataKey}></React.Fragment> };
           }
 
           const adjustedIndex = index - ignoredIndex;
@@ -203,7 +204,7 @@ const renderTooltipItems = (
         payload.map((item, index) => {
           if (!dataKeysExcludedFromTotal || !dataKeysExcludedFromTotal.includes(item.dataKey)) {
             ignoredIndex++;
-            return <></>;
+            return <React.Fragment key={item.dataKey}></React.Fragment>;
           }
 
           const adjustedIndex = index - ignoredIndex;

--- a/src/helpers/index.tsx
+++ b/src/helpers/index.tsx
@@ -160,3 +160,11 @@ export const testnetToMainnetContract = (address: string) => {
       return address;
   }
 };
+
+export const formatNumberOrLoading = (value: number | null | undefined): string => {
+  return value ? formatNumber(value) : "Loading...";
+};
+
+export const formatCurrencyOrLoading = (value: number | null | undefined): string => {
+  return value ? formatCurrency(value, 2) : "Loading...";
+};

--- a/src/helpers/subgraph/TreasuryQueryHelper.ts
+++ b/src/helpers/subgraph/TreasuryQueryHelper.ts
@@ -101,7 +101,8 @@ const getBalanceMultiplier = (record: TokenSupply, ohmIndex: number): number => 
  * in the {includedTypes} parameter will return a number that is
  * the sum of the balance property all records with matching types.
  *
- * @param records
+ * @param records TokenSupply records for the given day
+ * @param ohmIndex The index of OHM for the given day
  * @param includedTypes
  * @returns
  */
@@ -120,7 +121,8 @@ const getBalanceForTypes = (records: TokenSupply[], includedTypes: string[], ohm
  * in the {includedTypes} parameter will return a number that is
  * the sum of the supplyBalance property all records with matching types.
  *
- * @param records
+ * @param records TokenSupply records for the given day
+ * @param ohmIndex The index of OHM for the given day
  * @param includedTypes
  * @returns
  */
@@ -194,7 +196,8 @@ export const getExternalSupply = (records: TokenSupply[], ohmIndex: number): num
  * - minus: pre-minted OHM for bonds
  * - minus: OHM user deposits for bonds
  *
- * @param records
+ * @param records TokenSupply records for the given day
+ * @param ohmIndex The index of OHM for the given day
  * @returns
  */
 export const getOhmCirculatingSupply = (records: TokenSupply[], ohmIndex: number): number => {
@@ -223,7 +226,8 @@ export const getOhmCirculatingSupply = (records: TokenSupply[], ohmIndex: number
  * - minus: OHM user deposits for bonds
  * - minus: protocol-owned OHM in liquidity pools
  *
- * @param records
+ * @param records TokenSupply records for the given day
+ * @param ohmIndex The index of OHM for the given day
  * @returns
  */
 export const getOhmFloatingSupply = (records: TokenSupply[], ohmIndex: number): number => {
@@ -255,6 +259,9 @@ export const getOhmFloatingSupply = (records: TokenSupply[], ohmIndex: number): 
  * - minus: OHM user deposits for bonds
  * - minus: protocol-owned OHM in liquidity pools
  * - minus: OHM minted and deployed into lending markets
+ *
+ * @param records TokenSupply records for the given day
+ * @param ohmIndex The index of OHM for the given day
  */
 export const getOhmBackedSupply = (records: TokenSupply[], ohmIndex: number): number => {
   const includedTypes = [
@@ -276,7 +283,8 @@ export const getOhmBackedSupply = (records: TokenSupply[], ohmIndex: number): nu
  * For a given array of TokenSupply records (assumed to be at the same point in time),
  * this function returns the OHM total supply.
  *
- * @param records
+ * @param records TokenSupply records for the given day
+ * @param ohmIndex The index of OHM for the given day
  * @returns
  */
 export const getOhmTotalSupply = (records: TokenSupply[], ohmIndex: number): number => {

--- a/src/helpers/subgraph/TreasuryQueryHelper.ts
+++ b/src/helpers/subgraph/TreasuryQueryHelper.ts
@@ -93,6 +93,25 @@ const getBalanceForTypes = (records: TokenSupply[], includedTypes: string[]): nu
     .reduce((previousValue, record) => previousValue + +record.balance, 0);
 };
 
+/**
+ * Returns the sum of balances for different supply types.
+ *
+ * Note that this will return positive or negative balances, depending on the type.
+ *
+ * For example, passing [TOKEN_SUPPLY_TYPE_LIQUIDITY, TOKEN_SUPPLY_TYPE_TREASURY]
+ * in the {includedTypes} parameter will return a number that is
+ * the sum of the supplyBalance property all records with matching types.
+ *
+ * @param records
+ * @param includedTypes
+ * @returns
+ */
+const getSupplyBalanceForTypes = (records: TokenSupply[], includedTypes: string[]): number => {
+  return records
+    .filter(record => isSupportedToken(record) && includedTypes.includes(record.type))
+    .reduce((previousValue, record) => previousValue + +record.supplyBalance, 0);
+};
+
 export const getProtocolOwnedLiquiditySupply = (records: TokenSupply[]): number => {
   return getBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_LIQUIDITY]);
 };
@@ -164,9 +183,7 @@ export const getOhmCirculatingSupply = (records: TokenSupply[]): number => {
     TOKEN_SUPPLY_TYPE_BOOSTED_LIQUIDITY_VAULT,
   ];
 
-  return records
-    .filter(record => includedTypes.includes(record.type))
-    .reduce((previousValue, record) => previousValue + +record.supplyBalance, 0);
+  return getSupplyBalanceForTypes(records, includedTypes);
 };
 
 /**
@@ -196,9 +213,7 @@ export const getOhmFloatingSupply = (records: TokenSupply[]): number => {
     TOKEN_SUPPLY_TYPE_LIQUIDITY,
   ];
 
-  return records
-    .filter(record => includedTypes.includes(record.type))
-    .reduce((previousValue, record) => previousValue + +record.supplyBalance, 0);
+  return getSupplyBalanceForTypes(records, includedTypes);
 };
 
 /**
@@ -229,9 +244,7 @@ export const getOhmBackedSupply = (records: TokenSupply[]): number => {
     TOKEN_SUPPLY_TYPE_LENDING,
   ];
 
-  return records
-    .filter(record => includedTypes.includes(record.type))
-    .reduce((previousValue, record) => previousValue + +record.supplyBalance, 0);
+  return getSupplyBalanceForTypes(records, includedTypes);
 };
 
 /**
@@ -242,9 +255,7 @@ export const getOhmBackedSupply = (records: TokenSupply[]): number => {
  * @returns
  */
 export const getOhmTotalSupply = (records: TokenSupply[]): number => {
-  return records
-    .filter(record => record.type === TOKEN_SUPPLY_TYPE_TOTAL_SUPPLY)
-    .reduce((previousValue, record) => previousValue + +record.supplyBalance, 0);
+  return getSupplyBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_TOTAL_SUPPLY]);
 };
 
 /**

--- a/src/helpers/subgraph/TreasuryQueryHelper.ts
+++ b/src/helpers/subgraph/TreasuryQueryHelper.ts
@@ -1,3 +1,4 @@
+import { GOHM_ADDRESSES, OHM_ADDRESSES } from "src/constants/addresses";
 import { TokenRecord, TokenSupply } from "src/generated/graphql";
 import {
   CATEGORY_POL,
@@ -47,6 +48,30 @@ export const getTreasuryAssetValue = (
   }
 
   return filterReduce(records, record => categories.includes(record.category), false);
+};
+
+let supportedTokens: string[];
+
+const getSupportedTokens = (): string[] => {
+  if (!supportedTokens) {
+    const tokens: string[] = [];
+    const ohmAddresses = Object.values(OHM_ADDRESSES).map(address => address.toLowerCase());
+    const gOhmAddresses = Object.values(GOHM_ADDRESSES).map(address => address.toLowerCase());
+    tokens.push(...ohmAddresses);
+    tokens.push(...gOhmAddresses);
+
+    supportedTokens = tokens;
+  }
+
+  return supportedTokens;
+};
+
+const isSupportedToken = (record: TokenSupply) => {
+  if (!getSupportedTokens().includes(record.tokenAddress.toLocaleLowerCase())) {
+    return false;
+  }
+
+  return true;
 };
 
 /**

--- a/src/helpers/subgraph/TreasuryQueryHelper.ts
+++ b/src/helpers/subgraph/TreasuryQueryHelper.ts
@@ -52,6 +52,8 @@ export const getTreasuryAssetValue = (
 /**
  * Returns the sum of balances for different supply types.
  *
+ * Note that this will return positive balances for each type.
+ *
  * For example, passing [TOKEN_SUPPLY_TYPE_LIQUIDITY, TOKEN_SUPPLY_TYPE_TREASURY]
  * in the {includedTypes} parameter will return a number that is
  * the sum of the balance property all records with matching types.
@@ -60,45 +62,42 @@ export const getTreasuryAssetValue = (
  * @param includedTypes
  * @returns
  */
-export const getTokenSupplyBalanceForTypes = (records: TokenSupply[], includedTypes: string[]): number => {
+const getBalanceForTypes = (records: TokenSupply[], includedTypes: string[]): number => {
   return records
-    .filter(record => includedTypes.includes(record.type))
+    .filter(record => isSupportedToken(record) && includedTypes.includes(record.type))
     .reduce((previousValue, record) => previousValue + +record.balance, 0);
 };
 
 export const getProtocolOwnedLiquiditySupply = (records: TokenSupply[]): number => {
-  return getTokenSupplyBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_LIQUIDITY]);
+  return getBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_LIQUIDITY]);
 };
 
 export const getTreasurySupply = (records: TokenSupply[]): number => {
-  return getTokenSupplyBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_TREASURY]);
+  return getBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_TREASURY]);
 };
 
 export const getMigrationOffsetSupply = (records: TokenSupply[]): number => {
-  return getTokenSupplyBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_OFFSET]);
+  return getBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_OFFSET]);
 };
 
 export const getBondDepositsSupply = (records: TokenSupply[]): number => {
-  return getTokenSupplyBalanceForTypes(records, [
-    TOKEN_SUPPLY_TYPE_BONDS_VESTING_DEPOSITS,
-    TOKEN_SUPPLY_TYPE_BONDS_DEPOSITS,
-  ]);
+  return getBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_BONDS_VESTING_DEPOSITS, TOKEN_SUPPLY_TYPE_BONDS_DEPOSITS]);
 };
 
 export const getBondVestingTokensSupply = (records: TokenSupply[]): number => {
-  return getTokenSupplyBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_BONDS_VESTING_TOKENS]);
+  return getBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_BONDS_VESTING_TOKENS]);
 };
 
 export const getLendingSupply = (records: TokenSupply[]): number => {
-  return getTokenSupplyBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_LENDING]);
+  return getBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_LENDING]);
 };
 
 export const getBondPremintedSupply = (records: TokenSupply[]): number => {
-  return getTokenSupplyBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_BONDS_PREMINTED]);
+  return getBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_BONDS_PREMINTED]);
 };
 
 export const getBoostedLiquidityVaultSupply = (records: TokenSupply[]): number => {
-  return getTokenSupplyBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_BOOSTED_LIQUIDITY_VAULT]);
+  return getBalanceForTypes(records, [TOKEN_SUPPLY_TYPE_BOOSTED_LIQUIDITY_VAULT]);
 };
 
 export const getExternalSupply = (records: TokenSupply[]): number => {

--- a/src/helpers/subgraph/TreasuryQueryHelper.ts
+++ b/src/helpers/subgraph/TreasuryQueryHelper.ts
@@ -73,7 +73,7 @@ const getSupportedTokens = (): string[] => {
 };
 
 const isSupportedToken = (record: TokenSupply) => {
-  if (!getSupportedTokens().includes(record.tokenAddress.toLocaleLowerCase())) {
+  if (!getSupportedTokens().includes(record.tokenAddress.toLowerCase())) {
     return false;
   }
 

--- a/src/hooks/useProtocolMetrics.ts
+++ b/src/hooks/useProtocolMetrics.ts
@@ -101,6 +101,26 @@ export const useCurrentIndex = (subgraphUrl?: string) => {
       recordCount: 1,
       endpoint: endpoint,
     },
-    { select: data => data.protocolMetrics[0].currentIndex, ...QUERY_OPTIONS },
+    { select: data => (data.protocolMetrics.length ? data.protocolMetrics[0].currentIndex : 0), ...QUERY_OPTIONS },
+  );
+};
+
+/**
+ * Determines the index on the specified date.
+ *
+ * @param date YYYY-MM-DD format date string
+ * @returns
+ */
+export const useIndexOnDate = (date: string, subgraphUrl?: string) => {
+  const endpoint = subgraphUrl || getSubgraphUrl();
+
+  return useProtocolMetricsQuery(
+    getDataSource(endpoint),
+    {
+      recordCount: 1,
+      endpoint: endpoint,
+      filter: { date: date },
+    },
+    { select: data => (data.protocolMetrics.length ? data.protocolMetrics[0].currentIndex : 0), ...QUERY_OPTIONS },
   );
 };

--- a/src/hooks/useSubgraphTokenSupplies.ts
+++ b/src/hooks/useSubgraphTokenSupplies.ts
@@ -92,7 +92,6 @@ export const useTokenSuppliesQuery = (
       recordCount: DEFAULT_RECORD_COUNT,
       endpoint: endpointNotNull,
     });
-    console.log(`${chartName}: queryVariables`, queryVariables);
 
     setDataSource(getDataSource(endpointNotNull));
 

--- a/src/hooks/useSubgraphTokenSupplies.ts
+++ b/src/hooks/useSubgraphTokenSupplies.ts
@@ -7,7 +7,8 @@ import {
   useInfiniteTokenSuppliesQuery,
 } from "src/generated/graphql";
 import { getDataSource } from "src/graphql/query";
-import { adjustDateByDays, getISO8601String } from "src/helpers/DateHelper";
+import { adjustDateByDays, dateGreaterThan, getISO8601String } from "src/helpers/DateHelper";
+import { BLOCKCHAINS, SUBGRAPH_URLS } from "src/helpers/SubgraphUrlHelper";
 import { DEFAULT_RECORD_COUNT } from "src/views/TreasuryDashboard/components/Graph/Constants";
 import { getNextPageStartDate } from "src/views/TreasuryDashboard/components/Graph/helpers/SubgraphHelper";
 import {
@@ -38,7 +39,7 @@ type QueryOptionsType = {
  */
 export const useTokenSuppliesQuery = (
   chartName: string,
-  subgraphUrl: string, // shift to type with url per blockchain
+  subgraphUrl: string | null,
   baseFilter: TokenSupply_Filter,
   earliestDate: string | null,
   dateOffset?: number,
@@ -49,18 +50,24 @@ export const useTokenSuppliesQuery = (
   const [paginator, setPaginator] = useState<NextPageParamType | undefined>();
   const functionName = useMemo(() => `${chartName}/TokenSupply`, [chartName]);
 
+  // The generated react-query hook requires a non-null endpoint (but will be disabled if it is an empty string), so we cache the value here
+  const [endpointNotNull, setEndpointNotNull] = useState("");
+  useEffect(() => {
+    setEndpointNotNull(subgraphUrl || "");
+  }, [subgraphUrl]);
+
   /**
    * Handle changes to the props
    */
   const [dataSource, setDataSource] = useState<{ endpoint: string; fetchParams?: RequestInit }>(
-    getDataSource(subgraphUrl),
+    getDataSource(endpointNotNull),
   );
   const [queryVariables, setQueryVariables] = useState<TokenSuppliesQueryVariables>({
     filter: {
       ...baseFilter,
     },
     recordCount: DEFAULT_RECORD_COUNT,
-    endpoint: subgraphUrl,
+    endpoint: endpointNotNull,
   });
   const [queryOptions, setQueryOptions] = useState<QueryOptionsType>({
     enabled: false,
@@ -83,10 +90,11 @@ export const useTokenSuppliesQuery = (
         date_lt: finishDate,
       },
       recordCount: DEFAULT_RECORD_COUNT,
-      endpoint: subgraphUrl,
+      endpoint: endpointNotNull,
     });
+    console.log(`${chartName}: queryVariables`, queryVariables);
 
-    setDataSource(getDataSource(subgraphUrl));
+    setDataSource(getDataSource(endpointNotNull));
 
     // Create a new paginator with the new earliestDate
     const tempPaginator =
@@ -96,7 +104,7 @@ export const useTokenSuppliesQuery = (
     setPaginator(tempPaginator);
 
     const tempQueryOptions = {
-      enabled: earliestDate !== null && subgraphUrl.length > 0 && tempPaginator !== undefined,
+      enabled: earliestDate !== null && endpointNotNull.length > 0 && tempPaginator !== undefined,
       getNextPageParam: tempPaginator,
     };
     setQueryOptions(tempQueryOptions);
@@ -158,4 +166,233 @@ export const useTokenSuppliesQuery = (
   }, [data, functionName, isFetching, hasNextPage]);
 
   return byDateTokenSupplies;
+};
+
+/**
+ * Fetches TokenSupply records from each of the given subgraph URLs,
+ * returning the combined records grouped by date.
+ *
+ * Only the records belonging to the latest block per date are returned.
+ *
+ * This hook handles paging and returns the completed results up to {earliestDate}.
+ *
+ * @param chartName
+ * @param subgraphUrls
+ * @param baseFilter
+ * @param earliestDate the earliest date to fetch, in YYYY-MM-DD format
+ * @param dateOffset the number of days to fetch in each page/request
+ * @returns Records grouped by date, or null if still fetching
+ */
+export const useTokenSuppliesQueries = (
+  chartName: string,
+  subgraphUrls: SUBGRAPH_URLS | null | undefined,
+  _baseFilter: TokenSupply_Filter,
+  _earliestDate: string | null | undefined,
+  _dateOffset?: number,
+): Map<string, TokenSupply[]> | null => {
+  // Cache these props, as they will be passed to the query for each blockchain, and we don't want to propagate non-changes
+  const [baseFilter, setBaseFilter] = useState(_baseFilter);
+  useEffect(() => {
+    if (_baseFilter == baseFilter) return;
+
+    console.debug(`${chartName}: baseFilter changed to ${JSON.stringify(_baseFilter)}`);
+    setBaseFilter(_baseFilter);
+  }, [_baseFilter, chartName]);
+
+  const [earliestDate, setEarliestDate] = useState<string | null>(_earliestDate || null);
+  useEffect(() => {
+    if (_earliestDate == earliestDate) return;
+
+    console.debug(`${chartName}: earliestDate changed to ${_earliestDate}`);
+    setEarliestDate(_earliestDate || null);
+  }, [_earliestDate, chartName]);
+
+  const [dateOffset, setDateOffset] = useState(_dateOffset);
+  useEffect(() => {
+    if (_dateOffset == dateOffset) return;
+
+    console.debug(`${chartName}: dateOffset changed to ${_dateOffset}`);
+    setDateOffset(_dateOffset);
+  }, [_dateOffset, chartName]);
+
+  // Cache the subgraph urls, otherwise it will re-fetch and re-render continuously
+  const [subgraphUrlArbitrum, setSubgraphUrlArbitrum] = useState<string | null>(null);
+  const [subgraphUrlEthereum, setSubgraphUrlEthereum] = useState<string | null>(null);
+  const [subgraphUrlFantom, setSubgraphUrlFantom] = useState<string | null>(null);
+  const [subgraphUrlPolygon, setSubgraphUrlPolygon] = useState<string | null>(null);
+  useEffect(() => {
+    if (!subgraphUrls) {
+      console.debug(`${chartName}: subgraphUrls changed to null`);
+      setSubgraphUrlArbitrum(null);
+      setSubgraphUrlEthereum(null);
+      setSubgraphUrlFantom(null);
+      setSubgraphUrlPolygon(null);
+      return;
+    }
+
+    // Skip if the values are the same
+    if (
+      subgraphUrlArbitrum == subgraphUrls.Arbitrum &&
+      subgraphUrlEthereum == subgraphUrls.Ethereum &&
+      subgraphUrlFantom == subgraphUrls.Fantom &&
+      subgraphUrlPolygon == subgraphUrls.Polygon
+    ) {
+      return;
+    }
+
+    console.debug(`${chartName}: subgraphUrls changed to ${JSON.stringify(subgraphUrls)}`);
+    setSubgraphUrlArbitrum(subgraphUrls.Arbitrum);
+    setSubgraphUrlEthereum(subgraphUrls.Ethereum);
+    setSubgraphUrlFantom(subgraphUrls.Fantom);
+    setSubgraphUrlPolygon(subgraphUrls.Polygon);
+  }, [chartName, subgraphUrls]);
+
+  useEffect(() => {
+    // This ensures that components relying on this data are updated
+    console.info(`${chartName}: Inputs changed. Resetting combined results.`);
+    setCombinedResults(null);
+  }, [
+    baseFilter,
+    earliestDate,
+    dateOffset,
+    subgraphUrlArbitrum,
+    subgraphUrlEthereum,
+    subgraphUrlFantom,
+    subgraphUrlPolygon,
+    chartName,
+  ]);
+
+  // Start queries
+  const arbitrumResults = useTokenSuppliesQuery(
+    `${chartName}/Arbitrum`,
+    subgraphUrlArbitrum,
+    baseFilter,
+    earliestDate,
+    dateOffset,
+  );
+  const ethereumResults = useTokenSuppliesQuery(
+    `${chartName}/Ethereum`,
+    subgraphUrlEthereum,
+    baseFilter,
+    earliestDate,
+    dateOffset,
+  );
+  const fantomResults = useTokenSuppliesQuery(
+    `${chartName}/Fantom`,
+    subgraphUrlFantom,
+    baseFilter,
+    earliestDate,
+    dateOffset,
+  );
+  const polygonResults = useTokenSuppliesQuery(
+    `${chartName}/Polygon`,
+    subgraphUrlPolygon,
+    baseFilter,
+    earliestDate,
+    dateOffset,
+  );
+  const [combinedResults, setCombinedResults] = useState<Map<string, TokenSupply[]> | null>(null);
+
+  /**
+   * Combines the contents of {results} with the existing map of {currentResults}.
+   *
+   * If {currentResults} contains values for a key, the values are merged.
+   *
+   * @param results
+   * @param existingResults
+   */
+  const combineQueryResults = (
+    blockchain: BLOCKCHAINS,
+    results: Map<string, TokenSupply[]> | null,
+    existingResults: Map<string, TokenSupply[]>,
+    latestDate: string | null,
+  ): void => {
+    if (!results) return;
+
+    results.forEach((records: TokenSupply[], date: string) => {
+      // Skip if greater than latestDate
+      if (latestDate && dateGreaterThan(date, latestDate)) return;
+
+      // Get the existing value
+      const existingRecords = existingResults.get(date);
+
+      // Combine, if needed
+      const combinedRecords: TokenSupply[] = records.slice();
+      if (existingRecords) {
+        combinedRecords.push(...existingRecords);
+      }
+
+      // Set in the resulting map
+      existingResults.set(date, combinedRecords);
+    });
+  };
+
+  // Handle receiving the finalised data from each blockchain
+  useEffect(() => {
+    // Only combine (and trigger a re-render) when all results have been received
+    if (!arbitrumResults || !ethereumResults || !fantomResults || !polygonResults) {
+      return;
+    }
+
+    /**
+     * Returns the date representing the latest date in the given results.
+     *
+     * If the results are empty, null is returned.
+     *
+     * @param results
+     * @returns
+     */
+    const getLatestDate = (results: Map<string, TokenSupply[]>): string | null => {
+      const sortedKeys = Array.from(results.keys()).sort();
+
+      if (sortedKeys.length == 0) return null;
+
+      return sortedKeys[sortedKeys.length - 1];
+    };
+
+    /**
+     * Iterate over all of the query results and returns the
+     * latest date that is common across all of the results.
+     */
+    const getCommonLatestDate = (): string | null => {
+      if (!arbitrumResults || !ethereumResults || !fantomResults || !polygonResults) {
+        return null;
+      }
+
+      const latestDates = [
+        getLatestDate(arbitrumResults),
+        getLatestDate(ethereumResults),
+        getLatestDate(fantomResults),
+        getLatestDate(polygonResults),
+      ];
+
+      // Return the smallest, latest date
+      return latestDates.reduce((previousValue: string | null, currentValue: string | null) => {
+        if (!currentValue || currentValue.length == 0) return previousValue;
+
+        if (!previousValue || previousValue.length == 0) return currentValue;
+
+        if (new Date(previousValue).getTime() < new Date(currentValue).getTime()) return previousValue;
+
+        return currentValue;
+      }, "");
+    };
+
+    // This results in the dashboard only showing data for the latest day for which all blockchains have data
+    const commonLatestDate = getCommonLatestDate();
+
+    console.info(`${chartName}: Received all results. Combining.`);
+    const tempResults = new Map<string, TokenSupply[]>();
+    combineQueryResults(BLOCKCHAINS.Arbitrum, arbitrumResults, tempResults, commonLatestDate);
+    combineQueryResults(BLOCKCHAINS.Ethereum, ethereumResults, tempResults, commonLatestDate);
+    combineQueryResults(BLOCKCHAINS.Fantom, fantomResults, tempResults, commonLatestDate);
+    combineQueryResults(BLOCKCHAINS.Polygon, polygonResults, tempResults, commonLatestDate);
+
+    // We need to sort by key (date), as the ordering of arrival of results will result in them being out of order
+    const sortedResults = new Map([...tempResults].sort().reverse());
+
+    setCombinedResults(sortedResults);
+  }, [arbitrumResults, chartName, ethereumResults, fantomResults, polygonResults]);
+
+  return combinedResults;
 };

--- a/src/hooks/useTokenSupplyMetrics.ts
+++ b/src/hooks/useTokenSupplyMetrics.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { TokenSupply_Filter, useTokenSuppliesQuery } from "src/generated/graphql";
 import { getDataSource } from "src/graphql/query";
 import {
@@ -9,26 +9,16 @@ import {
 import { getSubgraphUrl, SUBGRAPH_URLS } from "src/helpers/SubgraphUrlHelper";
 import { useCurrentIndex } from "src/hooks/useProtocolMetrics";
 import { useTokenSuppliesQueries } from "src/hooks/useSubgraphTokenSupplies";
-import { useTokenRecordsLatestBlock, useTokenRecordsLatestRecord } from "src/hooks/useTokenRecordsMetrics";
+import { useTokenRecordsLatestBlock } from "src/hooks/useTokenRecordsMetrics";
 import { DEFAULT_RECORD_COUNT } from "src/views/TreasuryDashboard/components/Graph/Constants";
 
 const QUERY_OPTIONS = { refetchInterval: 60000 }; // Refresh every 60 seconds
 
-export const useOhmCirculatingSupply = (subgraphUrls?: SUBGRAPH_URLS): number => {
-  const { data } = useTokenRecordsLatestRecord(subgraphUrls?.Ethereum);
+export const useOhmCirculatingSupply = (subgraphUrls?: SUBGRAPH_URLS, earliestDate?: string | null): number => {
   const currentIndexQuery = useCurrentIndex(subgraphUrls?.Ethereum);
-  const [tokenSupplyBaseFilter, setTokenSupplyBaseFilter] = useState<TokenSupply_Filter>({});
+  const [tokenSupplyBaseFilter] = useState<TokenSupply_Filter>({});
 
-  useEffect(() => {
-    if (!data) {
-      return;
-    }
-
-    setTokenSupplyBaseFilter({ date: data.date });
-  }, [data]);
-
-  const supplyQuery = useTokenSuppliesQueries("CirculatingSupply", subgraphUrls, tokenSupplyBaseFilter, null);
-  console.log(`CirculatingSupply results: ${JSON.stringify(supplyQuery)}`);
+  const supplyQuery = useTokenSuppliesQueries("CirculatingSupply", subgraphUrls, tokenSupplyBaseFilter, earliestDate);
 
   const supplyData = supplyQuery && Array.from(supplyQuery).length > 0 ? Array.from(supplyQuery)[0][1] : [];
   return getOhmCirculatingSupply(supplyData, currentIndexQuery.data || 0);

--- a/src/hooks/useTokenSupplyMetrics.ts
+++ b/src/hooks/useTokenSupplyMetrics.ts
@@ -24,44 +24,24 @@ export const useOhmCirculatingSupply = (subgraphUrls?: SUBGRAPH_URLS, earliestDa
   return getOhmCirculatingSupply(supplyData, currentIndexQuery.data || 0);
 };
 
-export const useOhmFloatingSupply = (subgraphUrl?: string) => {
-  const latestDateQuery = useTokenRecordsLatestBlock(subgraphUrl);
-  const currentIndexQuery = useCurrentIndex(subgraphUrl);
-  const endpoint = subgraphUrl || getSubgraphUrl();
+export const useOhmFloatingSupply = (subgraphUrls?: SUBGRAPH_URLS, earliestDate?: string | null): number => {
+  const currentIndexQuery = useCurrentIndex(subgraphUrls?.Ethereum);
+  const [tokenSupplyBaseFilter] = useState<TokenSupply_Filter>({});
 
-  return useTokenSuppliesQuery(
-    getDataSource(endpoint),
-    {
-      recordCount: DEFAULT_RECORD_COUNT,
-      filter: { block: latestDateQuery.data },
-      endpoint: endpoint,
-    },
-    {
-      select: data => getOhmFloatingSupply(data.tokenSupplies, currentIndexQuery.data || 0),
-      ...QUERY_OPTIONS,
-      enabled: latestDateQuery.isSuccess && currentIndexQuery.isSuccess, // Only fetch when we've been able to get the latest date
-    },
-  );
+  const supplyQuery = useTokenSuppliesQueries("FloatingSupply", subgraphUrls, tokenSupplyBaseFilter, earliestDate);
+
+  const supplyData = supplyQuery && Array.from(supplyQuery).length > 0 ? Array.from(supplyQuery)[0][1] : [];
+  return getOhmFloatingSupply(supplyData, currentIndexQuery.data || 0);
 };
 
-export const useOhmBackedSupply = (subgraphUrl?: string) => {
-  const latestDateQuery = useTokenRecordsLatestBlock(subgraphUrl);
-  const currentIndexQuery = useCurrentIndex(subgraphUrl);
-  const endpoint = subgraphUrl || getSubgraphUrl();
+export const useOhmBackedSupply = (subgraphUrls?: SUBGRAPH_URLS, earliestDate?: string | null): number => {
+  const currentIndexQuery = useCurrentIndex(subgraphUrls?.Ethereum);
+  const [tokenSupplyBaseFilter] = useState<TokenSupply_Filter>({});
 
-  return useTokenSuppliesQuery(
-    getDataSource(endpoint),
-    {
-      recordCount: DEFAULT_RECORD_COUNT,
-      filter: { block: latestDateQuery.data },
-      endpoint: endpoint,
-    },
-    {
-      select: data => getOhmBackedSupply(data.tokenSupplies, currentIndexQuery.data || 0),
-      ...QUERY_OPTIONS,
-      enabled: latestDateQuery.isSuccess && currentIndexQuery.isSuccess, // Only fetch when we've been able to get the latest date
-    },
-  );
+  const supplyQuery = useTokenSuppliesQueries("BackedSupply", subgraphUrls, tokenSupplyBaseFilter, earliestDate);
+
+  const supplyData = supplyQuery && Array.from(supplyQuery).length > 0 ? Array.from(supplyQuery)[0][1] : [];
+  return getOhmBackedSupply(supplyData, currentIndexQuery.data || 0);
 };
 
 export const useGOhmSyntheticSupply = (subgraphUrl?: string) => {

--- a/src/hooks/useTokenSupplyMetrics.ts
+++ b/src/hooks/useTokenSupplyMetrics.ts
@@ -7,46 +7,58 @@ import {
   getOhmFloatingSupply,
 } from "src/helpers/subgraph/TreasuryQueryHelper";
 import { SUBGRAPH_URLS } from "src/helpers/SubgraphUrlHelper";
-import { useCurrentIndex } from "src/hooks/useProtocolMetrics";
+import { useIndexOnDate } from "src/hooks/useProtocolMetrics";
 import { useTokenSuppliesQueries } from "src/hooks/useSubgraphTokenSupplies";
 
 export const useOhmCirculatingSupply = (subgraphUrls?: SUBGRAPH_URLS, earliestDate?: string | null): number => {
-  const currentIndexQuery = useCurrentIndex(subgraphUrls?.Ethereum);
   const [tokenSupplyBaseFilter] = useState<TokenSupply_Filter>({});
 
   const supplyQuery = useTokenSuppliesQueries("CirculatingSupply", subgraphUrls, tokenSupplyBaseFilter, earliestDate);
-
   const supplyData = supplyQuery && Array.from(supplyQuery).length > 0 ? Array.from(supplyQuery)[0][1] : [];
+  const latestDate: string = supplyData.length ? supplyData[0].date : "";
+
+  // Ensures that the index for the day is displayed. Otherwise metrics will be inconsistent.
+  const currentIndexQuery = useIndexOnDate(latestDate, subgraphUrls?.Ethereum);
+
   return getOhmCirculatingSupply(supplyData, currentIndexQuery.data || 0);
 };
 
 export const useOhmFloatingSupply = (subgraphUrls?: SUBGRAPH_URLS, earliestDate?: string | null): number => {
-  const currentIndexQuery = useCurrentIndex(subgraphUrls?.Ethereum);
   const [tokenSupplyBaseFilter] = useState<TokenSupply_Filter>({});
 
   const supplyQuery = useTokenSuppliesQueries("FloatingSupply", subgraphUrls, tokenSupplyBaseFilter, earliestDate);
-
   const supplyData = supplyQuery && Array.from(supplyQuery).length > 0 ? Array.from(supplyQuery)[0][1] : [];
+  const latestDate: string = supplyData.length ? supplyData[0].date : "";
+
+  // Ensures that the index for the day is displayed. Otherwise metrics will be inconsistent.
+  const currentIndexQuery = useIndexOnDate(latestDate, subgraphUrls?.Ethereum);
+
   return getOhmFloatingSupply(supplyData, currentIndexQuery.data || 0);
 };
 
 export const useOhmBackedSupply = (subgraphUrls?: SUBGRAPH_URLS, earliestDate?: string | null): number => {
-  const currentIndexQuery = useCurrentIndex(subgraphUrls?.Ethereum);
   const [tokenSupplyBaseFilter] = useState<TokenSupply_Filter>({});
 
   const supplyQuery = useTokenSuppliesQueries("BackedSupply", subgraphUrls, tokenSupplyBaseFilter, earliestDate);
-
   const supplyData = supplyQuery && Array.from(supplyQuery).length > 0 ? Array.from(supplyQuery)[0][1] : [];
+  const latestDate: string = supplyData.length ? supplyData[0].date : "";
+
+  // Ensures that the index for the day is displayed. Otherwise metrics will be inconsistent.
+  const currentIndexQuery = useIndexOnDate(latestDate, subgraphUrls?.Ethereum);
+
   return getOhmBackedSupply(supplyData, currentIndexQuery.data || 0);
 };
 
 export const useGOhmSyntheticSupply = (subgraphUrls?: SUBGRAPH_URLS, earliestDate?: string | null) => {
-  const currentIndexQuery = useCurrentIndex(subgraphUrls?.Ethereum);
   const [tokenSupplyBaseFilter] = useState<TokenSupply_Filter>({});
 
   const supplyQuery = useTokenSuppliesQueries("GOhmSyntheticSupply", subgraphUrls, tokenSupplyBaseFilter, earliestDate);
-
   const supplyData = supplyQuery && Array.from(supplyQuery).length > 0 ? Array.from(supplyQuery)[0][1] : [];
+  const latestDate: string = supplyData.length ? supplyData[0].date : "";
+
+  // Ensures that the index for the day is displayed. Otherwise metrics will be inconsistent.
+  const currentIndexQuery = useIndexOnDate(latestDate, subgraphUrls?.Ethereum);
+
   return getGOhmSyntheticSupply(
     currentIndexQuery.data || 0,
     getOhmFloatingSupply(supplyData, currentIndexQuery.data || 0),

--- a/src/hooks/useTokenSupplyMetrics.ts
+++ b/src/hooks/useTokenSupplyMetrics.ts
@@ -1,37 +1,42 @@
-import { useTokenSuppliesQuery } from "src/generated/graphql";
+import { useEffect, useState } from "react";
+import { TokenSupply_Filter, useTokenSuppliesQuery } from "src/generated/graphql";
 import { getDataSource } from "src/graphql/query";
 import {
   getOhmBackedSupply,
   getOhmCirculatingSupply,
   getOhmFloatingSupply,
 } from "src/helpers/subgraph/TreasuryQueryHelper";
-import { getSubgraphUrl } from "src/helpers/SubgraphUrlHelper";
-import { useTokenRecordsLatestBlock } from "src/hooks/useTokenRecordsMetrics";
+import { getSubgraphUrl, SUBGRAPH_URLS } from "src/helpers/SubgraphUrlHelper";
+import { useCurrentIndex } from "src/hooks/useProtocolMetrics";
+import { useTokenSuppliesQueries } from "src/hooks/useSubgraphTokenSupplies";
+import { useTokenRecordsLatestBlock, useTokenRecordsLatestRecord } from "src/hooks/useTokenRecordsMetrics";
 import { DEFAULT_RECORD_COUNT } from "src/views/TreasuryDashboard/components/Graph/Constants";
 
 const QUERY_OPTIONS = { refetchInterval: 60000 }; // Refresh every 60 seconds
 
-export const useOhmCirculatingSupply = (subgraphUrl?: string) => {
-  const latestDateQuery = useTokenRecordsLatestBlock(subgraphUrl);
-  const endpoint = subgraphUrl || getSubgraphUrl();
+export const useOhmCirculatingSupply = (subgraphUrls?: SUBGRAPH_URLS): number => {
+  const { data } = useTokenRecordsLatestRecord(subgraphUrls?.Ethereum);
+  const currentIndexQuery = useCurrentIndex(subgraphUrls?.Ethereum);
+  const [tokenSupplyBaseFilter, setTokenSupplyBaseFilter] = useState<TokenSupply_Filter>({});
 
-  return useTokenSuppliesQuery(
-    getDataSource(endpoint),
-    {
-      recordCount: DEFAULT_RECORD_COUNT,
-      filter: { block: latestDateQuery.data },
-      endpoint: endpoint,
-    },
-    {
-      select: data => getOhmCirculatingSupply(data.tokenSupplies),
-      ...QUERY_OPTIONS,
-      enabled: latestDateQuery.isSuccess, // Only fetch when we've been able to get the latest date
-    },
-  );
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+
+    setTokenSupplyBaseFilter({ date: data.date });
+  }, [data]);
+
+  const supplyQuery = useTokenSuppliesQueries("CirculatingSupply", subgraphUrls, tokenSupplyBaseFilter, null);
+  console.log(`CirculatingSupply results: ${JSON.stringify(supplyQuery)}`);
+
+  const supplyData = supplyQuery && Array.from(supplyQuery).length > 0 ? Array.from(supplyQuery)[0][1] : [];
+  return getOhmCirculatingSupply(supplyData, currentIndexQuery.data || 0);
 };
 
 export const useOhmFloatingSupply = (subgraphUrl?: string) => {
   const latestDateQuery = useTokenRecordsLatestBlock(subgraphUrl);
+  const currentIndexQuery = useCurrentIndex(subgraphUrl);
   const endpoint = subgraphUrl || getSubgraphUrl();
 
   return useTokenSuppliesQuery(
@@ -42,15 +47,16 @@ export const useOhmFloatingSupply = (subgraphUrl?: string) => {
       endpoint: endpoint,
     },
     {
-      select: data => getOhmFloatingSupply(data.tokenSupplies),
+      select: data => getOhmFloatingSupply(data.tokenSupplies, currentIndexQuery.data || 0),
       ...QUERY_OPTIONS,
-      enabled: latestDateQuery.isSuccess, // Only fetch when we've been able to get the latest date
+      enabled: latestDateQuery.isSuccess && currentIndexQuery.isSuccess, // Only fetch when we've been able to get the latest date
     },
   );
 };
 
 export const useOhmBackedSupply = (subgraphUrl?: string) => {
   const latestDateQuery = useTokenRecordsLatestBlock(subgraphUrl);
+  const currentIndexQuery = useCurrentIndex(subgraphUrl);
   const endpoint = subgraphUrl || getSubgraphUrl();
 
   return useTokenSuppliesQuery(
@@ -61,15 +67,16 @@ export const useOhmBackedSupply = (subgraphUrl?: string) => {
       endpoint: endpoint,
     },
     {
-      select: data => getOhmBackedSupply(data.tokenSupplies),
+      select: data => getOhmBackedSupply(data.tokenSupplies, currentIndexQuery.data || 0),
       ...QUERY_OPTIONS,
-      enabled: latestDateQuery.isSuccess, // Only fetch when we've been able to get the latest date
+      enabled: latestDateQuery.isSuccess && currentIndexQuery.isSuccess, // Only fetch when we've been able to get the latest date
     },
   );
 };
 
 export const useGOhmSyntheticSupply = (subgraphUrl?: string) => {
   const latestDateQuery = useTokenRecordsLatestBlock(subgraphUrl);
+  const currentIndexQuery = useCurrentIndex(subgraphUrl);
   const endpoint = subgraphUrl || getSubgraphUrl();
 
   return useTokenSuppliesQuery(
@@ -80,9 +87,9 @@ export const useGOhmSyntheticSupply = (subgraphUrl?: string) => {
       endpoint: endpoint,
     },
     {
-      select: data => getOhmFloatingSupply(data.tokenSupplies),
+      select: data => getOhmFloatingSupply(data.tokenSupplies, currentIndexQuery.data || 0),
       ...QUERY_OPTIONS,
-      enabled: latestDateQuery.isSuccess, // Only fetch when we've been able to get the latest date
+      enabled: latestDateQuery.isSuccess && currentIndexQuery.isSuccess, // Only fetch when we've been able to get the latest date
     },
   );
 };

--- a/src/hooks/useTreasuryMetrics.ts
+++ b/src/hooks/useTreasuryMetrics.ts
@@ -27,6 +27,7 @@ const QUERY_OPTIONS = { refetchInterval: 60000 }; // Refresh every 60 seconds
 export const useMarketCap = (subgraphUrl?: string) => {
   const ohmPriceQuery = useOhmPrice(subgraphUrl);
   const latestDateQuery = useTokenRecordsLatestBlock(subgraphUrl);
+  const currentIndexQuery = useCurrentIndex(subgraphUrl);
   const endpoint = subgraphUrl || getSubgraphUrl();
 
   return useTokenSuppliesQuery(
@@ -37,9 +38,10 @@ export const useMarketCap = (subgraphUrl?: string) => {
       endpoint: endpoint,
     },
     {
-      select: data => getOhmCirculatingSupply(data.tokenSupplies) * (ohmPriceQuery.data || 0),
+      select: data =>
+        getOhmCirculatingSupply(data.tokenSupplies, currentIndexQuery.data || 0) * (ohmPriceQuery.data || 0),
       ...QUERY_OPTIONS,
-      enabled: latestDateQuery.isSuccess && ohmPriceQuery.isSuccess, // Only fetch when we've been able to get the latest date and price
+      enabled: latestDateQuery.isSuccess && currentIndexQuery.isSuccess && ohmPriceQuery.isSuccess, // Only fetch when we've been able to get the latest date and price
     },
   );
 };
@@ -52,6 +54,7 @@ export const useMarketCap = (subgraphUrl?: string) => {
  */
 export const useLiquidBackingPerOhmBacked = (subgraphUrls?: SUBGRAPH_URLS): UseQueryResult<number, unknown> => {
   const latestDateQuery = useTokenRecordsLatestRecord(subgraphUrls?.Ethereum);
+  const currentIndexQuery = useCurrentIndex(subgraphUrls?.Ethereum);
   const liquidBackingQuery = useTreasuryLiquidValue(
     !latestDateQuery.data ? undefined : latestDateQuery.data.date,
     subgraphUrls,
@@ -66,9 +69,9 @@ export const useLiquidBackingPerOhmBacked = (subgraphUrls?: SUBGRAPH_URLS): UseQ
       endpoint: endpoint,
     },
     {
-      select: data => getLiquidBackingPerOhmBacked(liquidBackingQuery, data.tokenSupplies),
+      select: data => getLiquidBackingPerOhmBacked(liquidBackingQuery, data.tokenSupplies, currentIndexQuery.data || 0),
       ...QUERY_OPTIONS,
-      enabled: latestDateQuery.isSuccess, // Only fetch when we've been able to get the latest date
+      enabled: latestDateQuery.isSuccess && currentIndexQuery.isSuccess, // Only fetch when we've been able to get the latest date
     },
   );
 };
@@ -81,6 +84,7 @@ export const useLiquidBackingPerOhmBacked = (subgraphUrls?: SUBGRAPH_URLS): UseQ
  */
 export const useLiquidBackingPerOhmFloating = (subgraphUrls?: SUBGRAPH_URLS): UseQueryResult<number, unknown> => {
   const latestDateQuery = useTokenRecordsLatestRecord(subgraphUrls?.Ethereum);
+  const currentIndexQuery = useCurrentIndex(subgraphUrls?.Ethereum);
   const liquidBackingQuery = useTreasuryLiquidValue(
     !latestDateQuery.data ? undefined : latestDateQuery.data.date,
     subgraphUrls,
@@ -95,9 +99,10 @@ export const useLiquidBackingPerOhmFloating = (subgraphUrls?: SUBGRAPH_URLS): Us
       endpoint: endpoint,
     },
     {
-      select: data => getLiquidBackingPerOhmFloating(liquidBackingQuery, data.tokenSupplies),
+      select: data =>
+        getLiquidBackingPerOhmFloating(liquidBackingQuery, data.tokenSupplies, currentIndexQuery.data || 0),
       ...QUERY_OPTIONS,
-      enabled: latestDateQuery.isSuccess, // Only fetch when we've been able to get the latest date
+      enabled: latestDateQuery.isSuccess && currentIndexQuery.isSuccess, // Only fetch when we've been able to get the latest date
     },
   );
 };

--- a/src/hooks/useTreasuryMetrics.ts
+++ b/src/hooks/useTreasuryMetrics.ts
@@ -1,104 +1,132 @@
 import { useState } from "react";
-import { TokenSupply_Filter } from "src/generated/graphql";
+import { TokenRecord_Filter, TokenSupply_Filter } from "src/generated/graphql";
 import {
+  getGOhmSyntheticSupply,
   getLiquidBackingPerGOhmSynthetic,
   getLiquidBackingPerOhmBacked,
   getLiquidBackingPerOhmFloating,
+  getOhmBackedSupply,
+  getOhmFloatingSupply,
+  getTreasuryAssetValue,
 } from "src/helpers/subgraph/TreasuryQueryHelper";
 import { SUBGRAPH_URLS } from "src/helpers/SubgraphUrlHelper";
-import { useCurrentIndex, useOhmPrice } from "src/hooks/useProtocolMetrics";
+import { useIndexOnDate, useOhmPrice } from "src/hooks/useProtocolMetrics";
+import { useTokenRecordsQueries } from "src/hooks/useSubgraphTokenRecords";
 import { useTokenSuppliesQueries } from "src/hooks/useSubgraphTokenSupplies";
-import { useTokenRecordsLatestRecord, useTreasuryLiquidValue } from "src/hooks/useTokenRecordsMetrics";
 import { useOhmCirculatingSupply } from "src/hooks/useTokenSupplyMetrics";
 
 /**
  * OHM price * circulating supply
  *
  * @param subgraphUrl
- * @returns
+ * @returns [marketCap, ohmPrice, circulatingSupply]
  */
-export const useMarketCap = (subgraphUrls?: SUBGRAPH_URLS, earliestDate?: string | null): number => {
+export const useMarketCap = (subgraphUrls?: SUBGRAPH_URLS, earliestDate?: string | null): [number, number, number] => {
   const ohmPriceQuery = useOhmPrice(subgraphUrls?.Ethereum);
-  return useOhmCirculatingSupply(subgraphUrls, earliestDate) * (ohmPriceQuery.data || 0);
+  const ohmPrice = ohmPriceQuery.data || 0;
+  const circulatingSupply = useOhmCirculatingSupply(subgraphUrls, earliestDate);
+  return [circulatingSupply * ohmPrice, ohmPrice, circulatingSupply];
 };
 
 /**
  * Liquid backing value / OHM backed supply
  *
  * @param subgraphUrl
- * @returns react-query result wrapping a number representing the liquid backing per OHM
+ * @returns [liquidBackingPerBackedOhm, liquidBacking, backedOhm]
  */
-export const useLiquidBackingPerOhmBacked = (subgraphUrls?: SUBGRAPH_URLS, earliestDate?: string | null): number => {
-  const currentIndexQuery = useCurrentIndex(subgraphUrls?.Ethereum);
+export const useLiquidBackingPerOhmBacked = (
+  subgraphUrls?: SUBGRAPH_URLS,
+  earliestDate?: string | null,
+): [number, number, number] => {
+  const chartName = "LiquidBackingPerOhmBacked";
   const [tokenSupplyBaseFilter] = useState<TokenSupply_Filter>({});
+  const [tokenRecordBaseFilter] = useState<TokenRecord_Filter>({});
 
-  const supplyQuery = useTokenSuppliesQueries(
-    "LiquidBackingPerOhmBacked",
-    subgraphUrls,
-    tokenSupplyBaseFilter,
-    earliestDate,
-  );
+  const supplyQuery = useTokenSuppliesQueries(chartName, subgraphUrls, tokenSupplyBaseFilter, earliestDate);
   const supplyData = supplyQuery && Array.from(supplyQuery).length > 0 ? Array.from(supplyQuery)[0][1] : [];
+  const latestDate: string = supplyData.length ? supplyData[0].date : "";
 
-  const latestDateQuery = useTokenRecordsLatestRecord(subgraphUrls?.Ethereum);
-  const liquidBackingQuery = useTreasuryLiquidValue(
-    !latestDateQuery.data ? undefined : latestDateQuery.data.date,
-    subgraphUrls,
-  );
+  const recordQuery = useTokenRecordsQueries(chartName, subgraphUrls, tokenRecordBaseFilter, earliestDate);
+  const recordData = recordQuery && Array.from(recordQuery).length > 0 ? Array.from(recordQuery)[0][1] : [];
+  const liquidBackingQuery: number = getTreasuryAssetValue(recordData, true);
 
-  return getLiquidBackingPerOhmBacked(liquidBackingQuery, supplyData, currentIndexQuery.data || 0);
+  // Ensures that the index for the day is displayed. Otherwise metrics will be inconsistent.
+  const latestIndexQuery = useIndexOnDate(latestDate, subgraphUrls?.Ethereum);
+  const latestIndex = latestIndexQuery.data || 0;
+
+  return [
+    getLiquidBackingPerOhmBacked(liquidBackingQuery, supplyData, latestIndex),
+    liquidBackingQuery,
+    getOhmBackedSupply(supplyData, latestIndex),
+  ];
 };
 
 /**
  * Liquid backing value / OHM floating supply
  *
  * @param subgraphUrl
- * @returns react-query result wrapping a number representing the liquid backing per OHM
+ * @returns [liquidBackingPerFloatingOhm, liquidBacking, floatingOhm]
  */
-export const useLiquidBackingPerOhmFloating = (subgraphUrls?: SUBGRAPH_URLS, earliestDate?: string | null): number => {
-  const currentIndexQuery = useCurrentIndex(subgraphUrls?.Ethereum);
+export const useLiquidBackingPerOhmFloating = (
+  subgraphUrls?: SUBGRAPH_URLS,
+  earliestDate?: string | null,
+): [number, number, number] => {
+  const chartName = "LiquidBackingPerOhmFloating";
   const [tokenSupplyBaseFilter] = useState<TokenSupply_Filter>({});
+  const [tokenRecordBaseFilter] = useState<TokenRecord_Filter>({});
 
-  const supplyQuery = useTokenSuppliesQueries(
-    "LiquidBackingPerOhmFloating",
-    subgraphUrls,
-    tokenSupplyBaseFilter,
-    earliestDate,
-  );
+  const supplyQuery = useTokenSuppliesQueries(chartName, subgraphUrls, tokenSupplyBaseFilter, earliestDate);
   const supplyData = supplyQuery && Array.from(supplyQuery).length > 0 ? Array.from(supplyQuery)[0][1] : [];
+  const latestDate: string = supplyData.length ? supplyData[0].date : "";
 
-  const latestDateQuery = useTokenRecordsLatestRecord(subgraphUrls?.Ethereum);
-  const liquidBackingQuery = useTreasuryLiquidValue(
-    !latestDateQuery.data ? undefined : latestDateQuery.data.date,
-    subgraphUrls,
-  );
+  const recordQuery = useTokenRecordsQueries(chartName, subgraphUrls, tokenRecordBaseFilter, earliestDate);
+  const recordData = recordQuery && Array.from(recordQuery).length > 0 ? Array.from(recordQuery)[0][1] : [];
+  const liquidBackingQuery: number = getTreasuryAssetValue(recordData, true);
 
-  return getLiquidBackingPerOhmFloating(liquidBackingQuery, supplyData, currentIndexQuery.data || 0);
+  // Ensures that the index for the day is displayed. Otherwise metrics will be inconsistent.
+  const latestIndexQuery = useIndexOnDate(latestDate, subgraphUrls?.Ethereum);
+  const latestIndex = latestIndexQuery.data || 0;
+
+  return [
+    getLiquidBackingPerOhmFloating(liquidBackingQuery, supplyData, latestIndex),
+    liquidBackingQuery,
+    getOhmFloatingSupply(supplyData, latestIndex),
+  ];
 };
 
 /**
  * Liquid backing value / gOHM synthetic supply
  *
  * @param subgraphUrl
- * @returns react-query result wrapping a number representing the liquid backing per gOHM
+ * @returns [liquidBackingPerGOhm, liquidBacking, gOHMSupply, latestIndex, ohmFloatingSupply]
  */
-export const useLiquidBackingPerGOhm = (subgraphUrls?: SUBGRAPH_URLS, earliestDate?: string | null): number => {
-  const currentIndexQuery = useCurrentIndex(subgraphUrls?.Ethereum);
+export const useLiquidBackingPerGOhm = (
+  subgraphUrls?: SUBGRAPH_URLS,
+  earliestDate?: string | null,
+): [number, number, number, number, number] => {
+  const chartName = "LiquidBackingPerGOhm";
   const [tokenSupplyBaseFilter] = useState<TokenSupply_Filter>({});
+  const [tokenRecordBaseFilter] = useState<TokenRecord_Filter>({});
 
-  const supplyQuery = useTokenSuppliesQueries(
-    "LiquidBackingPerGOhm",
-    subgraphUrls,
-    tokenSupplyBaseFilter,
-    earliestDate,
-  );
+  const supplyQuery = useTokenSuppliesQueries(chartName, subgraphUrls, tokenSupplyBaseFilter, earliestDate);
   const supplyData = supplyQuery && Array.from(supplyQuery).length > 0 ? Array.from(supplyQuery)[0][1] : [];
+  const latestDate: string = supplyData.length ? supplyData[0].date : "";
 
-  const latestDateQuery = useTokenRecordsLatestRecord(subgraphUrls?.Ethereum);
-  const liquidBackingQuery = useTreasuryLiquidValue(
-    !latestDateQuery.data ? undefined : latestDateQuery.data.date,
-    subgraphUrls,
-  );
+  const recordQuery = useTokenRecordsQueries(chartName, subgraphUrls, tokenRecordBaseFilter, earliestDate);
+  const recordData = recordQuery && Array.from(recordQuery).length > 0 ? Array.from(recordQuery)[0][1] : [];
+  const liquidBackingQuery: number = getTreasuryAssetValue(recordData, true);
 
-  return getLiquidBackingPerGOhmSynthetic(liquidBackingQuery, currentIndexQuery.data || 0, supplyData);
+  // Ensures that the index for the day is displayed. Otherwise metrics will be inconsistent.
+  const latestIndexQuery = useIndexOnDate(latestDate, subgraphUrls?.Ethereum);
+  const latestIndex = latestIndexQuery.data || 0;
+
+  const ohmFloatingSupply = getOhmFloatingSupply(supplyData, latestIndex);
+
+  return [
+    getLiquidBackingPerGOhmSynthetic(liquidBackingQuery, latestIndex, supplyData),
+    liquidBackingQuery,
+    getGOhmSyntheticSupply(latestIndex, ohmFloatingSupply),
+    latestIndex,
+    ohmFloatingSupply,
+  ];
 };

--- a/src/views/TreasuryDashboard/components/Graph/LiquidBackingComparisonGraph.tsx
+++ b/src/views/TreasuryDashboard/components/Graph/LiquidBackingComparisonGraph.tsx
@@ -16,7 +16,7 @@ import {
 } from "src/helpers/subgraph/TreasuryQueryHelper";
 import { useProtocolMetricsQuery } from "src/hooks/useSubgraphProtocolMetrics";
 import { useTokenRecordsQueries } from "src/hooks/useSubgraphTokenRecords";
-import { useTokenSuppliesQuery } from "src/hooks/useSubgraphTokenSupplies";
+import { useTokenSuppliesQueries } from "src/hooks/useSubgraphTokenSupplies";
 import {
   DEFAULT_BULLETPOINT_COLOURS,
   DEFAULT_COLORS,
@@ -51,9 +51,9 @@ export const LiquidBackingPerOhmComparisonGraph = ({
     subgraphDaysOffset,
   );
 
-  const tokenSupplyResults = useTokenSuppliesQuery(
+  const tokenSupplyResults = useTokenSuppliesQueries(
     chartName,
-    subgraphUrls.Ethereum,
+    subgraphUrls,
     baseFilter,
     earliestDate,
     subgraphDaysOffset,
@@ -131,7 +131,11 @@ export const LiquidBackingPerOhmComparisonGraph = ({
         block: latestTokenRecord.block,
         gOhmPrice: latestProtocolMetric.gOhmPrice,
         ohmPrice: latestProtocolMetric.ohmPrice,
-        liquidBackingPerBackedOhm: getLiquidBackingPerOhmBacked(liquidBacking, currentTokenSupplies),
+        liquidBackingPerBackedOhm: getLiquidBackingPerOhmBacked(
+          liquidBacking,
+          currentTokenSupplies,
+          latestProtocolMetric.currentIndex,
+        ),
         liquidBackingPerGOhmSynthetic: getLiquidBackingPerGOhmSynthetic(
           liquidBacking,
           latestProtocolMetric.currentIndex,

--- a/src/views/TreasuryDashboard/components/Graph/LiquidBackingComparisonGraph.tsx
+++ b/src/views/TreasuryDashboard/components/Graph/LiquidBackingComparisonGraph.tsx
@@ -206,8 +206,16 @@ export const LiquidBackingPerOhmComparisonGraph = ({
     setHeaderText(isActiveTokenOHM ? `OHM Backing` : `gOHM Backing`);
     setTooltipText(
       isActiveTokenOHM
-        ? `This chart compares the price of OHM against its liquid backing per backed OHM. When OHM is above liquid backing, the difference will be highlighted in green. Conversely, when OHM is below liquid backing, the difference will be highlighted in red.\n\nThe values are determined at the time a snapshot is recorded (every 8 hours). As a result, they will lag the real-time market rates.`
-        : `This chart compares the price of gOHM against its liquid backing per backed gOHM. When gOHM is above liquid backing, the difference will be highlighted in green. Conversely, when gOHM is below liquid backing, the difference will be highlighted in red.\n\nThe values are determined at the time a snapshot is recorded (every 8 hours). As a result, they will lag the real-time market rates.`,
+        ? `This chart compares the price of OHM against its liquid backing per backed OHM. When OHM is above liquid backing, the difference will be highlighted in green. Conversely, when OHM is below liquid backing, the difference will be highlighted in red.
+        
+The values are determined at the time a snapshot is recorded (every 8 hours). As a result, they will lag the real-time market rates.
+
+As data is sourced from multiple chains that may have different snapshot times, the data shown represents the snapshots for which all data has been recorded. As a result, the data may lag.`
+        : `This chart compares the price of gOHM against its liquid backing per backed gOHM. When gOHM is above liquid backing, the difference will be highlighted in green. Conversely, when gOHM is below liquid backing, the difference will be highlighted in red.
+
+The values are determined at the time a snapshot is recorded (every 8 hours). As a result, they will lag the real-time market rates.
+
+As data is sourced from multiple chains that may have different snapshot times, the data shown represents the snapshots for which all data has been recorded. As a result, the data may lag.`,
     );
   }, [isActiveTokenOHM]);
 

--- a/src/views/TreasuryDashboard/components/Graph/LiquidBackingComparisonGraph.tsx
+++ b/src/views/TreasuryDashboard/components/Graph/LiquidBackingComparisonGraph.tsx
@@ -206,8 +206,8 @@ export const LiquidBackingPerOhmComparisonGraph = ({
     setHeaderText(isActiveTokenOHM ? `OHM Backing` : `gOHM Backing`);
     setTooltipText(
       isActiveTokenOHM
-        ? `This chart compares the price of OHM against its liquid backing. When OHM is above liquid backing, the difference will be highlighted in green. Conversely, when OHM is below liquid backing, the difference will be highlighted in red.\n\nThe values are determined at the time a snapshot is recorded (every 8 hours). As a result, they will lag the real-time market rates.`
-        : `This chart compares the price of gOHM against its liquid backing. When gOHM is above liquid backing, the difference will be highlighted in green. Conversely, when gOHM is below liquid backing, the difference will be highlighted in red.\n\nThe values are determined at the time a snapshot is recorded (every 8 hours). As a result, they will lag the real-time market rates.`,
+        ? `This chart compares the price of OHM against its liquid backing per backed OHM. When OHM is above liquid backing, the difference will be highlighted in green. Conversely, when OHM is below liquid backing, the difference will be highlighted in red.\n\nThe values are determined at the time a snapshot is recorded (every 8 hours). As a result, they will lag the real-time market rates.`
+        : `This chart compares the price of gOHM against its liquid backing per backed gOHM. When gOHM is above liquid backing, the difference will be highlighted in green. Conversely, when gOHM is below liquid backing, the difference will be highlighted in red.\n\nThe values are determined at the time a snapshot is recorded (every 8 hours). As a result, they will lag the real-time market rates.`,
     );
   }, [isActiveTokenOHM]);
 

--- a/src/views/TreasuryDashboard/components/Graph/OhmSupplyGraph.tsx
+++ b/src/views/TreasuryDashboard/components/Graph/OhmSupplyGraph.tsx
@@ -104,8 +104,10 @@ export const OhmSupplyGraph = ({ subgraphUrls, earliestDate, subgraphDaysOffset 
        */
       const dayProtocolMetricsResults = protocolMetricsResults.get(dateString);
       if (!dayProtocolMetricsResults || dayProtocolMetricsResults.length == 0) {
-        throw new Error(`No protocol metrics found for ${dateString}`);
+        console.log(`${chartName}: No protocol metrics found for ${dateString}. Skipping.`);
+        return;
       }
+
       const ohmIndex = dayProtocolMetricsResults[0].currentIndex;
 
       const earliestTimestamp = getLatestTimestamp(dateSupplyValues);

--- a/src/views/TreasuryDashboard/components/Graph/OhmSupplyGraph.tsx
+++ b/src/views/TreasuryDashboard/components/Graph/OhmSupplyGraph.tsx
@@ -2,7 +2,7 @@ import { useTheme } from "@mui/material/styles";
 import { useEffect, useMemo, useState } from "react";
 import Chart from "src/components/Chart/Chart";
 import { ChartType, DataFormat } from "src/components/Chart/Constants";
-import { TokenSuppliesDocument, TokenSupply_Filter } from "src/generated/graphql";
+import { ProtocolMetric_Filter, TokenSuppliesDocument, TokenSupply_Filter } from "src/generated/graphql";
 import {
   getBulletpointStylesMap,
   getCategoriesMap,
@@ -23,7 +23,8 @@ import {
   getProtocolOwnedLiquiditySupply,
   getTreasurySupply,
 } from "src/helpers/subgraph/TreasuryQueryHelper";
-import { useTokenSuppliesQuery } from "src/hooks/useSubgraphTokenSupplies";
+import { useProtocolMetricsQuery } from "src/hooks/useSubgraphProtocolMetrics";
+import { useTokenSuppliesQueries } from "src/hooks/useSubgraphTokenSupplies";
 import {
   DEFAULT_BULLETPOINT_COLOURS,
   DEFAULT_COLORS,
@@ -44,12 +45,20 @@ export const OhmSupplyGraph = ({ subgraphUrls, earliestDate, subgraphDaysOffset 
   const theme = useTheme();
 
   const chartName = "OhmSupplyGraph";
-  const [baseFilter] = useState<TokenSupply_Filter>({});
+  const [tokenSupplyBaseFilter] = useState<TokenSupply_Filter>({});
+  const [protocolMetricsBaseFilter] = useState<ProtocolMetric_Filter>({});
 
-  const tokenSupplyResults = useTokenSuppliesQuery(
+  const tokenSupplyResults = useTokenSuppliesQueries(
+    chartName,
+    subgraphUrls,
+    tokenSupplyBaseFilter,
+    earliestDate,
+    subgraphDaysOffset,
+  );
+  const protocolMetricsResults = useProtocolMetricsQuery(
     chartName,
     subgraphUrls.Ethereum,
-    baseFilter,
+    protocolMetricsBaseFilter,
     earliestDate,
     subgraphDaysOffset,
   );
@@ -81,13 +90,24 @@ export const OhmSupplyGraph = ({ subgraphUrls, earliestDate, subgraphDaysOffset 
   };
   const [byDateOhmSupply, setByDateOhmSupply] = useState<OhmSupplyComparison[]>([]);
   useMemo(() => {
-    if (!tokenSupplyResults) {
+    if (!tokenSupplyResults || !protocolMetricsResults) {
       return;
     }
 
     console.debug(`${chartName}: rebuilding by date metrics`);
     const tempByDateOhmSupply: OhmSupplyComparison[] = [];
     tokenSupplyResults.forEach((dateSupplyValues, dateString) => {
+      /**
+       * Non-Ethereum mainnet chains do not have the OHM index, so they return
+       * TokenSupply results in terms of gOHM. We supply the OHM index from the
+       * protocol metrics query to convert the gOHM values to OHM.
+       */
+      const dayProtocolMetricsResults = protocolMetricsResults.get(dateString);
+      if (!dayProtocolMetricsResults || dayProtocolMetricsResults.length == 0) {
+        throw new Error(`No protocol metrics found for ${dateString}`);
+      }
+      const ohmIndex = dayProtocolMetricsResults[0].currentIndex;
+
       const earliestTimestamp = getLatestTimestamp(dateSupplyValues);
       const latestSupplyValue = dateSupplyValues[0];
 
@@ -95,26 +115,26 @@ export const OhmSupplyGraph = ({ subgraphUrls, earliestDate, subgraphDaysOffset 
         date: dateString,
         timestamp: earliestTimestamp,
         block: latestSupplyValue.block,
-        circulatingSupply: getOhmCirculatingSupply(dateSupplyValues),
-        floatingSupply: getOhmFloatingSupply(dateSupplyValues),
-        backedSupply: getOhmBackedSupply(dateSupplyValues),
-        totalSupply: getOhmTotalSupply(dateSupplyValues),
-        protocolOwnedLiquidity: getProtocolOwnedLiquiditySupply(dateSupplyValues),
-        treasury: getTreasurySupply(dateSupplyValues),
-        migrationOffset: getMigrationOffsetSupply(dateSupplyValues),
-        bondDeposits: getBondDepositsSupply(dateSupplyValues),
-        bondVestingTokens: getBondVestingTokensSupply(dateSupplyValues),
-        bondPreminted: getBondPremintedSupply(dateSupplyValues),
-        external: getExternalSupply(dateSupplyValues),
-        lending: getLendingSupply(dateSupplyValues),
-        boostedLiquidityVault: getBoostedLiquidityVaultSupply(dateSupplyValues),
+        circulatingSupply: getOhmCirculatingSupply(dateSupplyValues, ohmIndex),
+        floatingSupply: getOhmFloatingSupply(dateSupplyValues, ohmIndex),
+        backedSupply: getOhmBackedSupply(dateSupplyValues, ohmIndex),
+        totalSupply: getOhmTotalSupply(dateSupplyValues, ohmIndex),
+        protocolOwnedLiquidity: getProtocolOwnedLiquiditySupply(dateSupplyValues, ohmIndex),
+        treasury: getTreasurySupply(dateSupplyValues, ohmIndex),
+        migrationOffset: getMigrationOffsetSupply(dateSupplyValues, ohmIndex),
+        bondDeposits: getBondDepositsSupply(dateSupplyValues, ohmIndex),
+        bondVestingTokens: getBondVestingTokensSupply(dateSupplyValues, ohmIndex),
+        bondPreminted: getBondPremintedSupply(dateSupplyValues, ohmIndex),
+        external: getExternalSupply(dateSupplyValues, ohmIndex),
+        lending: getLendingSupply(dateSupplyValues, ohmIndex),
+        boostedLiquidityVault: getBoostedLiquidityVaultSupply(dateSupplyValues, ohmIndex),
       };
 
       tempByDateOhmSupply.push(dateOhmSupply);
     });
 
     setByDateOhmSupply(tempByDateOhmSupply);
-  }, [tokenSupplyResults]);
+  }, [tokenSupplyResults, protocolMetricsResults]);
 
   // Handle parameter changes
   useEffect(() => {

--- a/src/views/TreasuryDashboard/components/Metric/Metric.tsx
+++ b/src/views/TreasuryDashboard/components/Metric/Metric.tsx
@@ -119,8 +119,8 @@ export const GOhmCirculatingSupply: React.FC<AbstractedMetricProps> = props => {
 };
 
 export const BackingPerOHM: React.FC<AbstractedMetricProps & MetricSubgraphProps> = props => {
-  const { data: backedSupply } = useOhmBackedSupply(props.subgraphUrl);
-  const { data: liquidBackingPerOhmBacked } = useLiquidBackingPerOhmBacked(props.subgraphUrls);
+  const backedSupply = useOhmBackedSupply(props.subgraphUrls, props.earliestDate);
+  const liquidBackingPerOhmBacked: number = useLiquidBackingPerOhmBacked(props.subgraphUrls, props.earliestDate);
 
   // We include floating supply in the tooltip, as it is not displayed as a separate metric anywhere else
   const tooltip = `Liquid backing is divided by backed supply of OHM to give liquid backing per OHM.\n\nBacked supply (${
@@ -236,7 +236,7 @@ export const StakingAPY: React.FC<AbstractedMetricProps> = props => {
 
 export const TreasuryBalance: React.FC<AbstractedMetricProps & MetricSubgraphProps> = props => {
   const latestDateQuery = useTokenRecordsLatestRecord(props.subgraphUrls?.Ethereum);
-  const liquidBackingQuery = useTreasuryMarketValue(
+  const marketValueQuery = useTreasuryMarketValue(
     !latestDateQuery.data ? undefined : latestDateQuery.data.date,
     props.subgraphUrls,
   );
@@ -246,7 +246,7 @@ export const TreasuryBalance: React.FC<AbstractedMetricProps & MetricSubgraphPro
     label: `Treasury Balance`,
   };
 
-  if (liquidBackingQuery) _props.metric = formatCurrency(liquidBackingQuery);
+  if (marketValueQuery) _props.metric = formatCurrency(marketValueQuery);
   else _props.isLoading = true;
 
   return <Metric {..._props} />;

--- a/src/views/TreasuryDashboard/components/Metric/Metric.tsx
+++ b/src/views/TreasuryDashboard/components/Metric/Metric.tsx
@@ -23,7 +23,7 @@ type MetricProps = PropsOf<typeof Metric>;
 export type AbstractedMetricProps = Omit<MetricProps, "metric" | "label" | "tooltip" | "isLoading">;
 
 export const MarketCap: React.FC<AbstractedMetricProps & MetricSubgraphProps> = props => {
-  const { data: marketCap } = useMarketCap(props.subgraphUrl);
+  const marketCap = useMarketCap(props.subgraphUrls, props.earliestDate);
   const _props: MetricProps = {
     ...props,
     label: `OHM Market Cap`,
@@ -140,7 +140,7 @@ export const BackingPerOHM: React.FC<AbstractedMetricProps & MetricSubgraphProps
 };
 
 export const BackingPerGOHM: React.FC<AbstractedMetricProps & MetricSubgraphProps> = props => {
-  const { data: liquidBackingPerGOhmCirculating } = useLiquidBackingPerGOhm(props.subgraphUrls);
+  const liquidBackingPerGOhmCirculating = useLiquidBackingPerGOhm(props.subgraphUrls, props.earliestDate);
 
   const tooltip = `Liquid backing per gOHM is synthetically calculated as liquid backing multiplied by the current index and divided by OHM floating supply.`;
 

--- a/src/views/TreasuryDashboard/components/Metric/Metric.tsx
+++ b/src/views/TreasuryDashboard/components/Metric/Metric.tsx
@@ -93,7 +93,7 @@ export const SOHMPrice: React.FC<AbstractedMetricProps> = props => {
 
 export const OhmCirculatingSupply: React.FC<AbstractedMetricProps & MetricSubgraphProps> = props => {
   const { data: totalSupply } = useOhmTotalSupply(props.subgraphUrl);
-  const { data: circSupply } = useOhmCirculatingSupply(props.subgraphUrl);
+  const circSupply = useOhmCirculatingSupply(props.subgraphUrls);
   const _props: MetricProps = {
     ...props,
     label: `OHM Circulating Supply / Total`,

--- a/src/views/TreasuryDashboard/components/Metric/Metric.tsx
+++ b/src/views/TreasuryDashboard/components/Metric/Metric.tsx
@@ -146,8 +146,10 @@ Backed supply is the quantity of outstanding OHM that is backed by assets in the
 };
 
 export const BackingPerGOHM: React.FC<AbstractedMetricProps & MetricSubgraphProps> = props => {
-  const [liquidBackingPerGOhmCirculating, liquidBacking, gOhmSupply, latestIndex, ohmFloatingSupply] =
-    useLiquidBackingPerGOhm(props.subgraphUrls, props.earliestDate);
+  const [liquidBackingPerGOhmCirculating, liquidBacking, , latestIndex, ohmFloatingSupply] = useLiquidBackingPerGOhm(
+    props.subgraphUrls,
+    props.earliestDate,
+  );
 
   const tooltip = `Liquid backing per gOHM is calculated as liquid backing (${formatCurrencyOrLoading(
     liquidBacking,

--- a/src/views/TreasuryDashboard/components/Metric/Metric.tsx
+++ b/src/views/TreasuryDashboard/components/Metric/Metric.tsx
@@ -29,9 +29,9 @@ export const MarketCap: React.FC<AbstractedMetricProps & MetricSubgraphProps> = 
     label: `OHM Market Cap`,
     tooltip: `Market capitalization is the dollar value of the outstanding OHM tokens. It is calculated here as the price of OHM multiplied by the circulating supply. 
     
-    As the displayed OHM price is rounded to 2 decimal places, a manual calculation using the displayed values is likely to slightly differ from the reported market cap. The reported market cap is accurate, as it uses the unrounded price of OHM.
+As the displayed OHM price is rounded to 2 decimal places, a manual calculation using the displayed values is likely to slightly differ from the reported market cap. The reported market cap is accurate, as it uses the unrounded price of OHM.
 
-    Note: other sources may be inaccurate.`,
+Note: other sources may be inaccurate.`,
   };
 
   if (marketCap) _props.metric = formatCurrency(marketCap, 0);
@@ -123,7 +123,9 @@ export const BackingPerOHM: React.FC<AbstractedMetricProps & MetricSubgraphProps
   const liquidBackingPerOhmBacked: number = useLiquidBackingPerOhmBacked(props.subgraphUrls, props.earliestDate);
 
   // We include floating supply in the tooltip, as it is not displayed as a separate metric anywhere else
-  const tooltip = `Liquid backing is divided by backed supply of OHM to give liquid backing per OHM.\n\nBacked supply (${
+  const tooltip = `Liquid backing is divided by backed supply of OHM to give liquid backing per OHM.
+  
+Backed supply (${
     backedSupply ? formatNumber(backedSupply) : "Loading..."
   }) is the quantity of outstanding OHM that is backed by assets in the treasury. This typically excludes pre-minted OHM and user deposits for bonds, protocol-owned OHM in liquidity pools and OHM deployed into lending markets.`;
 

--- a/src/views/TreasuryDashboard/components/Metric/Metric.tsx
+++ b/src/views/TreasuryDashboard/components/Metric/Metric.tsx
@@ -93,7 +93,7 @@ export const SOHMPrice: React.FC<AbstractedMetricProps> = props => {
 
 export const OhmCirculatingSupply: React.FC<AbstractedMetricProps & MetricSubgraphProps> = props => {
   const { data: totalSupply } = useOhmTotalSupply(props.subgraphUrl);
-  const circSupply = useOhmCirculatingSupply(props.subgraphUrls);
+  const circSupply = useOhmCirculatingSupply(props.subgraphUrls, props.earliestDate);
   const _props: MetricProps = {
     ...props,
     label: `OHM Circulating Supply / Total`,

--- a/src/views/TreasuryDashboard/components/Metric/Metric.tsx
+++ b/src/views/TreasuryDashboard/components/Metric/Metric.tsx
@@ -212,7 +212,9 @@ export const GOHMPriceFromSubgraph: React.FC<AbstractedMetricProps & MetricSubgr
     ...props,
     label: "gOHM " + `Price`,
     tooltip:
-      "gOHM = sOHM * index" + "\n\n" + `The price of gOHM is equal to the price of OHM multiplied by the current index`,
+      "gOHM = sOHM * index" +
+      "\n\n" +
+      `The price of gOHM is equal to the price of OHM multiplied by the current index.`,
   };
 
   if (gOhmPrice) _props.metric = formatCurrency(gOhmPrice, 2);


### PR DESCRIPTION
- Fixes a few React-related warnings and errors
- Removes/simplifies code paths related to fetching and displaying metrics
- TokenSupply records are now fetched from the GraphQL endpoints for ALL chains. Previously it was just Ethereum

There is an existing issue when switching between OHM and gOHM, where the metrics never finish loading: #2782 

At some point, this needs an overhaul of the GraphQL code, which is quite brittle. Perhaps using `graph-client`, which has automatic pagination and endpoint stitching (#2344)