### PR TITLE
check bond aggregator for live market

### DIFF
--- a/src/views/Bond/hooks/useBondV3.ts
+++ b/src/views/Bond/hooks/useBondV3.ts
@@ -28,6 +28,7 @@ export const fetchBondV3 = async ({ id, isInverseBond, networkId }: UseBondOptio
   const aggregatorContract = BOND_AGGREGATOR_CONTRACT.getEthersContract(networkId);
   const auctioneerAddress = await aggregatorContract.getAuctioneer(id);
   const tellerAddress = await aggregatorContract.getTeller(id);
+  const isLive = await aggregatorContract.isLive(id);
   const tellerContract = BondFixedExpiryTeller__factory.connect(tellerAddress, aggregatorContract.provider);
 
   /*
@@ -149,5 +150,6 @@ export const fetchBondV3 = async ({ id, isInverseBond, networkId }: UseBondOptio
     },
     isV3Bond: true,
     bondToken,
+    isLive,
   };
 };

--- a/src/views/Range/hooks.tsx
+++ b/src/views/Range/hooks.tsx
@@ -235,7 +235,6 @@ export const DetermineRangePrice = (bidOrAsk: "bid" | "ask") => {
   const { data: rangeData } = RangeData();
   const { data: upperBondMarket } = useBondV3({ id: rangeData.high.market.toString() });
   const { data: lowerBondMarket } = useBondV3({ id: rangeData.low.market.toString(), isInverseBond: true });
-
   const {
     data = { price: 0, contract: "swap" },
     isFetched,
@@ -243,9 +242,10 @@ export const DetermineRangePrice = (bidOrAsk: "bid" | "ask") => {
   } = useQuery(
     ["getDetermineRangePrice", bidOrAsk, rangeData, upperBondMarket, lowerBondMarket],
     async () => {
+      const liveOnBondAggregator = (bidOrAsk === "ask" ? upperBondMarket?.isLive : lowerBondMarket?.isLive) || false;
       const sideActive = bidOrAsk === "ask" ? rangeData.high.active : rangeData.low.active;
       const market = bidOrAsk === "ask" ? rangeData.high.market : rangeData.low.market;
-      const activeBondMarket = market.gt(-1) && market.lt(ethers.constants.MaxUint256); //>=0 <=MAXUint256
+      const activeBondMarket = market.gt(-1) && market.lt(ethers.constants.MaxUint256) && liveOnBondAggregator; //>=0 <=MAXUint256
       const bondOutsideWall =
         bidOrAsk === "ask"
           ? upperBondMarket?.price.inBaseToken.gt(new DecimalBigNumber(rangeData.wall.high.price, 18))


### PR DESCRIPTION
Range Markets aren't cleaned up on range contract automatically sometimes resulting in a 'live' market being displayed even though they aren't live on the bond aggregator. 
Check the bond aggregator if the current market isLive. If it is, continue as normal, else we will display the operator prices