### PR TITLE
more bridging ux tweaks

### DIFF
--- a/src/components/TokenAllowanceGuard/TokenAllowanceGuard.tsx
+++ b/src/components/TokenAllowanceGuard/TokenAllowanceGuard.tsx
@@ -62,6 +62,8 @@ export const TokenAllowanceGuard: React.FC<{
   spenderAddressMap: AddressMap;
   approvalText?: string;
   approvalPendingText?: string;
+  spendAmount?: DecimalBigNumber;
+  children: any;
 }> = ({
   message,
   isVertical = false,
@@ -69,6 +71,7 @@ export const TokenAllowanceGuard: React.FC<{
   spenderAddressMap,
   approvalText = "Approve",
   approvalPendingText = "Approving...",
+  spendAmount,
   children,
 }) => {
   const { chain = { id: 1 } } = useNetwork();
@@ -87,11 +90,19 @@ export const TokenAllowanceGuard: React.FC<{
 
   if (
     (allowance && allowance.eq(0) && tokenAddressMap[chain.id as NetworkId] !== ethers.constants.AddressZero) ||
-    (allowance && allowance.lt(balance.toBigNumber()))
+    (allowance && allowance.lt(spendAmount?.toBigNumber() || balance.toBigNumber()))
   )
     return (
       <Grid container alignItems="center">
-        {message && (
+        {allowance && spendAmount && allowance.lt(spendAmount.toBigNumber()) ? (
+          <Grid item xs={12} sm={isVertical ? 12 : 8}>
+            <Box display="flex" textAlign="center" alignItems="center" justifyContent="center">
+              <Typography variant="body1" color="textSecondary">
+                <em>{`Your current allowance is less than your requested spend amount. Approve at least your spend amount.`}</em>
+              </Typography>
+            </Box>
+          </Grid>
+        ) : message ? (
           <Grid item xs={12} sm={isVertical ? 12 : 8}>
             <Box display="flex" textAlign="center" alignItems="center" justifyContent="center">
               <Typography variant="body1" color="textSecondary">
@@ -99,6 +110,8 @@ export const TokenAllowanceGuard: React.FC<{
               </Typography>
             </Box>
           </Grid>
+        ) : (
+          <></>
         )}
 
         <Grid item xs={12} sm={isVertical ? 12 : 4}>

--- a/src/views/Bridge/components/BridgeConfirmModal.tsx
+++ b/src/views/Bridge/components/BridgeConfirmModal.tsx
@@ -93,6 +93,7 @@ export const BridgeConfirmModal = (props: {
                   First time bridging <b>OHM</b>? <br /> Please approve Olympus DAO to use your <b>OHM</b> for bridging.
                 </>
               }
+              spendAmount={!!props.amount ? new DecimalBigNumber(props.amount, 9) : undefined}
             >
               <>
                 <PrimaryButton

--- a/src/views/Bridge/components/BridgeInputArea.tsx
+++ b/src/views/Bridge/components/BridgeInputArea.tsx
@@ -99,6 +99,7 @@ export const BridgeInputArea = () => {
                     bridging.
                   </>
                 }
+                spendAmount={!!amount ? new DecimalBigNumber(amount, 9) : new DecimalBigNumber("0", 9)}
               >
                 <PrimaryButton
                   fullWidth


### PR DESCRIPTION
1. token allowance guard

if your allowance is 1 ohm then tokenAllowanceGuard will let you through ONLY IF YOU PUT 1 OHM OR LESS IN THE INPUT

<img width="548" alt="image" src="https://user-images.githubusercontent.com/80423742/236217506-4437025c-2e64-4ead-bc42-ff8c95434d65.png">
<img width="557" alt="image" src="https://user-images.githubusercontent.com/80423742/236217651-4cb04936-fe33-4995-aa10-0e6d258e5627.png">
