### PR TITLE
ensure 18 decimals for spend approval check on ExtendLoan

### DIFF
--- a/src/views/Lending/Cooler/positions/ExtendLoan.tsx
+++ b/src/views/Lending/Cooler/positions/ExtendLoan.tsx
@@ -169,7 +169,7 @@ export const ExtendLoan = ({
                 payment.
               </>
             }
-            spendAmount={new DecimalBigNumber(interestDue.toString())}
+            spendAmount={new DecimalBigNumber(interestDue.toString(), 18)}
           >
             <PrimaryButton
               fullWidth


### PR DESCRIPTION
In some cases spendAmount was returning with 16 decimals, causing the 'spend amount' checks to pass when they should be failing.
 