### PR TITLE
Repayment Maturity Date Display

### DIFF
--- a/src/views/Lending/Cooler/positions/CreateOrRepayLoan.tsx
+++ b/src/views/Lending/Cooler/positions/CreateOrRepayLoan.tsx
@@ -57,7 +57,7 @@ export const CreateOrRepayLoan = ({
   const repayLoan = useRepayLoan();
 
   const maturityDate = loan ? new Date(Number(loan.expiry.toString()) * 1000) : new Date();
-  maturityDate.setDate(maturityDate.getDate() + Number(duration || 0));
+  !loan && maturityDate.setDate(maturityDate.getDate() + Number(duration || 0));
 
   const [paymentAmount, setPaymentAmount] = useState(new DecimalBigNumber("0"));
   const [collateralAmount, setCollateralAmount] = useState(new DecimalBigNumber("0"));


### PR DESCRIPTION
- Duration should only be added to maturity date calc when it's a new loan.
For active loans FE is currently displaying maturity date + duration , which is inaccurate 