### PR TITLE
Upper Market should be using 9 decimals to calculate human readable payout

### DIFF
--- a/src/views/Range/index.tsx
+++ b/src/views/Range/index.tsx
@@ -69,8 +69,6 @@ export const Range = () => {
       ? parseBigNumber(upperMaxPayout, 9)
       : parseBigNumber(rangeData.high.capacity, 9);
 
-  console.log(upperMaxCapacity, "upper max");
-
   const maxCapacity = sellActive ? lowerMaxCapacity : upperMaxCapacity;
 
   useEffect(() => {

--- a/src/views/Range/index.tsx
+++ b/src/views/Range/index.tsx
@@ -66,8 +66,10 @@ export const Range = () => {
 
   const upperMaxCapacity =
     upperMaxPayout && contractType === "bond"
-      ? parseBigNumber(upperMaxPayout, 18)
+      ? parseBigNumber(upperMaxPayout, 9)
       : parseBigNumber(rangeData.high.capacity, 9);
+
+  console.log(upperMaxCapacity, "upper max");
 
   const maxCapacity = sellActive ? lowerMaxCapacity : upperMaxCapacity;
 
@@ -197,8 +199,8 @@ export const Range = () => {
                                 ? "discount"
                                 : "premium"
                               : discount < 0
-                              ? "premium"
-                              : "discount"}{" "}
+                                ? "premium"
+                                : "discount"}{" "}
                             of {formatNumber(Math.abs(discount) * 100, 2)}% relative to market price of{" "}
                             {formatNumber(currentPrice, 2)} {reserveSymbol}
                           </InfoNotification>
@@ -214,8 +216,8 @@ export const Range = () => {
                                   ? "Discount"
                                   : "Premium"
                                 : discount < 0
-                                ? "Premium"
-                                : "Discount"
+                                  ? "Premium"
+                                  : "Discount"
                             }
                             balance={
                               <Typography
@@ -249,8 +251,8 @@ export const Range = () => {
                               {amountAboveCapacity
                                 ? `Amount exceeds capacity`
                                 : amountAboveBalance
-                                ? `Amount exceeds balance`
-                                : swapButtonText}
+                                  ? `Amount exceeds balance`
+                                  : swapButtonText}
                             </PrimaryButton>
                           </WalletConnectedGuard>
                         </Box>


### PR DESCRIPTION
![image](https://github.com/OlympusDAO/olympus-frontend/assets/95196612/ea4885e1-1054-4673-8d5b-8e55e9c4993d)
