### PR TITLE
Update RBS Pricing Display

### DIFF
--- a/src/helpers/CountdownTimer.tsx
+++ b/src/helpers/CountdownTimer.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from "react";
+
+type CountdownProps = {
+  targetDate: Date;
+};
+
+const CountdownTimer: React.FC<CountdownProps> = ({ targetDate }) => {
+  const calculateTimeLeft = () => {
+    const now = new Date();
+    const difference = targetDate.getTime() - now.getTime();
+    let timeLeft = { hours: 0, minutes: 0 };
+
+    if (difference > 0) {
+      timeLeft = {
+        hours: Math.floor(difference / (1000 * 60 * 60)),
+        minutes: Math.floor((difference % (1000 * 60 * 60)) / (1000 * 60)),
+      };
+    }
+
+    return timeLeft;
+  };
+
+  const [timeLeft, setTimeLeft] = useState(calculateTimeLeft());
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setTimeLeft(calculateTimeLeft());
+    }, 60000);
+
+    return () => clearTimeout(timer);
+  });
+
+  return (
+    <>
+      {timeLeft.hours > 0 || timeLeft.minutes > 0 ? (
+        <>
+          in {timeLeft.hours} hours, {timeLeft.minutes} minutes
+        </>
+      ) : (
+        <> in 0 hours, 0 minutes</>
+      )}
+    </>
+  );
+};
+
+export default CountdownTimer;

--- a/src/helpers/pricing/useGetDefillamaPrice.ts
+++ b/src/helpers/pricing/useGetDefillamaPrice.ts
@@ -1,0 +1,29 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+interface DefillamaPriceResponse {
+  coins: {
+    [address: string]: {
+      symbol: string;
+      price: number;
+    };
+  };
+}
+/**Mainnet only addresses */
+export const useGetDefillamaPrice = ({ addresses }: { addresses: string[] }) => {
+  return useQuery(
+    ["useGetDefillamaPrice", addresses],
+    async () => {
+      try {
+        const joinedAddresses = addresses.map(address => `ethereum:${address}`).join(",");
+        const response = await axios.get<DefillamaPriceResponse>(
+          `https://coins.llama.fi/prices/current/${joinedAddresses}`,
+        );
+        return response.data.coins;
+      } catch (error) {
+        return {};
+      }
+    },
+    { enabled: addresses.length > 0 },
+  );
+};

--- a/src/views/Range/RangeChart.tsx
+++ b/src/views/Range/RangeChart.tsx
@@ -127,7 +127,7 @@ const RangeChart = (props: {
         <Typography fontSize="15px" fontWeight={600} mt="33px">
           Price
         </Typography>
-        <DataRow title="Market Price" balance={formatCurrency(price ? price : currentPrice, 2, reserveSymbol)} />
+        <DataRow title="Snapshot Price" balance={formatCurrency(price ? price : currentPrice, 2, reserveSymbol)} />
         {label === "now" && (
           <>
             <DataRow title="Target Price" balance={`${formatCurrency(targetPrice, 2, reserveSymbol)}`} />

--- a/src/views/Range/hooks.tsx
+++ b/src/views/Range/hooks.tsx
@@ -233,7 +233,7 @@ export const DetermineRangePrice = (bidOrAsk: "bid" | "ask") => {
   const { data: lowerBondMarket } = useBondV3({ id: rangeData.low.market.toString(), isInverseBond: true });
 
   const {
-    data = { price: 0, contract: "swap", activeBondMarket: false },
+    data = { price: 0, contract: "swap" },
     isFetched,
     isLoading,
   } = useQuery(
@@ -266,7 +266,6 @@ export const DetermineRangePrice = (bidOrAsk: "bid" | "ask") => {
             bidOrAsk === "ask"
               ? Number(upperBondMarket?.discount.toString())
               : Number(lowerBondMarket?.discount.toString()),
-          activeBondMarket,
         };
       } else {
         return {
@@ -275,7 +274,6 @@ export const DetermineRangePrice = (bidOrAsk: "bid" | "ask") => {
               ? parseBigNumber(rangeData.high.wall.price, 18)
               : parseBigNumber(rangeData.low.wall.price, 18),
           contract: "swap" as RangeContracts,
-          activeBondMarket,
         };
       }
     },

--- a/src/views/Range/index.tsx
+++ b/src/views/Range/index.tsx
@@ -72,6 +72,8 @@ export const Range = () => {
   const ohmPriceUSD = currentMarketPrices?.[`ethereum:${OHM_ADDRESSES[1]}`].price;
   const marketOhmPriceDAI = daiPriceUSD && ohmPriceUSD ? ohmPriceUSD / daiPriceUSD : 0;
 
+  console;
+
   const maxString = sellActive ? `Max You Can Sell` : `Max You Can Buy`;
 
   const { data: upperMaxPayout } = RangeBondMaxPayout(rangeData.high.market);
@@ -282,10 +284,7 @@ export const Range = () => {
                           />
                         </div>
                         <div data-testid="swap-price">
-                          <DataRow
-                            title={`RBS price quote per OHM`}
-                            balance={`${swapPriceFormatted} ${reserveSymbol}`}
-                          />
+                          <DataRow title={`RBS quote per OHM`} balance={`${swapPriceFormatted} ${reserveSymbol}`} />
                         </div>
                         <Box mt="8px">
                           <WalletConnectedGuard fullWidth>

--- a/src/views/Range/index.tsx
+++ b/src/views/Range/index.tsx
@@ -4,6 +4,7 @@ import {
   Icon,
   InfoNotification,
   InfoTooltip,
+  Metric,
   OHMTokenProps,
   PrimaryButton,
 } from "@olympusdao/component-library";
@@ -14,6 +15,7 @@ import PageTitle from "src/components/PageTitle";
 import { WalletConnectedGuard } from "src/components/WalletConnectedGuard";
 import { DAI_ADDRESSES, OHM_ADDRESSES } from "src/constants/addresses";
 import { formatNumber, parseBigNumber } from "src/helpers";
+import CountdownTimer from "src/helpers/CountdownTimer";
 import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber";
 import { useGetDefillamaPrice } from "src/helpers/pricing/useGetDefillamaPrice";
 import { useBalance } from "src/hooks/useBalance";
@@ -169,6 +171,11 @@ export const Range = () => {
       <Paper sx={{ width: "98%" }}>
         {currentPrice ? (
           <>
+            <Metric
+              label="Market Price"
+              metric={`${formatNumber(marketOhmPriceDAI, 2)} DAI`}
+              tooltip="Market Price uses DefiLlama API, and is also used when calculating premium/discount on RBS"
+            />
             <Grid container>
               <Grid item xs={12} lg={6}>
                 {!rangeDataLoading && (
@@ -191,14 +198,16 @@ export const Range = () => {
                           {formatNumber(currentPrice, 2)} {reserveSymbol}
                           <Box display="flex" fontSize="12px" alignItems="center">
                             <InfoTooltip
-                              message={`This price is returned from the RBS Operator Contract from its connected price feed`}
+                              message={`Snapshot Price is returned from price feed connected to RBS Operator. The current price feed is Chainlink, which updates price if there's a 2% deviation or 24 hours, whichever comes first. The Snapshot Price is used by RBS Operator to turn on/off bond markets.`}
                             />
                           </Box>
                         </Box>
                       }
                     />
-                    <DataRow title="Estimated Next Heartbeat" balance={nextBeatDateString} />
-                    <DataRow title="Current Market Price" balance={`${formatNumber(marketOhmPriceDAI, 2)} DAI`} />
+                    <DataRow
+                      title="Estimated Next Snapshot"
+                      balance={<>{nextBeat && <CountdownTimer targetDate={nextBeat} />}</>}
+                    />
                   </Box>
                 )}
               </Grid>
@@ -268,15 +277,15 @@ export const Range = () => {
                                 >
                                   {formatNumber(Math.abs(discount) * 100, 2)}%
                                 </Typography>
-                                <InfoTooltip
-                                  message={`Current market price: ${formatNumber(marketOhmPriceDAI, 2)} DAI`}
-                                />
                               </Box>
                             }
                           />
                         </div>
                         <div data-testid="swap-price">
-                          <DataRow title={`Swap Price per OHM`} balance={`${swapPriceFormatted} ${reserveSymbol}`} />
+                          <DataRow
+                            title={`RBS price quote per OHM`}
+                            balance={`${swapPriceFormatted} ${reserveSymbol}`}
+                          />
                         </div>
                         <Box mt="8px">
                           <WalletConnectedGuard fullWidth>


### PR DESCRIPTION
- Display 'Snapshot Price' from operator contract getCurrentPrice function. This function returns the current price from the underlying chainlink contracts. This price is updated when there is a 2% deviation in price or every 24 hours. Whichever comes first.

- Add estimated next heart beat. Determined via last observation time and observation frequency functions on the range price contract.

- Introduce 'Market Price'. This is currently querying defillama API.  Market price is being used to determine discount/premium displayed. We query defillama for both OHM price and the reserve price, to calculate this discount/premium in the reserve token. 

![image](https://github.com/OlympusDAO/olympus-frontend/assets/95196612/36070ea4-5aab-4cc0-b85f-804ede26f94f)
<img width="807" alt="image" src="https://github.com/OlympusDAO/olympus-frontend/assets/95196612/6b6c21e9-e2fe-4560-aefe-035f9a60a0e5">
<img width="619" alt="image" src="https://github.com/OlympusDAO/olympus-frontend/assets/95196612/695b227c-0978-4eda-857f-fb3cc010eb20">
