### PR TITLE
RBS: check if market price is set before evaluating buy vs sell default display

### DIFF
--- a/src/views/Range/hooks.tsx
+++ b/src/views/Range/hooks.tsx
@@ -233,7 +233,7 @@ export const DetermineRangePrice = (bidOrAsk: "bid" | "ask") => {
   const { data: lowerBondMarket } = useBondV3({ id: rangeData.low.market.toString(), isInverseBond: true });
 
   const {
-    data = { price: 0, contract: "swap" },
+    data = { price: 0, contract: "swap", activeBondMarket: false },
     isFetched,
     isLoading,
   } = useQuery(
@@ -266,6 +266,7 @@ export const DetermineRangePrice = (bidOrAsk: "bid" | "ask") => {
             bidOrAsk === "ask"
               ? Number(upperBondMarket?.discount.toString())
               : Number(lowerBondMarket?.discount.toString()),
+          activeBondMarket,
         };
       } else {
         return {


### PR DESCRIPTION

previously marketOhmPriceDAI would potentially load with value of 0, causing a race condition on evaluating which side of the market to display by default.

We now set sell active if market price is defined and is below lower cushion OR if there is a active lower bond market.
