### PR TITLE
Allow for OHM to be included in treasury market value

### DIFF
--- a/src/views/TreasuryDashboard/components/Graph/TreasuryAssetsTable.tsx
+++ b/src/views/TreasuryDashboard/components/Graph/TreasuryAssetsTable.tsx
@@ -51,7 +51,7 @@ export const TreasuryAssetsTable = ({
     console.debug(`${chartName}: rebuilding by date token summary`);
 
     // Filter out dust
-    const nonDustRecords = tokenRecordResults.filter(value => parseFloat(value.valueExcludingOhm) > 1);
+    const nonDustRecords = tokenRecordResults.filter(value => parseFloat(value.value) > 1);
 
     // We do the filtering of isLiquid client-side. Doing it in the GraphQL query results in incorrect data being spliced into the TreasuryAssetsGraph. Very weird.
     const filteredRecords = isLiquidBackingActive


### PR DESCRIPTION
Minor fix that back-tracks some heavy-handed filtering in the frontend. Relates to https://github.com/OlympusDAO/treasury-subgraph/issues/92