### PR TITLE
Adds support for multi-reserve cooler loans

### DIFF
--- a/src/abi/CoolerFactoryV2.json
+++ b/src/abi/CoolerFactoryV2.json
@@ -1,434 +1,434 @@
 {
-    "abi": [
-      {
-        "inputs": [],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-      },
-      {
-        "inputs": [],
-        "type": "error",
-        "name": "CreateFail"
-      },
-      {
-        "inputs": [],
-        "type": "error",
-        "name": "DecimalsNot18"
-      },
-      {
-        "inputs": [],
-        "type": "error",
-        "name": "NotFromFactory"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "cooler",
-            "type": "address",
-            "indexed": true
-          },
-          {
-            "internalType": "uint256",
-            "name": "reqID",
-            "type": "uint256",
-            "indexed": false
-          },
-          {
-            "internalType": "uint256",
-            "name": "loanID",
-            "type": "uint256",
-            "indexed": false
-          }
-        ],
-        "type": "event",
-        "name": "ClearRequest",
-        "anonymous": false
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "cooler",
-            "type": "address",
-            "indexed": true
-          },
-          {
-            "internalType": "uint256",
-            "name": "loanID",
-            "type": "uint256",
-            "indexed": false
-          },
-          {
-            "internalType": "uint256",
-            "name": "amount",
-            "type": "uint256",
-            "indexed": false
-          }
-        ],
-        "type": "event",
-        "name": "DefaultLoan",
-        "anonymous": false
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "cooler",
-            "type": "address",
-            "indexed": true
-          },
-          {
-            "internalType": "uint256",
-            "name": "loanID",
-            "type": "uint256",
-            "indexed": false
-          },
-          {
-            "internalType": "uint8",
-            "name": "times",
-            "type": "uint8",
-            "indexed": false
-          }
-        ],
-        "type": "event",
-        "name": "ExtendLoan",
-        "anonymous": false
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "cooler",
-            "type": "address",
-            "indexed": true
-          },
-          {
-            "internalType": "uint256",
-            "name": "loanID",
-            "type": "uint256",
-            "indexed": false
-          },
-          {
-            "internalType": "uint256",
-            "name": "amount",
-            "type": "uint256",
-            "indexed": false
-          }
-        ],
-        "type": "event",
-        "name": "RepayLoan",
-        "anonymous": false
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "cooler",
-            "type": "address",
-            "indexed": true
-          },
-          {
-            "internalType": "address",
-            "name": "collateral",
-            "type": "address",
-            "indexed": false
-          },
-          {
-            "internalType": "address",
-            "name": "debt",
-            "type": "address",
-            "indexed": false
-          },
-          {
-            "internalType": "uint256",
-            "name": "reqID",
-            "type": "uint256",
-            "indexed": false
-          }
-        ],
-        "type": "event",
-        "name": "RequestLoan",
-        "anonymous": false
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "cooler",
-            "type": "address",
-            "indexed": true
-          },
-          {
-            "internalType": "uint256",
-            "name": "reqID",
-            "type": "uint256",
-            "indexed": false
-          }
-        ],
-        "type": "event",
-        "name": "RescindRequest",
-        "anonymous": false
-      },
-      {
-        "inputs": [],
-        "stateMutability": "view",
-        "type": "function",
-        "name": "coolerImplementation",
-        "outputs": [
-          {
-            "internalType": "contract Cooler",
-            "name": "",
-            "type": "address"
-          }
-        ]
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "contract ERC20",
-            "name": "",
-            "type": "address"
-          },
-          {
-            "internalType": "contract ERC20",
-            "name": "",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "",
-            "type": "uint256"
-          }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "name": "coolersFor",
-        "outputs": [
-          {
-            "internalType": "address",
-            "name": "",
-            "type": "address"
-          }
-        ]
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "",
-            "type": "address"
-          }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "name": "created",
-        "outputs": [
-          {
-            "internalType": "bool",
-            "name": "",
-            "type": "bool"
-          }
-        ]
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "contract ERC20",
-            "name": "collateral_",
-            "type": "address"
-          },
-          {
-            "internalType": "contract ERC20",
-            "name": "debt_",
-            "type": "address"
-          }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "generateCooler",
-        "outputs": [
-          {
-            "internalType": "address",
-            "name": "cooler",
-            "type": "address"
-          }
-        ]
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "address",
-            "name": "user_",
-            "type": "address"
-          },
-          {
-            "internalType": "address",
-            "name": "collateral_",
-            "type": "address"
-          },
-          {
-            "internalType": "address",
-            "name": "debt_",
-            "type": "address"
-          }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "name": "getCoolerFor",
-        "outputs": [
-          {
-            "internalType": "address",
-            "name": "",
-            "type": "address"
-          }
-        ]
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "uint256",
-            "name": "reqID_",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "loanID_",
-            "type": "uint256"
-          }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "logClearRequest"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "uint256",
-            "name": "loanID_",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "collateral_",
-            "type": "uint256"
-          }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "logDefaultLoan"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "uint256",
-            "name": "loanID_",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint8",
-            "name": "times_",
-            "type": "uint8"
-          }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "logExtendLoan"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "uint256",
-            "name": "loanID_",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "repayment_",
-            "type": "uint256"
-          }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "logRepayLoan"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "uint256",
-            "name": "reqID_",
-            "type": "uint256"
-          }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "logRequestLoan"
-      },
-      {
-        "inputs": [
-          {
-            "internalType": "uint256",
-            "name": "reqID_",
-            "type": "uint256"
-          }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function",
-        "name": "logRescindRequest"
-      }
-    ],
-    "devdoc": {
-      "kind": "dev",
-      "methods": {
-        "generateCooler(address,address)": {
-          "params": {
-            "collateral_": "the token given as collateral.",
-            "debt_": "the token to be lent. Interest is denominated in debt tokens."
-          },
-          "returns": {
-            "cooler": "address of the contract."
-          }
-        }
-      },
-      "version": 1
+  "abi": [
+    {
+      "inputs": [],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
     },
-    "userdoc": {
-      "kind": "user",
-      "methods": {
-        "coolerImplementation()": {
-          "notice": "Cooler reference implementation (deployed on creation to clone from)."
+    {
+      "inputs": [],
+      "type": "error",
+      "name": "CreateFail"
+    },
+    {
+      "inputs": [],
+      "type": "error",
+      "name": "DecimalsNot18"
+    },
+    {
+      "inputs": [],
+      "type": "error",
+      "name": "NotFromFactory"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "cooler",
+          "type": "address",
+          "indexed": true
         },
-        "coolersFor(address,address,uint256)": {
-          "notice": "Mapping to query Coolers for Collateral-Debt pair."
+        {
+          "internalType": "uint256",
+          "name": "reqID",
+          "type": "uint256",
+          "indexed": false
         },
-        "created(address)": {
-          "notice": "Mapping to validate deployed coolers."
-        },
-        "generateCooler(address,address)": {
-          "notice": "creates a new Escrow contract for collateral and debt tokens."
-        },
-        "getCoolerFor(address,address,address)": {
-          "notice": "Getter function to get an existing cooler for a given user <> collateral <> debt combination."
-        },
-        "logClearRequest(uint256,uint256)": {
-          "notice": "Emit a global event when a loan request is fulfilled."
-        },
-        "logDefaultLoan(uint256,uint256)": {
-          "notice": "Emit a global event when the collateral of defaulted loan is claimed."
-        },
-        "logExtendLoan(uint256,uint8)": {
-          "notice": "Emit a global event when a loan is extended."
-        },
-        "logRepayLoan(uint256,uint256)": {
-          "notice": "Emit a global event when a loan is repaid."
-        },
-        "logRequestLoan(uint256)": {
-          "notice": "Emit a global event when a new loan request is created."
-        },
-        "logRescindRequest(uint256)": {
-          "notice": "Emit a global event when a loan request is rescinded."
+        {
+          "internalType": "uint256",
+          "name": "loanID",
+          "type": "uint256",
+          "indexed": false
         }
-      },
-      "version": 1
+      ],
+      "type": "event",
+      "name": "ClearRequest",
+      "anonymous": false
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "cooler",
+          "type": "address",
+          "indexed": true
+        },
+        {
+          "internalType": "uint256",
+          "name": "loanID",
+          "type": "uint256",
+          "indexed": false
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false
+        }
+      ],
+      "type": "event",
+      "name": "DefaultLoan",
+      "anonymous": false
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "cooler",
+          "type": "address",
+          "indexed": true
+        },
+        {
+          "internalType": "uint256",
+          "name": "loanID",
+          "type": "uint256",
+          "indexed": false
+        },
+        {
+          "internalType": "uint8",
+          "name": "times",
+          "type": "uint8",
+          "indexed": false
+        }
+      ],
+      "type": "event",
+      "name": "ExtendLoan",
+      "anonymous": false
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "cooler",
+          "type": "address",
+          "indexed": true
+        },
+        {
+          "internalType": "uint256",
+          "name": "loanID",
+          "type": "uint256",
+          "indexed": false
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256",
+          "indexed": false
+        }
+      ],
+      "type": "event",
+      "name": "RepayLoan",
+      "anonymous": false
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "cooler",
+          "type": "address",
+          "indexed": true
+        },
+        {
+          "internalType": "address",
+          "name": "collateral",
+          "type": "address",
+          "indexed": false
+        },
+        {
+          "internalType": "address",
+          "name": "debt",
+          "type": "address",
+          "indexed": false
+        },
+        {
+          "internalType": "uint256",
+          "name": "reqID",
+          "type": "uint256",
+          "indexed": false
+        }
+      ],
+      "type": "event",
+      "name": "RequestLoan",
+      "anonymous": false
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "cooler",
+          "type": "address",
+          "indexed": true
+        },
+        {
+          "internalType": "uint256",
+          "name": "reqID",
+          "type": "uint256",
+          "indexed": false
+        }
+      ],
+      "type": "event",
+      "name": "RescindRequest",
+      "anonymous": false
+    },
+    {
+      "inputs": [],
+      "stateMutability": "view",
+      "type": "function",
+      "name": "coolerImplementation",
+      "outputs": [
+        {
+          "internalType": "contract Cooler",
+          "name": "",
+          "type": "address"
+        }
+      ]
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract ERC20",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "contract ERC20",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function",
+      "name": "coolersFor",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ]
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function",
+      "name": "created",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract ERC20",
+          "name": "collateral_",
+          "type": "address"
+        },
+        {
+          "internalType": "contract ERC20",
+          "name": "debt_",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "generateCooler",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "cooler",
+          "type": "address"
+        }
+      ]
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "user_",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "collateral_",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "debt_",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function",
+      "name": "getCoolerFor",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ]
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "reqID_",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "loanID_",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "logClearRequest"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "loanID_",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "collateral_",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "logDefaultLoan"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "loanID_",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "times_",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "logExtendLoan"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "loanID_",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "repayment_",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "logRepayLoan"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "reqID_",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "logRequestLoan"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "reqID_",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function",
+      "name": "logRescindRequest"
     }
+  ],
+  "devdoc": {
+    "kind": "dev",
+    "methods": {
+      "generateCooler(address,address)": {
+        "params": {
+          "collateral_": "the token given as collateral.",
+          "debt_": "the token to be lent. Interest is denominated in debt tokens."
+        },
+        "returns": {
+          "cooler": "address of the contract."
+        }
+      }
+    },
+    "version": 1
+  },
+  "userdoc": {
+    "kind": "user",
+    "methods": {
+      "coolerImplementation()": {
+        "notice": "Cooler reference implementation (deployed on creation to clone from)."
+      },
+      "coolersFor(address,address,uint256)": {
+        "notice": "Mapping to query Coolers for Collateral-Debt pair."
+      },
+      "created(address)": {
+        "notice": "Mapping to validate deployed coolers."
+      },
+      "generateCooler(address,address)": {
+        "notice": "creates a new Escrow contract for collateral and debt tokens."
+      },
+      "getCoolerFor(address,address,address)": {
+        "notice": "Getter function to get an existing cooler for a given user <> collateral <> debt combination."
+      },
+      "logClearRequest(uint256,uint256)": {
+        "notice": "Emit a global event when a loan request is fulfilled."
+      },
+      "logDefaultLoan(uint256,uint256)": {
+        "notice": "Emit a global event when the collateral of defaulted loan is claimed."
+      },
+      "logExtendLoan(uint256,uint8)": {
+        "notice": "Emit a global event when a loan is extended."
+      },
+      "logRepayLoan(uint256,uint256)": {
+        "notice": "Emit a global event when a loan is repaid."
+      },
+      "logRequestLoan(uint256)": {
+        "notice": "Emit a global event when a new loan request is created."
+      },
+      "logRescindRequest(uint256)": {
+        "notice": "Emit a global event when a loan request is rescinded."
+      }
+    },
+    "version": 1
   }
+}

--- a/src/components/Migration/MigrationModal.tsx
+++ b/src/components/Migration/MigrationModal.tsx
@@ -112,8 +112,8 @@ function MigrationModal({ open, handleClose }: { open: boolean; handleClose: any
           isMigrationComplete || !oldAssetsDetected
             ? `Migration complete`
             : isAllApproved
-            ? `You are now ready to migrate`
-            : `You have assets ready to migrate to v2`
+              ? `You are now ready to migrate`
+              : `You have assets ready to migrate to v2`
         }
       >
         <>

--- a/src/generated/coolerLoans.ts
+++ b/src/generated/coolerLoans.ts
@@ -46,12 +46,18 @@ export type GetSnapshotsParams = {
  * Represents the state of the Treasury at the time of the snapshot.
  */
 export type SnapshotTreasury = {
-  /** Total balance of DAI in the active treasury */
+  /** Total balance of the DAI token in the active treasury */
   daiBalance: number;
-  /** Total balance of sDAI in the active treasury */
+  /** Total balance of the sDAI token in the active treasury */
   sDaiBalance: number;
-  /** Total balance of sDAI in terms of DAI in the active treasury */
+  /** Total balance of the sDAI token in terms of DAI in the active treasury */
   sDaiInDaiBalance: number;
+  /** Total balance of the sUSDS token in the active treasury */
+  sUsdsBalance: number;
+  /** Total balance of the sUSDS token in terms of USDS in the active treasury */
+  sUsdsInUsdsBalance: number;
+  /** Total balance of the USDS token in the active treasury */
+  usdsBalance: number;
 };
 
 /**
@@ -86,12 +92,18 @@ export type SnapshotExpiryBuckets = {
  * Totals for the Clearinghouses at the time of the snapshot.
  */
 export type SnapshotClearinghouseTotals = {
-  /** Total balance of DAI across all Clearinghouses */
+  /** Total balance of the DAI token across all Clearinghouses */
   daiBalance: number;
-  /** Total balance of sDAI across all Clearinghouses */
+  /** Total balance of the sDAI token across all Clearinghouses */
   sDaiBalance: number;
-  /** Total balance of sDAI in terms of DAI across all Clearinghouses */
+  /** Total balance of the sDAI token in terms of DAI  across all Clearinghouses */
   sDaiInDaiBalance: number;
+  /** Total balance of the sUSDS token across all Clearinghouses */
+  sUsdsBalance: number;
+  /** Total balance of the sUSDS token in terms of USDS across all Clearinghouses */
+  sUsdsInUsdsBalance: number;
+  /** Total balance of the USDS token across all Clearinghouses */
+  usdsBalance: number;
 };
 
 export type SnapshotClearinghousesItem = {
@@ -101,18 +113,18 @@ export type SnapshotClearinghousesItem = {
   collateralAddress: string;
   /** The address of the CoolerFactory */
   coolerFactoryAddress: string;
-  /** Balance of DAI */
-  daiBalance: number;
   /** The address of the debt */
   debtAddress: string;
-  /** Amount of DAI that the Clearinghouse should be funded with */
+  /** Amount of the reserve token that the Clearinghouse should be funded with */
   fundAmount: number;
   /** The cadence of the funding */
   fundCadence: number;
-  /** Balance of sDAI */
-  sDaiBalance: number;
-  /** Balance of sDAI in terms of DAI */
-  sDaiInDaiBalance: number;
+  /** Balance of the reserve token */
+  reserveBalance: number;
+  /** Balance of the sReserve token */
+  sReserveBalance: number;
+  /** Balance of the sReserve token in terms of the reserve token */
+  sReserveInReserveBalance: number;
 };
 
 export type Snapshot = {

--- a/src/hooks/useScreenSize.ts
+++ b/src/hooks/useScreenSize.ts
@@ -5,14 +5,14 @@ export const useScreenSize = (size: "xs" | "sm" | "md" | "lg" | "xl") => {
     size === "xs"
       ? "(max-width: 0px)"
       : size === "sm"
-      ? "(max-width: 600px)"
-      : size === "md"
-      ? "(max-width: 900px)"
-      : size === "lg"
-      ? "(max-width: 1200px)"
-      : size === "xl"
-      ? "(max-width: 153600px)"
-      : "";
+        ? "(max-width: 600px)"
+        : size === "md"
+          ? "(max-width: 900px)"
+          : size === "lg"
+            ? "(max-width: 1200px)"
+            : size === "xl"
+              ? "(max-width: 153600px)"
+              : "";
 
   return useMediaQuery(breakpoint);
 };

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -26,8 +26,8 @@ const useTheme = (): [string, (e: KeyboardEvent) => void, boolean] => {
     window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches && !localTheme
       ? setMode("dark")
       : localTheme
-      ? setTheme(localTheme)
-      : setMode("dark");
+        ? setTheme(localTheme)
+        : setMode("dark");
     setMounted(true);
   }, []);
 

--- a/src/views/Bond/components/BondModal/BondModal.tsx
+++ b/src/views/Bond/components/BondModal/BondModal.tsx
@@ -159,8 +159,8 @@ const TokenPrice: React.VFC<{ token: Token; isInverseBond?: boolean; baseSymbol:
   const price = sameToken
     ? formatNumber(1, 2)
     : isInverseBond
-    ? formatNumber(ohmPrice, 2)
-    : `${formatNumber(Number(priceToken.toString({ decimals: 2, format: true, trim: false })), 2)}`;
+      ? formatNumber(ohmPrice, 2)
+      : `${formatNumber(Number(priceToken.toString({ decimals: 2, format: true, trim: false })), 2)}`;
   return price ? (
     <>
       {price} {isInverseBond ? baseSymbol : quoteSymbol}

--- a/src/views/Bond/components/BondModal/components/BondInputArea/BondInputArea.tsx
+++ b/src/views/Bond/components/BondModal/components/BondInputArea/BondInputArea.tsx
@@ -195,8 +195,8 @@ export const BondInputArea: React.VFC<{
                   {isInverseBond
                     ? `${quoteTokenString} (≈${baseTokenString})`
                     : props.bond.baseToken === props.bond.quoteToken
-                    ? `${baseTokenString}`
-                    : `${baseTokenString} (≈${quoteTokenString})`}
+                      ? `${baseTokenString}`
+                      : `${baseTokenString} (≈${quoteTokenString})`}
                 </span>
               }
             />

--- a/src/views/Bridge/components/BridgeConfirmModal.tsx
+++ b/src/views/Bridge/components/BridgeConfirmModal.tsx
@@ -118,12 +118,14 @@ export const BridgeConfirmModal = (props: {
                   {props.amountExceedsBalance
                     ? "Amount exceeds balance"
                     : !props.amount || parseFloat(props.amount) === 0
-                    ? "Enter an amount"
-                    : !isValidAddress
-                    ? `Invalid recipient address: ${shorten(props.recipientAddress)}`
-                    : props.bridgeMutation.isLoading
-                    ? "Confirming Bridging in your wallet"
-                    : `Bridge OHM to ${BRIDGE_CHAINS[props.destinationChainId as keyof typeof BRIDGE_CHAINS].name}`}
+                      ? "Enter an amount"
+                      : !isValidAddress
+                        ? `Invalid recipient address: ${shorten(props.recipientAddress)}`
+                        : props.bridgeMutation.isLoading
+                          ? "Confirming Bridging in your wallet"
+                          : `Bridge OHM to ${
+                              BRIDGE_CHAINS[props.destinationChainId as keyof typeof BRIDGE_CHAINS].name
+                            }`}
                 </PrimaryButton>
               </>
             </TokenAllowanceGuard>

--- a/src/views/Lending/Cooler/dashboard/Metrics.tsx
+++ b/src/views/Lending/Cooler/dashboard/Metrics.tsx
@@ -108,15 +108,19 @@ export const TotalCapacityRemaining = () => {
       label="Total Capacity Remaining"
       metric={formatCurrency(getTotalCapacity(latestSnapshot), 0, "DAI")}
       isLoading={latestSnapshot === undefined}
-      tooltip={`The capacity remaining is the sum of the DAI and sDAI in the clearinghouse and treasury. As of the latest snapshot, the values (in DAI) are:
+      tooltip={`The capacity remaining is the sum of the DAI/sDAI and USDS/sUSDS in the clearinghouse and treasury. As of the latest snapshot, the values are:
 
 Clearinghouse:
 DAI: ${formatCurrency(latestSnapshot?.clearinghouseTotals.daiBalance || 0, 0, "DAI")}
 sDAI: ${formatCurrency(latestSnapshot?.clearinghouseTotals.sDaiInDaiBalance || 0, 0, "DAI")}
+USDS: ${formatCurrency(latestSnapshot?.clearinghouseTotals.usdsBalance || 0, 0, "USDS")}
+sUSDS: ${formatCurrency(latestSnapshot?.clearinghouseTotals.sUsdsInUsdsBalance || 0, 0, "USDS")}
 
 Treasury:
 DAI: ${formatCurrency(latestSnapshot?.treasury?.daiBalance || 0, 0, "DAI")}
-sDAI: ${formatCurrency(latestSnapshot?.treasury?.sDaiInDaiBalance || 0, 0, "DAI")}`}
+sDAI: ${formatCurrency(latestSnapshot?.treasury?.sDaiInDaiBalance || 0, 0, "DAI")}
+USDS: ${formatCurrency(latestSnapshot?.treasury?.usdsBalance || 0, 0, "USDS")}
+sUSDS: ${formatCurrency(latestSnapshot?.treasury?.sUsdsInUsdsBalance || 0, 0, "USDS")}`}
     />
   );
 };

--- a/src/views/Lending/Cooler/hooks/useSnapshot.tsx
+++ b/src/views/Lending/Cooler/hooks/useSnapshot.tsx
@@ -104,9 +104,22 @@ export const getTotalCapacity = (snapshot: Snapshot | undefined): number => {
 
   const treasuryDaiBalance = snapshot.treasury?.daiBalance || 0;
   const treasurySDaiInDaiBalance = snapshot.treasury?.sDaiInDaiBalance || 0;
+  const treasuryUsdsBalance = snapshot.treasury?.usdsBalance || 0;
+  const treasurySUsdsInUsdsBalance = snapshot.treasury?.sUsdsInUsdsBalance || 0;
 
   const clearinghouseDaiBalance = snapshot.clearinghouseTotals.daiBalance || 0;
   const clearinghouseSDaiInDaiBalance = snapshot.clearinghouseTotals.sDaiInDaiBalance || 0;
+  const clearinghouseUsdsBalance = snapshot.clearinghouseTotals.usdsBalance || 0;
+  const clearinghouseSUsdsInUsdsBalance = snapshot.clearinghouseTotals.sUsdsInUsdsBalance || 0;
 
-  return treasuryDaiBalance + treasurySDaiInDaiBalance + clearinghouseDaiBalance + clearinghouseSDaiInDaiBalance;
+  return (
+    treasuryDaiBalance +
+    treasurySDaiInDaiBalance +
+    treasuryUsdsBalance +
+    treasurySUsdsInUsdsBalance +
+    clearinghouseDaiBalance +
+    clearinghouseSDaiInDaiBalance +
+    clearinghouseUsdsBalance +
+    clearinghouseSUsdsInUsdsBalance
+  );
 };

--- a/src/views/Lending/Cooler/positions/ConsolidateLoan.tsx
+++ b/src/views/Lending/Cooler/positions/ConsolidateLoan.tsx
@@ -1,13 +1,6 @@
-import { Box, SvgIcon, Typography } from "@mui/material";
-import { InfoNotification, Modal, PrimaryButton } from "@olympusdao/component-library";
-import { BigNumber, ethers } from "ethers";
+import { BigNumber } from "ethers";
 import { formatEther } from "ethers/lib/utils.js";
 import { useEffect, useState } from "react";
-import lendAndBorrowIcon from "src/assets/icons/lendAndBorrow.svg?react";
-import { TokenAllowanceGuard } from "src/components/TokenAllowanceGuard/TokenAllowanceGuard";
-import { COOLER_CONSOLIDATION_ADDRESSES, DAI_ADDRESSES, GOHM_ADDRESSES } from "src/constants/addresses";
-import { formatNumber } from "src/helpers";
-import { DecimalBigNumber } from "src/helpers/DecimalBigNumber/DecimalBigNumber";
 import { useBalance } from "src/hooks/useBalance";
 import { useTestableNetworks } from "src/hooks/useTestableNetworks";
 import { useConsolidateCooler } from "src/views/Lending/Cooler/hooks/useConsolidateCooler";
@@ -57,8 +50,5 @@ export const ConsolidateLoans = ({
   }, [daiBalance, totals.interest]);
 
   console.log("consolidate loans");
-  return (
-    <>
-    </>
-  );
+  return <></>;
 };

--- a/src/views/Lending/Cooler/positions/Positions.tsx
+++ b/src/views/Lending/Cooler/positions/Positions.tsx
@@ -21,7 +21,6 @@ import { BorrowRate, OutstandingPrincipal, WeeklyCapacityRemaining } from "src/v
 import { useGetClearingHouse } from "src/views/Lending/Cooler/hooks/useGetClearingHouse";
 import { useGetCoolerForWallet } from "src/views/Lending/Cooler/hooks/useGetCoolerForWallet";
 import { useGetCoolerLoans } from "src/views/Lending/Cooler/hooks/useGetCoolerLoans";
-import { ConsolidateLoans } from "src/views/Lending/Cooler/positions/ConsolidateLoan";
 import { CreateOrRepayLoan } from "src/views/Lending/Cooler/positions/CreateOrRepayLoan";
 import { ExtendLoan } from "src/views/Lending/Cooler/positions/ExtendLoan";
 import { useAccount } from "wagmi";

--- a/src/views/Lending/LendingMarkets.tsx
+++ b/src/views/Lending/LendingMarkets.tsx
@@ -81,12 +81,12 @@ export const LendingMarkets = () => {
     poolFilter === "stable"
       ? stablePools
       : poolFilter === "volatile"
-      ? volatilePools
-      : poolFilter === "gohm"
-      ? gOHMPools
-      : poolFilter === "ohm"
-      ? ohmPools
-      : defiLlamaPools;
+        ? volatilePools
+        : poolFilter === "gohm"
+          ? gOHMPools
+          : poolFilter === "ohm"
+            ? ohmPools
+            : defiLlamaPools;
 
   const poolListByNetwork = networkFilter ? poolList?.filter(pool => pool.chain === networkFilter) : poolList;
   const PoolChip = ({ label }: { label: string }) => (

--- a/src/views/Liquidity/ExternalStakePools/ExternalStakePools.tsx
+++ b/src/views/Liquidity/ExternalStakePools/ExternalStakePools.tsx
@@ -79,10 +79,10 @@ export const ExternalStakePools = () => {
     poolFilter === "stable"
       ? stablePools
       : poolFilter === "volatile"
-      ? volatilePools
-      : poolFilter === "gohm"
-      ? gOHMPools
-      : defiLlamaPools;
+        ? volatilePools
+        : poolFilter === "gohm"
+          ? gOHMPools
+          : defiLlamaPools;
 
   const poolListByNetwork = networkFilter ? poolList?.filter(pool => pool.chain === networkFilter) : poolList;
   const PoolChip = ({ label }: { label: string }) => (

--- a/src/views/Stake/components/StakeArea/components/StakeInputArea/components/StakeConfirmationModal.tsx
+++ b/src/views/Stake/components/StakeArea/components/StakeInputArea/components/StakeConfirmationModal.tsx
@@ -170,14 +170,14 @@ const StakeConfirmationModal = (props: {
                     {props.amountExceedsBalance
                       ? "Amount exceeds balance"
                       : !props.amount || parseFloat(props.amount) === 0
-                      ? "Enter an amount"
-                      : props.currentAction === "STAKE"
-                      ? props.isMutating
-                        ? "Confirming Wrapping in your wallet"
-                        : "Wrap"
-                      : props.isMutating
-                      ? "Confirming Unwrapping in your wallet "
-                      : "Unwrap"}
+                        ? "Enter an amount"
+                        : props.currentAction === "STAKE"
+                          ? props.isMutating
+                            ? "Confirming Wrapping in your wallet"
+                            : "Wrap"
+                          : props.isMutating
+                            ? "Confirming Unwrapping in your wallet "
+                            : "Unwrap"}
                   </PrimaryButton>
                 </>
               )}
@@ -195,14 +195,14 @@ const StakeConfirmationModal = (props: {
                   {props.amountExceedsBalance
                     ? "Amount exceeds balance"
                     : !props.amount || parseFloat(props.amount) === 0
-                    ? "Enter an amount"
-                    : props.currentAction === "STAKE"
-                    ? props.isMutating
-                      ? "Confirming Wrapping in your wallet"
-                      : "Wrap to gOHM"
-                    : props.isMutating
-                    ? "Confirming Unwrapping in your wallet "
-                    : "Unwrap"}
+                      ? "Enter an amount"
+                      : props.currentAction === "STAKE"
+                        ? props.isMutating
+                          ? "Confirming Wrapping in your wallet"
+                          : "Wrap to gOHM"
+                        : props.isMutating
+                          ? "Confirming Unwrapping in your wallet "
+                          : "Unwrap"}
                 </PrimaryButton>
               )}
             </TokenAllowanceGuard>


### PR DESCRIPTION
- The Cooler Loans API has some breaking changes to add support for USDS and sUSDS Clearinghouses and assets in the treasury. This PR adds support for the API changes.

It should be merged after https://github.com/OlympusDAO/cooler-loans-api/pull/14 is deployed to production and has finished indexing.

Relates to https://github.com/OlympusDAO/bophades/issues/426