### PR TITLE
hide estimated execution time if undefined

### DIFF
--- a/src/views/Governance/Components/Status.tsx
+++ b/src/views/Governance/Components/Status.tsx
@@ -55,10 +55,12 @@ export const Status = ({ proposalId }: { proposalId: number }) => {
                 <Typography fontWeight="500">Queued for Execution</Typography>
               </div>
             )}
-            <div>
-              <Typography fontSize="12px">{proposalDetails.etaDate.toLocaleString()}</Typography>
-              <Typography fontWeight="500">Estimated Execution Time</Typography>
-            </div>
+            {proposalDetails.etaDate && (
+              <div>
+                <Typography fontSize="12px">{proposalDetails.etaDate.toLocaleString()}</Typography>
+                <Typography fontWeight="500">Estimated Execution Time</Typography>
+              </div>
+            )}
           </>
         )}
         {proposalDetails?.status === "Expired" && (
@@ -69,10 +71,12 @@ export const Status = ({ proposalId }: { proposalId: number }) => {
                 <Typography fontWeight="500">Queued for Execution</Typography>
               </div>
             )}
-            <div>
-              <Typography fontSize="12px">{proposalDetails.etaDate.toLocaleString()}</Typography>
-              <Typography fontWeight="500">Execution Expired</Typography>
-            </div>
+            {proposalDetails.etaDate && (
+              <div>
+                <Typography fontSize="12px">{proposalDetails.etaDate.toLocaleString()}</Typography>
+                <Typography fontWeight="500">Execution Expired</Typography>
+              </div>
+            )}
           </>
         )}
         {proposalDetails?.status === "Executed" && (

--- a/src/views/Governance/Proposals/index.tsx
+++ b/src/views/Governance/Proposals/index.tsx
@@ -51,7 +51,9 @@ export const ProposalPage = () => {
 
   const currentBlockTime = currentBlock?.timestamp ? new Date(currentBlock?.timestamp * 1000) : new Date();
   const pending = !pendingActivation && proposalDetails.status === "Pending";
-  const pendingExecution = Boolean(proposalDetails.status === "Queued" && currentBlockTime >= proposalDetails.etaDate);
+  const pendingExecution = Boolean(
+    proposalDetails.status === "Queued" && proposalDetails.etaDate && currentBlockTime >= proposalDetails.etaDate,
+  );
 
   return (
     <div id="stake-view">

--- a/src/views/Governance/hooks/useGetProposalDetails.tsx
+++ b/src/views/Governance/hooks/useGetProposalDetails.tsx
@@ -28,7 +28,7 @@ export const useGetProposalDetails = ({ proposalId }: { proposalId: number }) =>
         startBlock: proposalDetails.startBlock.toNumber(),
         endBlock: proposalDetails.endBlock.toNumber(),
         eta: proposalDetails.eta.toNumber(),
-        etaDate: new Date(Number(proposalDetails?.eta) * 1000),
+        etaDate: proposalDetails?.eta ? new Date(Number(proposalDetails.eta) * 1000) : undefined,
         quorumVotes: Number(formatEther(proposalDetails.quorumVotes)),
         proposalThreshold: Number(formatEther(proposalDetails.proposalThreshold)),
         startDate: startDateBlockTimestamp?.timestamp ? new Date(startDateBlockTimestamp.timestamp * 1000) : startDate,


### PR DESCRIPTION
- Handle case where proposal has not yet been queued for execution. We should not display estimated execution time, because it is not yet defined and cant be calculated until the proposal is queued for execution