### PR TITLE
fix: don't filter liabilities (negative values) as dust

### DIFF
--- a/.github/workflows/coverageBadges.yml
+++ b/.github/workflows/coverageBadges.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Run unit tests
         run: yarn test:unit --reporter=json --outputFile=branch-report.json
       - name: Upload Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: branch-report
           path: branch-report.json
@@ -25,7 +25,7 @@ jobs:
     needs: [test-branch]
     steps:
       - name: Download Branch Report
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: branch-report
       - name: Prepare coverage badges

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Run unit tests
         run: yarn test:unit --coverage.reporter=json --outputFile=base-report.json && node ./scripts/fix-coverage-report.js --outputFile base-report.json
       - name: Upload Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: base-report
           path: base-report.json
@@ -33,7 +33,7 @@ jobs:
       - name: Run unit tests
         run: yarn test:unit --coverage.reporter=json --outputFile=branch-report.json && node ./scripts/fix-coverage-report.js --outputFile branch-report.json
       - name: Upload Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: branch-report
           path: branch-report.json
@@ -45,11 +45,11 @@ jobs:
       contents: write
     steps:
       - name: Download Base Report
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: base-report
       - name: Download Branch Report
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: branch-report
       - name: Generate Coverage Report

--- a/src/views/TreasuryDashboard/components/Graph/TreasuryAssetsTable.tsx
+++ b/src/views/TreasuryDashboard/components/Graph/TreasuryAssetsTable.tsx
@@ -50,8 +50,8 @@ export const TreasuryAssetsTable = ({
     // We need to flatten the tokenRecords from all of the pages arrays
     console.debug(`${chartName}: rebuilding by date token summary`);
 
-    // Filter out dust
-    const nonDustRecords = tokenRecordResults.filter(value => parseFloat(value.value) > 1);
+    // Filter out dust (|value| < $1)
+    const nonDustRecords = tokenRecordResults.filter(value => Math.abs(parseFloat(String(value.value))) > 1);
 
     // We do the filtering of isLiquid client-side. Doing it in the GraphQL query results in incorrect data being spliced into the TreasuryAssetsGraph. Very weird.
     const filteredRecords = isLiquidBackingActive


### PR DESCRIPTION
The assets table in the treasury dashboard was filtering dust (< $1), but in doing so filtered liabilities. Required to support https://github.com/OlympusDAO/olympus-protocol-metrics-subgraph/pull/306